### PR TITLE
utilize statsd as job state recorder

### DIFF
--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestPipeline(t *testing.T) {
-	//func TestDatasetToHttpDatasetSinkFullSync(t *testing.T) {
 	g := goblin.Goblin(t)
 	g.Describe("A pipeline", func() {
 		testCnt := 0
@@ -55,7 +54,7 @@ func TestPipeline(t *testing.T) {
 			go func() {
 				_ = mockService.echo.Start(":7777")
 			}()
-			scheduler, store, runner, dsm = setupScheduler(storeLocation, t)
+			scheduler, store, runner, dsm, _ = setupScheduler(storeLocation, t)
 
 			// undo redirect of stdout and stderr after successful init of fx and jobrunner
 			os.Stderr = oldErr
@@ -63,11 +62,11 @@ func TestPipeline(t *testing.T) {
 
 		})
 		g.AfterEach(func() {
+			runner.Stop()
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			_ = mockService.echo.Shutdown(ctx)
 			cancel()
 			mockService.HttpNotificationChannel = nil
-			runner.Stop()
 			_ = store.Close()
 			_ = os.RemoveAll(storeLocation)
 		})

--- a/internal/jobs/raffle.go
+++ b/internal/jobs/raffle.go
@@ -116,14 +116,19 @@ func (r *raffle) borrowTicket(job *job) *ticket {
 }
 
 func (r *raffle) returnTicket(ticket *ticket) {
+	tags := []string{
+		"application:datahub",
+	}
 	r.runningMu.Lock()
 	defer r.runningMu.Unlock()
 
 	delete(r.runningJobs, ticket.runState.id)
 	if ticket.runState.isFull {
 		r.ticketsFull++
+		_ = r.statsdClient.Gauge("jobs.tickets.full", float64(r.ticketsFull), tags, 1)
 	} else {
 		r.ticketsIncr++
+		_ = r.statsdClient.Gauge("jobs.tickets.incr", float64(r.ticketsIncr), tags, 1)
 	}
 
 }

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -152,12 +152,12 @@ func TestEvents(t *testing.T) {
 		g.It("Should emit event on sink's topic when a job with datasetSink is done", func() {
 			var eventReceived bool
 			var wg sync.WaitGroup
-			wg.Add(1)
+			wg.Add(2)
 			eventBus.SubscribeToDataset("people", "*", func(e *bus.Event) {
 				if e.Topic == "dataset.people" {
 					eventReceived = true
-					wg.Done()
 				}
+				wg.Done()
 			})
 			sj, err := scheduler.Parse([]byte((`{
 				"id" : "job1",
@@ -176,7 +176,7 @@ func TestEvents(t *testing.T) {
 			err = scheduler.AddJob(sj)
 			g.Assert(err).IsNil()
 
-			_, err = scheduler.RunJob(sj.Id, jobs.JobTypeFull)
+			_, err = scheduler.RunJob(sj.Id, jobs.JobTypeIncremental)
 			g.Assert(err).IsNil()
 			wg.Wait()
 			g.Assert(eventReceived).IsTrue("Should have observed event for people dataset")


### PR DESCRIPTION
and remove usage of time.Sleep to improve test robustness.

Fixes #2 

In this fix, the tests are overriding a statsd `ClientInterface`.

Since the raffle system reports to statsd, we are able to hook waitgroups in right before and after asyncronous job exectutions. This allows the tests to wait for async jobs without time.Sleep() and should therefore much less dependent on hardware specifics.