### PR TITLE
Feat/issue 5 http fullsync

### DIFF
--- a/app.go
+++ b/app.go
@@ -19,7 +19,7 @@ func wire() *fx.App {
 		),
 		fx.Provide(
 			conf.NewEnv,
-			conf.NewStatsD,
+			conf.NewMetricsClient,
 			conf.NewLogger,
 			server.NewBus,
 			server.NewStore,
@@ -43,6 +43,7 @@ func wire() *fx.App {
 			web.NewJobsHandler,
 			web.NewNamespaceHandler,
 			server.NewBackupManager,
+			server.NewGarbageCollector,
 		),
 	)
 }

--- a/app.go
+++ b/app.go
@@ -1,0 +1,58 @@
+package datahub
+
+import (
+	"context"
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/content"
+	"github.com/mimiro-io/datahub/internal/jobs"
+	"github.com/mimiro-io/datahub/internal/security"
+	"github.com/mimiro-io/datahub/internal/server"
+	"github.com/mimiro-io/datahub/internal/web"
+	"go.uber.org/fx"
+	"time"
+)
+
+func wire() *fx.App {
+	return fx.New(
+		fx.Options(
+			fx.StartTimeout(60*time.Second),
+		),
+		fx.Provide(
+			conf.NewEnv,
+			conf.NewStatsD,
+			conf.NewLogger,
+			server.NewBus,
+			server.NewStore,
+			server.NewDsManager,
+			security.NewTokenProviders,
+			jobs.NewRunnerConfig,
+			jobs.NewRunner,
+			jobs.NewScheduler,
+			content.NewContent,
+			web.NewAuthorizer,
+			web.NewWebServer,
+			web.NewMiddleware,
+		),
+		fx.Invoke( // no other functions are using these, so they need to be invoked to kick things off
+			conf.NewMemoryReporter,
+			web.Register,
+			web.NewContentHandler,
+			web.NewDatasetHandler,
+			web.NewQueryHandler,
+			web.NewJobOperationHandler,
+			web.NewJobsHandler,
+			web.NewNamespaceHandler,
+			server.NewBackupManager,
+		),
+	)
+}
+
+func Run() {
+	wire().Run()
+}
+
+func Start(ctx context.Context) (*fx.App, error) {
+	app := wire()
+	err := app.Start(ctx)
+	return app, err
+}

--- a/cmd/datahub/main.go
+++ b/cmd/datahub/main.go
@@ -14,53 +14,8 @@
 
 package main
 
-import (
-	"time"
-
-	"github.com/mimiro-io/datahub"
-	"github.com/mimiro-io/datahub/internal/conf"
-	"github.com/mimiro-io/datahub/internal/content"
-	"github.com/mimiro-io/datahub/internal/jobs"
-	"github.com/mimiro-io/datahub/internal/security"
-	"github.com/mimiro-io/datahub/internal/server"
-	"github.com/mimiro-io/datahub/internal/web"
-	"go.uber.org/fx"
-)
+import "github.com/mimiro-io/datahub"
 
 func main() {
-	app := fx.New(
-		fx.Options(
-			fx.StartTimeout(60*time.Second),
-		),
-		fx.Provide(
-			datahub.NewEnv,
-			conf.NewMetricsClient,
-			conf.NewLogger,
-			server.NewBus,
-			server.NewStore,
-			server.NewDsManager,
-			security.NewTokenProviders,
-			jobs.NewRunnerConfig,
-			jobs.NewRunner,
-			jobs.NewScheduler,
-			content.NewContent,
-			web.NewAuthorizer,
-			web.NewWebServer,
-			web.NewMiddleware,
-		),
-		fx.Invoke( // no other functions are using these, so they need to be invoked to kick things off
-			conf.NewMemoryReporter,
-			web.Register,
-			web.NewContentHandler,
-			web.NewDatasetHandler,
-			web.NewQueryHandler,
-			web.NewJobOperationHandler,
-			web.NewJobsHandler,
-			web.NewNamespaceHandler,
-			server.NewBackupManager,
-			server.NewGarbageCollector,
-		),
-	)
-
-	app.Run()
+	datahub.Run()
 }

