### PR TITLE
more detailed error messages in API responses

### DIFF
--- a/internal/server/error.go
+++ b/internal/server/error.go
@@ -15,7 +15,6 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -39,14 +38,14 @@ func (e *StorageError) Error() string {
 
 // we define these errors to prevent leaking of internal details on the api
 var (
-	AttemptStoreEntitiesErr = errors.New("failed when attempting to store entities")
-	SinceParseErr           = errors.New("since should be an integer number")
-	HttpBodyMissingErr      = errors.New("body is missing or could not read")
-	HttpJobParsingErr       = errors.New("failed at parsing the job definition")
-	HttpJobSchedulingErr    = errors.New("failed at scheduling the job definition")
-	HttpJsonParsingErr      = errors.New("failed parsing the json body")
-	HttpContentStoreErr     = errors.New("failed updating the content")
-	HttpQueryParamErr       = errors.New("one or more of the query parameters failed its validation")
-	HttpGenericErr          = errors.New("internal failure")
-	HttpFullsyncErr         = errors.New("an error occured trying to start or update a full sync")
+	AttemptStoreEntitiesErr = func(detail error) error { return fmt.Errorf("failed when attempting to store entities: %w", detail) }
+	SinceParseErr           = func(detail error) error { return fmt.Errorf("since should be an integer number: %w", detail) }
+	HttpBodyMissingErr      = func(detail error) error { return fmt.Errorf("body is missing or could not read: %w", detail) }
+	HttpJobParsingErr       = func(detail error) error { return fmt.Errorf("failed at parsing the job definition: %w", detail) }
+	HttpJobSchedulingErr    = func(detail error) error { return fmt.Errorf("failed at scheduling the job definition: %w", detail) }
+	HttpJsonParsingErr      = func(detail error) error { return fmt.Errorf("failed parsing the json body: %w", detail) }
+	HttpContentStoreErr     = func(detail error) error { return fmt.Errorf("failed updating the content: %w", detail) }
+	HttpQueryParamErr       = func(detail error) error { return fmt.Errorf("one or more of the query parameters failed its validation: %w", detail) }
+	HttpGenericErr          = func(detail error) error { return fmt.Errorf("internal failure: %w", detail) }
+	HttpFullsyncErr         = func(detail error) error { return fmt.Errorf("an error occured trying to start or update a full sync: %w", detail) }
 )

--- a/internal/web/contenthandler.go
+++ b/internal/web/contenthandler.go
@@ -54,7 +54,7 @@ func NewContentHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger,
 func (handler *contentHandler) contentList(c echo.Context) error {
 	res, err := handler.content.ListContents()
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, server.HttpGenericErr.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, server.HttpGenericErr(err).Error())
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -64,18 +64,18 @@ func (handler *contentHandler) contentAdd(c echo.Context) error {
 	// read json
 	body, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
 	}
 
 	content := &content.Content{}
 	err = json.Unmarshal(body, content)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
 	}
 
 	err = handler.content.AddContent(content.Id, content)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -97,18 +97,18 @@ func (handler *contentHandler) contentShow(c echo.Context) error {
 func (handler *contentHandler) contentUpdate(c echo.Context) error {
 	body, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
 	}
 	contentId := c.Param("contentId")
 	payload := &content.Content{}
 	err = json.Unmarshal(body, payload)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
 	}
 
 	err = handler.content.UpdateContent(contentId, payload)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -123,7 +123,7 @@ func (handler *contentHandler) contentDelete(c echo.Context) error {
 
 	err = handler.content.DeleteContent(contentId)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
 	}
 
 	return c.NoContent(http.StatusOK)

--- a/internal/web/jobshandler.go
+++ b/internal/web/jobshandler.go
@@ -73,12 +73,12 @@ func (handler *jobsHandler) jobsAdd(c echo.Context) error {
 	// read json
 	body, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
 	}
 
 	config, err := handler.jobScheduler.Parse(body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJobParsingErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJobParsingErr(err).Error())
 	}
 
 	err = handler.jobScheduler.AddJob(config)

--- a/internal/web/queryhandler.go
+++ b/internal/web/queryhandler.go
@@ -106,12 +106,12 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 	body, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
 		handler.logger.Warn("Unable to read body")
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
 	}
 	err = json.Unmarshal(body, &query)
 	if err != nil {
 		handler.logger.Warn("Unable to parse json")
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
 	}
 
 	if query.EntityId != "" {


### PR DESCRIPTION
When the datahub is accessed with it's web api, it is currently hard to tell what went  wrong if the user sends invalid input data. This is because the web handler return generic error messages. 
This can be improved by appening the underlying error messages to the respones.

Example, when sending an empty payload to a dataset:
![image](https://user-images.githubusercontent.com/674691/114983998-8beddc00-9e91-11eb-9f85-32c010bbc024.png)
