### PR TITLE
fixed query issues

### DIFF
--- a/internal/server/dataset.go
+++ b/internal/server/dataset.go
@@ -371,7 +371,13 @@ func (ds *Dataset) StoreEntities(entities []*Entity) (Error error) {
 				// get time
 				et := binary.BigEndian.Uint64(k[10:])
 
-				// if time has changed then we are onto previous version of entity
+				// get dataset
+				datasetId := binary.BigEndian.Uint32(k[36:])
+				if datasetId != ds.InternalID {
+					continue
+				}
+
+				// if time has changed for entities in this dataset then we are onto previous version of entity
 				if entityTime != 0 && et != entityTime {
 					break
 				} else {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -885,7 +885,6 @@ func (s *Store) GetRelatedAtTime(uri string, predicate string, inverse bool, tar
 			binary.BigEndian.PutUint16(prefixBuffer, OUTGOING_REF_INDEX)
 			binary.BigEndian.PutUint64(prefixBuffer[2:], rid)
 
-			// var entityTime uint64 = 0 // used to know when we hit an old version
 			candidates := 0
 			datasetTimestamps := make(map[uint32]uint64)
 			for outgoingIterator.Seek(searchBuffer); outgoingIterator.ValidForPrefix(prefixBuffer); outgoingIterator.Next() {
@@ -920,12 +919,6 @@ func (s *Store) GetRelatedAtTime(uri string, predicate string, inverse bool, tar
 				} else {
 					datasetTimestamps[datasetId] = et
 				}
-
-				/* if entityTime != 0 && et != entityTime {
-					break
-				} else {
-					entityTime = et
-				} */
 
 				// get predicate
 				predID := binary.BigEndian.Uint64(k[18:])

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/dgraph-io/badger/v2"
 	"os"
 	"reflect"
 	"strconv"
@@ -32,6 +33,425 @@ import (
 
 	"go.uber.org/zap"
 )
+
+
+func TestStoreRelations(test *testing.T) {
+	g := goblin.Goblin(test)
+	g.Describe("The dataset storage", func() {
+		testCnt := 0
+		var dsm *DsManager
+		var store *Store
+		var storeLocation string
+		g.BeforeEach(func() {
+			testCnt += 1
+			storeLocation = fmt.Sprintf("./test_store_%v", testCnt)
+			err := os.RemoveAll(storeLocation)
+			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
+			e := &conf.Env{
+				Logger:        zap.NewNop().Sugar(),
+				StoreLocation: storeLocation,
+			}
+
+			devNull, _ := os.Open("/dev/null")
+			oldErr := os.Stderr
+			os.Stderr = devNull
+			lc := fxtest.NewLifecycle(test)
+			store = NewStore(lc, e, &statsd.NoOpClient{})
+			dsm = NewDsManager(lc, e, store, NoOpBus())
+
+			err = lc.Start(context.Background())
+			g.Assert(err).IsNil()
+			os.Stderr = oldErr
+		})
+		g.AfterEach(func() {
+			_ = store.Close()
+			_ = os.RemoveAll(storeLocation)
+		})
+		g.It("Should delete the correct incoming and outgoing references", func() {
+			g.Timeout(time.Hour)
+			b := store.database
+			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/people/")
+			workPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/work/")
+			g.Assert(count(b)).Eql(16)
+
+			friendsDS, _ := dsm.CreateDataset("friends")
+			g.Assert(count(b)).Eql(24)
+
+			workDS, _ := dsm.CreateDataset("work")
+			g.Assert(count(b)).Eql(32)
+
+			_ = friendsDS.StoreEntities([]*Entity{
+				NewEntityFromMap(map[string]interface{}{
+					"id":    peopleNamespacePrefix + ":person-1",
+					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+					"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"}}),
+				NewEntityFromMap(map[string]interface{}{
+					"id":    peopleNamespacePrefix + ":person-2",
+					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+					"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1"}}),
+			})
+			g.Assert(count(b)).Eql(55)
+
+			// check that we can query outgoing
+			result, err := store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", false, nil)
+			g.Assert(err).IsNil()
+			g.Assert(len(result)).Eql(1)
+			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
+			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
+
+			// check that we can query incoming
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", true, nil)
+			g.Assert(err).IsNil()
+			g.Assert(len(result)).Eql(1)
+			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
+			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
+
+			_ = workDS.StoreEntities([]*Entity{
+				NewEntityFromMap(map[string]interface{}{
+					"id":    peopleNamespacePrefix + ":person-1",
+					"props": map[string]interface{}{workPrefix + ":Wage": "110"},
+					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-2"}}),
+				NewEntityFromMap(map[string]interface{}{
+					"id":    peopleNamespacePrefix + ":person-2",
+					"props": map[string]interface{}{workPrefix + ":Wage": "100"},
+					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-3"}}),
+			})
+			g.Assert(count(b)).Eql(72)
+
+			// check that we can still query outgoing
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", false, nil)
+			// result, err = store.GetManyRelatedEntities( []string{"http://data.mimiro.io/people/person-1"}, "*", false, nil)
+			g.Assert(err).IsNil()
+			g.Assert(len(result)).Eql(1, "Expected still to find person-3 as a friend")
+			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
+
+			// and incoming
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", true, nil)
+			g.Assert(err).IsNil()
+			g.Assert(len(result)).Eql(1, "Expected still to find person-2 as reverse friend")
+			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
+		})
+
+		g.It("Should build query results", func() {
+			g.Timeout(time.Hour)
+
+			// create dataset
+			ds, err := dsm.CreateDataset("people")
+
+			batchSize := 5
+			entities := make([]*Entity, batchSize)
+
+			peopleNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/people/")
+			modelNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/model/")
+			rdfNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+
+			for i := 0; i < batchSize; i++ {
+				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+				entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
+				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+				entities[i] = entity
+			}
+
+			err = ds.StoreEntities(entities)
+			g.Assert(err).IsNil()
+
+			results, err := store.GetRelated("http://data.mimiro.io/people/p-1", RdfTypeUri, false, []string{})
+			g.Assert(err).IsNil()
+			g.Assert(len(results)).Eql(1)
+
+			invresults, err := store.GetRelated("http://data.mimiro.io/model/Person", RdfTypeUri, true, []string{})
+			g.Assert(err).IsNil()
+			g.Assert(len(invresults)).Eql(5)
+
+			invresults, err = store.GetRelated("http://data.mimiro.io/model/Person", "*", true, []string{})
+			g.Assert(err).IsNil()
+			g.Assert(len(invresults)).Eql(5)
+
+			for i := 0; i < batchSize; i++ {
+				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+				entities[i] = entity
+			}
+
+			err = ds.StoreEntities(entities)
+			g.Assert(err).IsNil()
+
+			time0 := time.Now().UnixNano()
+
+			invresults, err = store.GetRelated("http://data.mimiro.io/model/Person", RdfTypeUri, true, []string{})
+			g.Assert(err).IsNil()
+			g.Assert(len(invresults)).Eql(0)
+
+			results, err = store.GetRelated("http://data.mimiro.io/people/p-1", RdfTypeUri, false, []string{})
+			g.Assert(err).IsNil()
+			g.Assert(len(results)).Eql(0)
+
+			for i := 0; i < batchSize; i++ {
+				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+				entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
+				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+				entities[i] = entity
+			}
+
+			err = ds.StoreEntities(entities)
+			g.Assert(err).IsNil()
+
+			invresults, err = store.GetRelated("http://data.mimiro.io/model/Person", RdfTypeUri, true, []string{})
+			g.Assert(err).IsNil()
+			g.Assert(len(invresults)).Eql(5)
+
+			results, err = store.GetRelated("http://data.mimiro.io/people/p-1", RdfTypeUri, false, []string{})
+			g.Assert(err).IsNil()
+			g.Assert(len(results)).Eql(1)
+
+			// test at point in time
+			results, err = store.GetRelatedAtTime("http://data.mimiro.io/people/p-1", RdfTypeUri, false, []uint32{}, time0)
+			g.Assert(err).IsNil()
+			g.Assert(len(results)).Eql(0)
+
+			invresults, err = store.GetRelatedAtTime("http://data.mimiro.io/model/Person", RdfTypeUri, true, []uint32{}, time0)
+			g.Assert(err).IsNil()
+			g.Assert(len(invresults)).Eql(0)
+		})
+		g.It("Should respect dataset scope in queries", func() {
+			g.Timeout(time.Hour)
+
+			// namespaces
+			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/people/")
+			companyNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/company/")
+			modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/model/")
+			rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+
+			type TestModel struct {
+				person      int   //id of a person
+				workhistory []int //list of company-ids
+				currentwork int   //id of a company
+			}
+
+			testdata := []TestModel{
+				{person: 1, workhistory: []int{}, currentwork: 1},
+				{person: 2, workhistory: []int{1}, currentwork: 2},
+				{person: 3, workhistory: []int{2}, currentwork: 1},
+				{person: 4, workhistory: []int{1, 2}, currentwork: 3},
+				{person: 5, workhistory: []int{3}, currentwork: 1},
+			}
+
+			type TestCase struct {
+				CaseID                     int
+				startURI                   string
+				predicate                  string
+				inverse                    bool
+				datasets                   []string
+				expectedRelationCount      int
+				firstRelationID            string
+				firstRelationPropertyName  string
+				firstRelationPropertyValue interface{}
+				firstRelationPropertyCheck interface{} // nil, true or false
+				extraCheck                 func(e *Entity, g *goblin.G)
+			}
+
+			const PEOPLE = "people"
+			const COMPANIES = "companies"
+			const HISTORY = "history"
+			testMatrix := []TestCase{
+				//no constraints, resolving company should work
+				{CaseID: 1, startURI: peopleNamespacePrefix + ":person-1", predicate: "http://data.mimiro.io/people/worksfor",
+					inverse: false, datasets: []string{},
+					expectedRelationCount: 2, firstRelationID: "ns4:company-1", firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: "Company 1"},
+
+				//constraint on "people" only. we should find the relation to a company in "people",
+				//but resolving the company should be omitted because we lack access to the "companies" dataset
+				{CaseID: 2, startURI: peopleNamespacePrefix + ":person-1", predicate: "http://data.mimiro.io/people/worksfor",
+					inverse: false, datasets: []string{PEOPLE},
+					expectedRelationCount: 1, firstRelationID: "ns4:company-1", firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: nil},
+
+				//constraint on "companies". we cannot access outgoing refs in the "people" or "history" datasets, therefore we should not find anything
+				{CaseID: 3, startURI: peopleNamespacePrefix + ":person-1", predicate: "http://data.mimiro.io/people/worksfor",
+					inverse: false, datasets: []string{COMPANIES},
+					expectedRelationCount: 0},
+
+				//constraint on bogus dataset. due to implementation, this dataset filter will be ignored, query behaves as unrestricted
+				//TODO: this can be discussed. Producing an error would make Queries less unpredictable. But ignoring invalid input makes the API more approachable
+				{CaseID: 4, startURI: peopleNamespacePrefix + ":person-1", predicate: "http://data.mimiro.io/people/worksfor",
+					inverse: false, datasets: []string{"bogus"},
+					expectedRelationCount: 2, firstRelationID: "ns4:company-1", firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: "Company 1"},
+
+				//constraint on history dataset. we should find an outgoing relatoin from history to a company,
+				//but company resolving should be disabled since we lack access to the companies dataset
+				{CaseID: 5, startURI: peopleNamespacePrefix + ":person-1", predicate: "http://data.mimiro.io/people/worksfor",
+					inverse: false, datasets: []string{HISTORY},
+					expectedRelationCount: 1, firstRelationID: "ns4:company-1", firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: nil},
+
+				//inverse query for "company-1", no datasets restriction. should find 3 people with resolved entities
+				{CaseID: 6, startURI: companyNamespacePrefix + ":company-1", predicate: "http://data.mimiro.io/people/worksfor",
+					inverse: true, datasets: []string{},
+					expectedRelationCount: 6, firstRelationID: "ns3:person-5", firstRelationPropertyName: "ns3:Name", firstRelationPropertyValue: "Person 5",
+					extraCheck: func(e *Entity, g *goblin.G) {
+						//we should find 4 refs for the first resolved person, from both history and people datasets
+						g.Assert(len(e.References)).Eql(4)
+						//verify that history entity has been merged in by checking for "workedfor"
+						g.Assert(e.References["ns3:workedfor"].([]interface{})[0]).Eql("ns4:company-3", "inverse query should find company-3 in history following 'worksfor' to person-5's employment enity")
+					},
+				},
+
+				//inverse query for "company-1" with only "people" accessible.
+				//should still find 3 people (incoming relation is owned by people dataset, which we have access to)
+				//people should be resolved
+				//but resolved relations in people should only be "people" data with no "history" refs merged in
+				{CaseID: 7, startURI: companyNamespacePrefix + ":company-1", predicate: "http://data.mimiro.io/people/worksfor",
+					inverse: true, datasets: []string{PEOPLE},
+					expectedRelationCount: 3, firstRelationID: "ns3:person-5", firstRelationPropertyName: "ns3:Name", firstRelationPropertyCheck: true,
+					extraCheck: func(e *Entity, g *goblin.G) {
+						//make sure we only have two refs returned (worksfor + type), confirming that history refs have not been accessed
+						g.Assert(len(e.References)).Eql(2)
+					},
+				},
+
+				//inverse query for "company-1" with restriction to "companies" dataset.
+				//all incoming relations are stored in either history or people dataset.
+				//with access limited to companies dataset, we should not find incoming relations
+				{CaseID: 8, startURI: companyNamespacePrefix + ":company-1", predicate: "http://data.mimiro.io/people/worksfor",
+					inverse: true, datasets: []string{COMPANIES}, expectedRelationCount: 0,
+				},
+
+				//find person-4 and follow its workedfor relations without restriction
+				//should find 2 companies in "history" dataset, and fully resolve the company entities
+				{CaseID: 9, startURI: peopleNamespacePrefix + ":person-4", predicate: "http://data.mimiro.io/people/workedfor",
+					inverse: false, datasets: []string{}, expectedRelationCount: 2, firstRelationID: "ns4:company-2",
+					firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: "Company 2",
+				},
+
+				//find person-4 and follow its workedfor relations in dataset "history"
+				//should find 2 companies in "history" dataset,
+				//but not fully resolve the company entities because we lack access to "company"
+				{CaseID: 10, startURI: peopleNamespacePrefix + ":person-4", predicate: "http://data.mimiro.io/people/workedfor",
+					inverse: false, datasets: []string{HISTORY}, expectedRelationCount: 2, firstRelationID: "ns4:company-2",
+					firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: nil,
+				},
+
+				//find company-2 and inversely follow workedfor relations without restriction
+				//should find person 3 and 4 in "history" dataset, and fully resolve the person entities
+				{CaseID: 11, startURI: companyNamespacePrefix + ":company-2", predicate: "http://data.mimiro.io/people/workedfor",
+					inverse: true, datasets: []string{}, expectedRelationCount: 2, firstRelationID: "ns3:person-4",
+					firstRelationPropertyName: "ns3:Name", firstRelationPropertyValue: "Person 4",
+					extraCheck: func(e *Entity, g *goblin.G) {
+						//There should be 4 references both from history and people
+						if len(e.References) != 4 {
+							g.Failf("Expected %v refs in inversely found person from both people and history datasets, actual: %v", 2, len(e.References))
+						}
+						//check that reference values are merged from all datasets. type should be list of type refs from both people and history
+						if reflect.DeepEqual(e.References["ns2:type"], []string{"ns5:Person", "ns5:Employment"}) {
+							g.Failf("Expected Person+Employment as type ref values, but found %v", e.References["ns2:type"])
+						}
+					},
+				},
+
+				//find company-2 and inversely follow workedfor relations with filter on history
+				//should find person 3 and 4 in "history" dataset, but not fully resolve the person entities
+				{CaseID: 12, startURI: companyNamespacePrefix + ":company-2", predicate: "http://data.mimiro.io/people/workedfor",
+					inverse: true, datasets: []string{HISTORY}, expectedRelationCount: 2, firstRelationID: "ns3:person-4",
+					firstRelationPropertyName: "ns3:Name", firstRelationPropertyValue: nil,
+					extraCheck: func(e *Entity, g *goblin.G) {
+						//there should be 4 refs from the history entity
+						if len(e.References) != 4 {
+							g.Failf("Case 12 :: Expected %v refs in inversely found person from history dataset only, actual: %v", 4, len(e.References))
+						}
+						//but we should only find type=Employment now. not Person
+						if e.References["ns2:type"] != "ns5:Employment" {
+							g.Failf("Expected ns5:Employment as type ref value, but found %v", e.References["ns2:type"])
+						}
+					},
+				},
+
+				//find company-2 and inversely follow workedfor relations with filter on people and companies
+				//should not find any relations since history access is not allowed, and workedfor is only stored there
+				{CaseID: 13, startURI: companyNamespacePrefix + ":company-2", predicate: "http://data.mimiro.io/people/workedfor",
+					inverse: true, datasets: []string{PEOPLE, COMPANIES}, expectedRelationCount: 0,
+				},
+			}
+
+			// create dataset
+			peopleDataset, _ := dsm.CreateDataset(PEOPLE)
+			companiesDataset, _ := dsm.CreateDataset(COMPANIES)
+			employmentHistoryDataset, _ := dsm.CreateDataset(HISTORY)
+
+			for _, td := range testdata {
+				cid := companyNamespacePrefix + ":company-" + strconv.Itoa(td.currentwork)
+				_ = companiesDataset.StoreEntities([]*Entity{NewEntityFromMap(map[string]interface{}{
+					"id":    cid,
+					"props": map[string]interface{}{companyNamespacePrefix + ":Name": "Company " + strconv.Itoa(td.currentwork)},
+					"refs":  map[string]interface{}{rdfNamespacePrefix + ":type": modelNamespacePrefix + ":Company"}})})
+
+				pid := peopleNamespacePrefix + ":person-" + strconv.Itoa(td.person)
+				_ = peopleDataset.StoreEntities([]*Entity{NewEntityFromMap(map[string]interface{}{
+					"id":    pid,
+					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Person " + strconv.Itoa(td.person)},
+					"refs": map[string]interface{}{
+						rdfNamespacePrefix + ":type":        modelNamespacePrefix + ":Person",
+						peopleNamespacePrefix + ":worksfor": companyNamespacePrefix + ":company-" + strconv.Itoa(td.currentwork),
+					}})})
+
+				var workHistory []string
+				for _, histId := range td.workhistory {
+					workHistory = append(workHistory, companyNamespacePrefix+":company-"+strconv.Itoa(histId))
+				}
+				_ = employmentHistoryDataset.StoreEntities([]*Entity{NewEntityFromMap(map[string]interface{}{
+					"id":    pid,
+					"props": map[string]interface{}{},
+					"refs": map[string]interface{}{
+						rdfNamespacePrefix + ":type":         modelNamespacePrefix + ":Employment",
+						peopleNamespacePrefix + ":Employee":  pid,
+						peopleNamespacePrefix + ":worksfor":  companyNamespacePrefix + ":company-" + strconv.Itoa(td.currentwork),
+						peopleNamespacePrefix + ":workedfor": workHistory,
+					}})})
+			}
+
+			for _, tc := range testMatrix {
+				result, _ := store.GetManyRelatedEntities([]string{tc.startURI}, tc.predicate, tc.inverse, tc.datasets)
+				g.Assert(len(result)).Eql(tc.expectedRelationCount, "Case "+strconv.Itoa(tc.CaseID))
+				if tc.expectedRelationCount == 0 {
+					continue
+				}
+				/*
+					for _, r := range result {
+						e := r[2].(*Entity)
+						t.Logf("%v",e)
+						t.Logf("%v :: %v, props: %v, refs: %v", tc.CaseID, e.ID, e.Properties, e.References)
+					}
+				*/
+				entity := result[0][2].(*Entity)
+				g.Assert(entity.ID).Eql(tc.firstRelationID, fmt.Sprintf("Case %v :: startURI was %v; dataset constraints were %v", tc.CaseID, tc.startURI, tc.datasets))
+				observedPropVal := entity.Properties[tc.firstRelationPropertyName]
+				if tc.firstRelationPropertyCheck == nil {
+					g.Assert(observedPropVal).Eql(tc.firstRelationPropertyValue,
+						fmt.Sprintf("Case %v :: should resolve Relation property %v as %v, actually observed value: %v",
+							tc.CaseID, tc.firstRelationPropertyName, tc.firstRelationPropertyValue, observedPropVal))
+				}
+				if tc.firstRelationPropertyCheck != nil && (observedPropVal == nil) == tc.firstRelationPropertyCheck {
+					g.Failf("Case %v :: should resolve Relation property %v : %v, actually observed value: %v",
+						tc.CaseID, tc.firstRelationPropertyName, tc.firstRelationPropertyCheck, observedPropVal)
+				}
+				if tc.extraCheck != nil {
+					tc.extraCheck(entity, g)
+				}
+			}
+		})
+
+	})
+}
 
 func TestStore(test *testing.T) {
 	g := goblin.Goblin(test)
@@ -855,7 +1275,7 @@ func TestStore(test *testing.T) {
 				//no constraints, resolving company should work
 				{CaseID: 1, startURI: peopleNamespacePrefix + ":person-1", predicate: "http://data.mimiro.io/people/worksfor",
 					inverse: false, datasets: []string{},
-					expectedRelationCount: 1, firstRelationID: "ns4:company-1", firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: "Company 1"},
+					expectedRelationCount: 2, firstRelationID: "ns4:company-1", firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: "Company 1"},
 
 				//constraint on "people" only. we should find the relation to a company in "people",
 				//but resolving the company should be omitted because we lack access to the "companies" dataset
@@ -872,7 +1292,7 @@ func TestStore(test *testing.T) {
 				//TODO: this can be discussed. Producing an error would make Queries less unpredictable. But ignoring invalid input makes the API more approachable
 				{CaseID: 4, startURI: peopleNamespacePrefix + ":person-1", predicate: "http://data.mimiro.io/people/worksfor",
 					inverse: false, datasets: []string{"bogus"},
-					expectedRelationCount: 1, firstRelationID: "ns4:company-1", firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: "Company 1"},
+					expectedRelationCount: 2, firstRelationID: "ns4:company-1", firstRelationPropertyName: "ns4:Name", firstRelationPropertyValue: "Company 1"},
 
 				//constraint on history dataset. we should find an outgoing relatoin from history to a company,
 				//but company resolving should be disabled since we lack access to the companies dataset
@@ -883,7 +1303,7 @@ func TestStore(test *testing.T) {
 				//inverse query for "company-1", no datasets restriction. should find 3 people with resolved entities
 				{CaseID: 6, startURI: companyNamespacePrefix + ":company-1", predicate: "http://data.mimiro.io/people/worksfor",
 					inverse: true, datasets: []string{},
-					expectedRelationCount: 3, firstRelationID: "ns3:person-5", firstRelationPropertyName: "ns3:Name", firstRelationPropertyValue: "Person 5",
+					expectedRelationCount: 6, firstRelationID: "ns3:person-5", firstRelationPropertyName: "ns3:Name", firstRelationPropertyValue: "Person 5",
 					extraCheck: func(e *Entity, g *goblin.G) {
 						//we should find 4 refs for the first resolved person, from both history and people datasets
 						g.Assert(len(e.References)).Eql(4)
@@ -1115,5 +1535,91 @@ func TestStore(test *testing.T) {
 
 			g.Assert(err).IsNil()
 		})
+
+		g.It("Should delete the correct incoming and outgoing references", func() {
+			g.Timeout(time.Hour)
+			b := store.database
+			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/people/")
+			workPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/work/")
+			g.Assert(count(b)).Eql(16)
+
+			friendsDS, _ := dsm.CreateDataset("friends")
+			g.Assert(count(b)).Eql(24)
+
+			workDS, _ := dsm.CreateDataset("work")
+			g.Assert(count(b)).Eql(32)
+
+			_ = friendsDS.StoreEntities([]*Entity{
+				NewEntityFromMap(map[string]interface{}{
+					"id":    peopleNamespacePrefix + ":person-1",
+					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+					"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"}}),
+				NewEntityFromMap(map[string]interface{}{
+					"id":    peopleNamespacePrefix + ":person-2",
+					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+					"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1"}}),
+			})
+			g.Assert(count(b)).Eql(55)
+
+			// check that we can query outgoing
+			result, err := store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", false, nil)
+			g.Assert(err).IsNil()
+			g.Assert(len(result)).Eql(1)
+			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
+			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
+
+			// check that we can query incoming
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", true, nil)
+			g.Assert(err).IsNil()
+			g.Assert(len(result)).Eql(1)
+			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
+			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
+
+			_ = workDS.StoreEntities([]*Entity{
+				NewEntityFromMap(map[string]interface{}{
+					"id":    peopleNamespacePrefix + ":person-1",
+					"props": map[string]interface{}{workPrefix + ":Wage": "110"},
+					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-2"}}),
+				NewEntityFromMap(map[string]interface{}{
+					"id":    peopleNamespacePrefix + ":person-2",
+					"props": map[string]interface{}{workPrefix + ":Wage": "100"},
+					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-3"}}),
+			})
+			g.Assert(count(b)).Eql(72)
+
+			// check that we can still query outgoing
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", false, nil)
+			// result, err = store.GetManyRelatedEntities( []string{"http://data.mimiro.io/people/person-1"}, "*", false, nil)
+			g.Assert(err).IsNil()
+			g.Assert(len(result)).Eql(1, "Expected still to find person-3 as a friend")
+			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
+
+			// and incoming
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", true, nil)
+			g.Assert(err).IsNil()
+			g.Assert(len(result)).Eql(1, "Expected still to find person-2 as reverse friend")
+			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
+		})
 	})
+}
+
+func count(b *badger.DB) int {
+	items := 0
+	_ = b.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+
+		for it.Rewind(); it.Valid(); it.Next() {
+			items++
+			//os.Stdout.Write([]byte(fmt.Sprintf("%v\n",it.Item())))
+		}
+
+		it.Close()
+		return nil
+	})
+	//os.Stdout.Write([]byte(fmt.Sprintf("%v\n\n\n",items)))
+	return items
 }


### PR DESCRIPTION
outgoing refs were being hidden by later version of the same entity in another dataset
some incoming refs were getting wrongly marked as deleted when storing the same entity in another dataset
point in time queries for inverse relationships was broken

NOTE: the binary representation has not changed, but some inverse rels may be marked as deleted when they are not. it is recommended to delete and reload the affected datasets.