### PR TITLE
BUGFIX: Add Content-Type header to http sink

### DIFF
--- a/internal/jobs/sink.go
+++ b/internal/jobs/sink.go
@@ -275,6 +275,8 @@ func (httpDatasetSink *httpDatasetSink) processEntities(runner *Runner, entities
 		}
 	}
 
+	req.Header.Add("Content-Type", "application/json")
+
 	res, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
The http sink is missing it's content-type, so added it.

This is considered a bug, and is currently breaking Spring Boot based
datalayers.