--- a/dataset_http_integration_test.go
+++ b/dataset_http_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -25,7 +26,6 @@ func TestFullSync(t *testing.T) {
 
 	g.Describe("The dataset endpoint", func() {
 		g.Before(func() {
-
 			_ = os.Setenv("STORE_LOCATION", location)
 			_ = os.Setenv("PROFILE", "test")
 			_ = os.Setenv("SERVER_PORT", "24998")
@@ -44,17 +44,20 @@ func TestFullSync(t *testing.T) {
 			g.Assert(err).IsNil()
 			err = os.RemoveAll(location)
 			g.Assert(err).IsNil()
+			_ = os.Unsetenv("STORE_LOCATION")
+			_ = os.Unsetenv("PROFILE")
+			_ = os.Unsetenv("SERVER_PORT")
 		})
 
 		g.It("Should create a dataset", func() {
-			//create new dataset
+			// create new dataset
 			res, err := http.Post(dsUrl, "application/json", strings.NewReader(""))
 			g.Assert(err).IsNil()
 			g.Assert(res).IsNotZero()
 			g.Assert(res.StatusCode).Eql(200)
 		})
 		g.It("Should accept a single batch of changes", func() {
-			//populate dataset
+			// populate dataset
 			payload := strings.NewReader(bananasFromTo(1, 10, false))
 			res, err := http.Post(dsUrl+"/entities", "application/json", payload)
 
@@ -62,7 +65,7 @@ func TestFullSync(t *testing.T) {
 			g.Assert(res).IsNotZero()
 			g.Assert(res.StatusCode).Eql(200)
 
-			//read it back
+			// read it back
 			res, err = http.Get(dsUrl + "/changes")
 			g.Assert(err).IsNil()
 			g.Assert(res).IsNotZero()
@@ -76,7 +79,7 @@ func TestFullSync(t *testing.T) {
 		})
 
 		g.It("Should accept multiple overlapping batches of changes", func() {
-			//replace 5-10 and add 11-15
+			// replace 5-10 and add 11-15
 			payload := strings.NewReader(bananasFromTo(5, 15, false))
 			res, err := http.Post(dsUrl+"/entities", "application/json", payload)
 			g.Assert(err).IsNil()
@@ -168,7 +171,6 @@ func TestFullSync(t *testing.T) {
 			_, _ = http.DefaultClient.Do(req)
 			cancel()
 
-
 			// read changes back
 			res, err := http.Get(dsUrl + "/changes")
 			g.Assert(err).IsNil()
@@ -179,7 +181,7 @@ func TestFullSync(t *testing.T) {
 			var entities []*server.Entity
 			err = json.Unmarshal(bodyBytes, &entities)
 			g.Assert(err).IsNil()
-			g.Assert(len(entities)).Eql(33, "expected 20 entities plus 13 changes and @context and @continuation")
+			g.Assert(len(entities)).Eql(33, "expected 20 entities plus 11 changes and @context and @continuation")
 			g.Assert(entities[7].IsDeleted).IsFalse("original change 7 is still undeleted")
 			g.Assert(entities[22].IsDeleted).IsTrue("deleted state for 7  is a new change at end of list")
 
@@ -194,7 +196,7 @@ func TestFullSync(t *testing.T) {
 			err = json.Unmarshal(bodyBytes, &entities)
 			g.Assert(err).IsNil()
 			g.Assert(len(entities)).Eql(22, "expected 20 entities plus @context and @continuation")
-			//remove context
+			// remove context
 			entities = entities[1:]
 			for i := 0; i < 3; i++ {
 				g.Assert(entities[i].IsDeleted).IsTrue("entity was not part of fullsync, should be deleted: ", i)
@@ -207,10 +209,95 @@ func TestFullSync(t *testing.T) {
 			}
 		})
 
-		g.It("should handle fullsync requests with same sync-id in parallel")
-		g.It("should abandon fullsync and start new fullsync if new start-signal is sent during sync")
-		g.It("should reject fullsync when job writing to same dataset is running?")
-		g.It("should not start job writing to same dataset while http fullsync is running?")
+		g.It("should keep fullsync requests with same sync-id in parallel", func() {
+			// only send IDs 4 through 16 in batches as fullsync
+			// 1-3 and 17-20 should end up deleted
+
+			// first batch with "start" header
+			payload := strings.NewReader(bananasFromTo(4, 4, false))
+			ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+			req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+			req.Header.Add("universal-data-api-full-sync-start", "true")
+			req.Header.Add("universal-data-api-full-sync-id", "43")
+			_, _ = http.DefaultClient.Do(req)
+			cancel()
+
+			// next, updated id 5 with wrong sync-id. should not be registered as "seen" and therefore be deleted after fs
+			payload = strings.NewReader(bananasFromTo(5, 5, false))
+			ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
+			req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+			req.Header.Add("universal-data-api-full-sync-id", "44")
+			res, err := http.DefaultClient.Do(req)
+			cancel()
+			g.Assert(res.StatusCode).Eql(409, "request should be rejected because fullsync is going on")
+
+			// 10 batches in parallel with correct sync-id
+			wg := sync.WaitGroup{}
+			for i := 6; i < 16; i++ {
+				wg.Add(1)
+				id := i
+				go func() {
+					payload := strings.NewReader(bananasFromTo(id, id, false))
+					ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+					req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+					req.Header.Add("universal-data-api-full-sync-id", "43")
+					_, _ = http.DefaultClient.Do(req)
+					cancel()
+					wg.Done()
+				}()
+			}
+
+			wg.Wait()
+
+			// last batch with "end" signal
+			payload = strings.NewReader(bananasFromTo(16, 16, false))
+			ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
+			req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+			req.Header.Add("universal-data-api-full-sync-id", "43")
+			req.Header.Add("universal-data-api-full-sync-end", "true")
+			_, _ = http.DefaultClient.Do(req)
+			cancel()
+
+			// read changes back
+			res, err = http.Get(dsUrl + "/changes")
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+			bodyBytes, _ := ioutil.ReadAll(res.Body)
+			_ = res.Body.Close()
+			var entities []*server.Entity
+			err = json.Unmarshal(bodyBytes, &entities)
+			g.Assert(err).IsNil()
+			g.Assert(len(entities)).Eql(34, "expected 31 changes from before plus deletion of 5 and @context and @continuation")
+			g.Assert(entities[32].IsDeleted).IsTrue("deleted state for 5  is a new change at end of list")
+		})
+		g.It("should reject new fullsync and while fullsync is running", func() {
+			// start a fullsync
+			payload := strings.NewReader(bananasFromTo(1, 1, false))
+			ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+			req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+			req.Header.Add("universal-data-api-full-sync-start", "true")
+			req.Header.Add("universal-data-api-full-sync-id", "45")
+			res, err := http.DefaultClient.Do(req)
+			cancel()
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+
+			// start another fullsync
+			payload = strings.NewReader(bananasFromTo(1, 1, false))
+			ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
+			req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+			req.Header.Add("universal-data-api-full-sync-start", "true")
+			req.Header.Add("universal-data-api-full-sync-id", "46")
+			res, err = http.DefaultClient.Do(req)
+			cancel()
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(409)
+		})
+		g.It("should abandon fullsync after a timeout period without new requests", func() {
+		})
 	})
 }
 
@@ -218,6 +305,7 @@ func bananasFromTo(from, to int, deleted bool) string {
 	prefix := `[ { "id" : "@context", "namespaces" : { "_" : "http://example.com" } }, `
 
 	var bananas []string
+
 	for i := from; i <= to; i++ {
 		if deleted {
 			bananas = append(bananas, fmt.Sprintf(`{ "id" : "%v", "deleted": true }`, i))

--- a/dataset_http_integration_test.go
+++ b/dataset_http_integration_test.go
@@ -187,7 +187,7 @@ func TestFullSync(t *testing.T) {
 			g.Assert(err).IsNil()
 			g.Assert(len(entities)).Eql(33, "expected 20 entities plus 11 changes and @context and @continuation")
 			g.Assert(entities[7].IsDeleted).IsFalse("original change 7 is still undeleted")
-			g.Assert(entities[22].IsDeleted).IsTrue("deleted state for 7  is a new change at end of list")
+			g.Assert(entities[21].IsDeleted).IsTrue("deleted state for 7  is a new change at end of list")
 
 			// read entities back
 			res, err = http.Get(dsUrl + "/entities")
@@ -272,7 +272,7 @@ func TestFullSync(t *testing.T) {
 			var entities []*server.Entity
 			err = json.Unmarshal(bodyBytes, &entities)
 			g.Assert(err).IsNil()
-			g.Assert(len(entities)).Eql(34, "expected 31 changes from before plus deletion of 5 and @context and @continuation")
+			g.Assert(len(entities)).Eql(34, "expected 31 changes from before plus deletion of id5 and @context and @continuation")
 			g.Assert(entities[32].IsDeleted).IsTrue("deleted state for 5  is a new change at end of list")
 		})
 		g.It("should reject new fullsync and while fullsync is running", func() {

--- a/dataset_http_integration_test.go
+++ b/dataset_http_integration_test.go
@@ -1,0 +1,230 @@
+package datahub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/franela/goblin"
+	"github.com/mimiro-io/datahub/internal/server"
+	"go.uber.org/fx"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFullSync(t *testing.T) {
+	g := goblin.Goblin(t)
+
+	var app *fx.App
+
+	location := "./dataset_fullsync_integration_test"
+	dsUrl := "http://localhost:24998/datasets/bananas"
+
+	g.Describe("The dataset endpoint", func() {
+		g.Before(func() {
+
+			_ = os.Setenv("STORE_LOCATION", location)
+			_ = os.Setenv("PROFILE", "test")
+			_ = os.Setenv("SERVER_PORT", "24998")
+			oldOut := os.Stdout
+			oldErr := os.Stderr
+			devNull, _ := os.Open("/dev/null")
+			os.Stdout = devNull
+			os.Stderr = devNull
+			app, _ = Start(context.Background())
+			os.Stdout = oldOut
+			os.Stderr = oldErr
+		})
+		g.After(func() {
+			ctx := context.Background()
+			err := app.Stop(ctx)
+			g.Assert(err).IsNil()
+			err = os.RemoveAll(location)
+			g.Assert(err).IsNil()
+		})
+
+		g.It("Should create a dataset", func() {
+			//create new dataset
+			res, err := http.Post(dsUrl, "application/json", strings.NewReader(""))
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+		})
+		g.It("Should accept a single batch of changes", func() {
+			//populate dataset
+			payload := strings.NewReader(bananasFromTo(1, 10, false))
+			res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+
+			//read it back
+			res, err = http.Get(dsUrl + "/changes")
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+
+			bodyBytes, err := ioutil.ReadAll(res.Body)
+			var entities []*server.Entity
+			err = json.Unmarshal(bodyBytes, &entities)
+			g.Assert(err).IsNil()
+			g.Assert(len(entities)).Eql(12, "expected 10 entities plus @context and @continuation")
+		})
+
+		g.It("Should accept multiple overlapping batches of changes", func() {
+			//replace 5-10 and add 11-15
+			payload := strings.NewReader(bananasFromTo(5, 15, false))
+			res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+
+			// replace 10-15 and add 16-20
+			payload = strings.NewReader(bananasFromTo(10, 20, false))
+			res, err = http.Post(dsUrl+"/entities", "application/json", payload)
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+
+			// read it back
+			res, err = http.Get(dsUrl + "/changes")
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+			bodyBytes, _ := ioutil.ReadAll(res.Body)
+			_ = res.Body.Close()
+			var entities []*server.Entity
+			err = json.Unmarshal(bodyBytes, &entities)
+			g.Assert(err).IsNil()
+			g.Assert(len(entities)).Eql(22, "expected 20 entities plus @context and @continuation")
+		})
+
+		g.It("Should record deleted states", func() {
+			payload := strings.NewReader(bananasFromTo(7, 8, true))
+			res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+
+			// read changes back
+			res, err = http.Get(dsUrl + "/changes")
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+			bodyBytes, _ := ioutil.ReadAll(res.Body)
+			_ = res.Body.Close()
+			var entities []*server.Entity
+			err = json.Unmarshal(bodyBytes, &entities)
+			g.Assert(err).IsNil()
+			g.Assert(len(entities)).Eql(24, "expected 20 entities plus 2 deleted-changes plus @context and @continuation")
+			g.Assert(entities[7].IsDeleted).IsFalse("original change 7 is still undeleted")
+			g.Assert(entities[22].IsDeleted).IsTrue("deleted state for 7  is a new change at end of list")
+
+			// read entities back
+			res, err = http.Get(dsUrl + "/entities")
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+			bodyBytes, _ = ioutil.ReadAll(res.Body)
+			_ = res.Body.Close()
+			entities = nil
+			err = json.Unmarshal(bodyBytes, &entities)
+			g.Assert(err).IsNil()
+			g.Assert(len(entities)).Eql(22, "expected 20 entities plus @context and @continuation")
+			g.Assert(entities[7].IsDeleted).IsTrue("entity 7 is deleted")
+		})
+
+		g.It("Should do deletion detection in a fullsync", func() {
+			// only send IDs 4 through 16 in batches as fullsync
+			// 1-3 and 17-20 should end up deleted
+
+			// first batch with "start" header
+			payload := strings.NewReader(bananasFromTo(4, 8, false))
+			ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+			req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+			req.Header.Add("universal-data-api-full-sync-start", "true")
+			req.Header.Add("universal-data-api-full-sync-id", "42")
+			_, _ = http.DefaultClient.Do(req)
+			cancel()
+
+			// 2nd batch
+			payload = strings.NewReader(bananasFromTo(9, 12, false))
+			ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
+			req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+			req.Header.Add("universal-data-api-full-sync-id", "42")
+			_, _ = http.DefaultClient.Do(req)
+			cancel()
+
+			// last batch with "end" signal
+			payload = strings.NewReader(bananasFromTo(13, 16, false))
+			ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
+			req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+			req.Header.Add("universal-data-api-full-sync-id", "42")
+			req.Header.Add("universal-data-api-full-sync-end", "true")
+			_, _ = http.DefaultClient.Do(req)
+			cancel()
+
+
+			// read changes back
+			res, err := http.Get(dsUrl + "/changes")
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+			bodyBytes, _ := ioutil.ReadAll(res.Body)
+			_ = res.Body.Close()
+			var entities []*server.Entity
+			err = json.Unmarshal(bodyBytes, &entities)
+			g.Assert(err).IsNil()
+			g.Assert(len(entities)).Eql(33, "expected 20 entities plus 13 changes and @context and @continuation")
+			g.Assert(entities[7].IsDeleted).IsFalse("original change 7 is still undeleted")
+			g.Assert(entities[22].IsDeleted).IsTrue("deleted state for 7  is a new change at end of list")
+
+			// read entities back
+			res, err = http.Get(dsUrl + "/entities")
+			g.Assert(err).IsNil()
+			g.Assert(res).IsNotZero()
+			g.Assert(res.StatusCode).Eql(200)
+			bodyBytes, _ = ioutil.ReadAll(res.Body)
+			_ = res.Body.Close()
+			entities = nil
+			err = json.Unmarshal(bodyBytes, &entities)
+			g.Assert(err).IsNil()
+			g.Assert(len(entities)).Eql(22, "expected 20 entities plus @context and @continuation")
+			//remove context
+			entities = entities[1:]
+			for i := 0; i < 3; i++ {
+				g.Assert(entities[i].IsDeleted).IsTrue("entity was not part of fullsync, should be deleted: ", i)
+			}
+			for i := 3; i < 16; i++ {
+				g.Assert(entities[i].IsDeleted).IsFalse("entity was part of fullsync, should be active: ", i)
+			}
+			for i := 16; i < 20; i++ {
+				g.Assert(entities[i].IsDeleted).IsTrue("entity was not part of fullsync, should be deleted: ", i)
+			}
+		})
+
+		g.It("should handle fullsync requests with same sync-id in parallel")
+		g.It("should abandon fullsync and start new fullsync if new start-signal is sent during sync")
+		g.It("should reject fullsync when job writing to same dataset is running?")
+		g.It("should not start job writing to same dataset while http fullsync is running?")
+	})
+}
+
+func bananasFromTo(from, to int, deleted bool) string {
+	prefix := `[ { "id" : "@context", "namespaces" : { "_" : "http://example.com" } }, `
+
+	var bananas []string
+	for i := from; i <= to; i++ {
+		if deleted {
+			bananas = append(bananas, fmt.Sprintf(`{ "id" : "%v", "deleted": true }`, i))
+		} else {
+			bananas = append(bananas, fmt.Sprintf(`{ "id" : "%v" }`, i))
+		}
+	}
+
+	return prefix + strings.Join(bananas, ",") + "]"
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -76,6 +76,7 @@ func loadEnv(basePath *string, loadFromHome bool) (*Env, error) {
 			Endpoint:     viper.GetString("DL_JWT_ENDPOINT"),
 		},
 		GcOnStartup: viper.GetBool("GC_ON_STARTUP"),
+		FullsyncLeaseTimeout: viper.GetDuration("FULLSYNC_LEASE_TIMEOUT"),
 	}, nil
 }
 
@@ -123,6 +124,7 @@ func parseEnv(basePath *string, profile string, logger *zap.SugaredLogger, loadF
 	viper.SetDefault("BACKUP_USE_RSYNC", "true")
 	viper.SetDefault("SECRETS_MANAGER", "noop") // turned off by default
 	viper.SetDefault("GC_ON_STARTUP", "true")
+	viper.SetDefault("FULLSYNC_LEASE_TIMEOUT", "1h")
 
 	viper.AutomaticEnv()
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package datahub
+package conf
 
 import (
 	"flag"
@@ -20,8 +20,6 @@ import (
 	"github.com/mimiro-io/datahub/internal/conf/secrets"
 	"os"
 	"strings"
-
-	"github.com/mimiro-io/datahub/internal/conf"
 
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -35,19 +33,19 @@ import (
 // switch to the correct logger
 // You can give it a basePath, this is great for testing, but by default
 // this is set to "."
-func NewEnv() (*conf.Env, error) {
+func NewEnv() (*Env, error) {
 	filePtr := flag.String("config", "", "Optional path to the config file")
 	flag.Parse()
 	return loadEnv(filePtr, true)
 }
 
-func loadEnv(basePath *string, loadFromHome bool) (*conf.Env, error) {
+func loadEnv(basePath *string, loadFromHome bool) (*Env, error) {
 	profile, found := os.LookupEnv("PROFILE")
 	if !found {
 		profile = "local"
 	}
 
-	logger := conf.GetLogger(profile, zapcore.InfoLevel) // add a default logger while loading the env
+	logger := GetLogger(profile, zapcore.InfoLevel) // add a default logger while loading the env
 	logger.Infof("Loading logging profile: %s", profile)
 
 	err := parseEnv(basePath, profile, logger, loadFromHome)
@@ -55,7 +53,7 @@ func loadEnv(basePath *string, loadFromHome bool) (*conf.Env, error) {
 		return nil, err
 	}
 
-	return &conf.Env{
+	return &Env{
 		Logger:         logger,
 		Env:            profile,
 		Port:           viper.GetString("SERVER_PORT"),
@@ -64,13 +62,13 @@ func loadEnv(basePath *string, loadFromHome bool) (*conf.Env, error) {
 		BackupSchedule: viper.GetString("BACKUP_SCHEDULE"),
 		BackupRsync:    viper.GetBool("BACKUP_USE_RSYNC"),
 		AgentHost:      viper.GetString("DD_AGENT_HOST"),
-		Auth: &conf.AuthConfig{
+		Auth: &AuthConfig{
 			WellKnown:  viper.GetString("TOKEN_WELL_KNOWN"),
 			Audience:   viper.GetString("TOKEN_AUDIENCE"),
 			Issuer:     viper.GetString("TOKEN_ISSUER"),
 			Middleware: viper.GetString("AUTHORIZATION_MIDDLEWARE"),
 		},
-		DlJwtConfig: &conf.DatalayerJwtConfig{
+		DlJwtConfig: &DatalayerJwtConfig{
 			ClientId:     viper.GetString("DL_JWT_CLIENT_ID"),
 			ClientSecret: viper.GetString("DL_JWT_CLIENT_SECRET"),
 			Audience:     viper.GetString("DL_JWT_AUDIENCE"),

--- a/internal/conf/config_test.go
+++ b/internal/conf/config_test.go
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package datahub
+package conf
 
 import (
 	"os"
 	"testing"
 
 	"github.com/franela/goblin"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/spf13/viper"
 )
 
@@ -36,7 +35,7 @@ func TestLoadEnv(t *testing.T) {
 			if err != nil {
 				g.Fail(err)
 			}
-			currentDir = d + "/.env-test"
+			currentDir = d + "/../../.env-test"
 
 		})
 		g.It("should parse the test env file", func() {
@@ -59,7 +58,7 @@ func TestParseEnvFromFile(t *testing.T) {
 	g := goblin.Goblin(t)
 
 	var currentDir string
-	var env *conf.Env
+	var env *Env
 	g.Describe("Parsing the env file", func() {
 		g.Before(func() {
 			_ = os.Setenv("PROFILE", "test")
@@ -68,7 +67,7 @@ func TestParseEnvFromFile(t *testing.T) {
 			if err != nil {
 				g.Fail(err)
 			}
-			currentDir = d + "/.env-test"
+			currentDir = d + "/../../.env-test"
 			e, err := loadEnv(&currentDir, false)
 			if err != nil {
 				g.Fail(err)
@@ -137,7 +136,7 @@ func TestLoadEnvNoFile(t *testing.T) {
 func TestLoadEnvVariables(t *testing.T) {
 	g := goblin.Goblin(t)
 	g.Describe("Loading env from env variables only", func() {
-		var c *conf.Env
+		var c *Env
 
 		g.Before(func() {
 			viper.Reset()

--- a/internal/conf/environment.go
+++ b/internal/conf/environment.go
@@ -16,6 +16,7 @@ package conf
 
 import (
 	"go.uber.org/zap"
+	"time"
 )
 
 type Env struct {
@@ -30,6 +31,7 @@ type Env struct {
 	Auth           *AuthConfig
 	DlJwtConfig    *DatalayerJwtConfig
 	GcOnStartup    bool
+	FullsyncLeaseTimeout time.Duration
 }
 
 type AuthConfig struct {

--- a/internal/jobs/sink.go
+++ b/internal/jobs/sink.go
@@ -303,7 +303,7 @@ type datasetSink struct {
 
 func (datasetSink *datasetSink) startFullSync(runner *Runner) error {
 	dataset := datasetSink.DatasetManager.GetDataset(datasetSink.DatasetName)
-	return dataset.StartFullSync(datasetSink.DatasetName)
+	return dataset.StartFullSync()
 }
 
 func (datasetSink *datasetSink) endFullSync(runner *Runner) error {
@@ -320,12 +320,6 @@ func (datasetSink *datasetSink) processEntities(runner *Runner, entities []*serv
 	dataset := datasetSink.DatasetManager.GetDataset(datasetSink.DatasetName)
 
 	err := dataset.StoreEntities(entities)
-	if err == nil {
-		// refresh fullsync if necessary
-		if dataset.FullSyncStarted() {
-			err = dataset.RefreshFullSyncLease(datasetSink.DatasetName)
-		}
-	}
 
 	if err == nil {
 		// we emit the event so event handlers can react to it

--- a/internal/server/error.go
+++ b/internal/server/error.go
@@ -48,5 +48,5 @@ var (
 	HttpContentStoreErr     = errors.New("failed updating the content")
 	HttpQueryParamErr       = errors.New("one or more of the query parameters failed its validation")
 	HttpGenericErr          = errors.New("internal failure")
-	HttpFullsyncRunning     = errors.New("cannot start full sync while another full sync is in process")
+	HttpFullsyncErr         = errors.New("an error occured trying to start or update a full sync")
 )

--- a/internal/server/error.go
+++ b/internal/server/error.go
@@ -48,4 +48,5 @@ var (
 	HttpContentStoreErr     = errors.New("failed updating the content")
 	HttpQueryParamErr       = errors.New("one or more of the query parameters failed its validation")
 	HttpGenericErr          = errors.New("internal failure")
+	HttpFullsyncRunning     = errors.New("cannot start full sync while another full sync is in process")
 )

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -739,7 +739,7 @@ func TestStore(test *testing.T) {
 			g.Assert(err).IsNil()
 			batchSize := 5
 
-			err = ds.StartFullSync()
+			err = ds.StartFullSync("")
 			g.Assert(err).IsNil()
 
 			entities := make([]*Entity, batchSize)
@@ -755,7 +755,7 @@ func TestStore(test *testing.T) {
 			g.Assert(err).IsNil()
 
 			//start 2nd fullsync
-			err = ds.StartFullSync()
+			err = ds.StartFullSync("")
 			g.Assert(err).IsNil()
 
 			entities = make([]*Entity, 1)

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -739,7 +739,7 @@ func TestStore(test *testing.T) {
 			g.Assert(err).IsNil()
 			batchSize := 5
 
-			err = ds.StartFullSync("")
+			err = ds.StartFullSync()
 			g.Assert(err).IsNil()
 
 			entities := make([]*Entity, batchSize)
@@ -755,7 +755,7 @@ func TestStore(test *testing.T) {
 			g.Assert(err).IsNil()
 
 			//start 2nd fullsync
-			err = ds.StartFullSync("")
+			err = ds.StartFullSync()
 			g.Assert(err).IsNil()
 
 			entities = make([]*Entity, 1)

--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -338,7 +338,7 @@ func (handler *datasetHandler) processEntities(c echo.Context, datasetName strin
 	if fullSyncEnd {
 		err = dataset.CompleteFullSync()
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, server.HttpGenericErr.Error())
+			return echo.NewHTTPError(http.StatusGone, server.HttpGenericErr.Error())
 		}
 	}
 	// we have to emit the dataset, so that subscribers can react to the event

--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -293,12 +293,12 @@ func (handler *datasetHandler) processEntities(c echo.Context, datasetName strin
 	if fullSyncStart {
 		err := dataset.StartFullSyncWithLease(fullSyncID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusConflict, server.HttpFullsyncRunning.Error())
+			return echo.NewHTTPError(http.StatusConflict, server.HttpFullsyncErr.Error())
 		}
 	} else if dataset.FullSyncStarted() {
 		err = dataset.RefreshFullSyncLease(fullSyncID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusConflict, server.HttpFullsyncRunning.Error())
+			return echo.NewHTTPError(http.StatusConflict, server.HttpFullsyncErr.Error())
 		}
 	}
 


### PR DESCRIPTION
This change resolves #5 

When we receive the specified http headers in a POST request to a dataset, datahub now starts to track a fullsync process. We try to build on the existing full-sync mechanism that is already in use for internal jobs.
Since this is http, we have some cases to consider that are not relevant for internal jobs though. Most important:

  * user could try to start multiple concurrent fullsync processes
  * fullsyncs can be started, but the "fullsync-end" request may never arrive

In order to deal with that, there is a fullSyncLease in the implementation. A lease is a timeout after which datahub will cancel an ongoing fullsync process. This is necessary to clean state, which can for large datasets block a lot of memory. The timeout defaults to one hour, and can be configured with `FULLSYNC_LEASE_TIMEOUT` 

In addition to the actual changes in datasetwebhandler.go and dataset.go, this Pull Request alters the the main function and config loading slightly, to enable running a full datahub in a test, so that the web API can be tested. 
