### PR TITLE
[FEATURE] Update transform functions #36

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -648,6 +648,23 @@ id = GetId(e);
 
 returns value `ns0:bob`
 
+#### SetId
+
+`SetId(entity, id)` takes a parameter of type `Entity` and a string with an id, and updates the id of the entity.
+
+Example:
+
+```javascript
+var e = NewEntity();
+SetId(e, PrefixField("ns0", 42));
+
+Log("Id is now: " + GetId(e));
+```
+```text
+ INFO  - Id is now: ns0:42
+```
+
+
 #### GetNamespacePrefix
 
 URIs are often represented as CURIEs. CURIEs are formed of a prefix part and local part. The prefix is key that corresponds to an expansion. To resolve a CURIE into a full URI the local part of appended to the prefix expansion.
@@ -719,6 +736,22 @@ var personTypePrefix = GetNamespacePrefix("http://data.mimiro.io/schema/person/"
 personName = GetProperty(person, personTypePrefix, "name");
 ```
 
+The `GetProperty` function can also take an optional extra defaultValue
+
+```javascript
+var e = NewEntity();
+
+// field1 is missing
+var value = GetProperty(e, "ns0", "field1", "my default value");
+
+Log(value);
+
+```
+```text
+ INFO  - my default value
+```
+
+
 #### SetProperty
 
 To set the value of a named property on an entity use the SetProperty function.
@@ -727,6 +760,27 @@ To set the value of a named property on an entity use the SetProperty function.
 var personTypePrefix = GetNamespacePrefix("http://data.mimiro.io/schema/person/");
 
 SetProperty(person, personTypePrefix, "name", "bobby");
+```
+
+#### SetDeleted / GetDeleted
+
+`SetDeleted` takes a parameter `entity` of type Entity, and a boolean flag, and updates the deleted state on the Entity.
+
+`GetDeleted` takes a single parameter `entity` of type Entity, and returns the deleted state of the Entity. If entity is 
+missing or null, this function returns undefined.
+
+Example:
+
+```javascript
+var e = NewEntity()
+
+SetDeleted(e, true);
+var deleted = GetDeleted(e);
+
+Log("Deleted: " + ToString(deleted));
+```
+```text
+ INFO  - Deleted: true
 ```
 
 #### RenameProperty

--- a/internal/jobs/transform.go
+++ b/internal/jobs/transform.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -40,29 +41,79 @@ type Transform interface {
 // (i mean, not really, but maybe it will help)
 const helperJavascriptFunctions = `
 function SetProperty(entity, prefix, name, value) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	if (entity.Properties === null || entity.Properties === undefined) {
+		return;
+	}
 	entity["Properties"][prefix+":"+name] = value;
 }
-function GetProperty(entity, prefix, name) {
-	return entity["Properties"][prefix+":"+name];
+function GetProperty(entity, prefix, name, defaultValue) {
+	if (entity === null || entity === undefined) {
+		return defaultValue;
+	}
+	if (entity.Properties === null || entity.Properties === undefined) {
+		return defaultValue;
+	}
+	var value = entity["Properties"][prefix+":"+name]
+	if (value === undefined || value === null) {
+		return defaultValue;
+	}
+	return value;
 }
 function AddReference(entity, prefix, name, value) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	if (entity.References === null || entity.References === undefined) {
+		return;
+	}
 	entity["References"][prefix+":"+name] = value;
 }
 function GetId(entity) {
-    return entity["ID"];
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	return entity["ID"];
 }
+function SetId(entity, id) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	entity.ID = id
+}
+
+function SetDeleted(entity, deleted) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	entity.IsDeleted = deleted
+}
+
+function GetDeleted(entity) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	return entity.IsDeleted;
+}
+
 function PrefixField(prefix, field) {
     return prefix + ":" + field;
 }
 function RenameProperty(entity, originalPrefix, originalName, newPrefix, newName) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
 	var value = GetProperty(entity, originalPrefix, originalName);
 	SetProperty(entity, newPrefix, newName, value);
 	RemoveProperty(entity, originalPrefix, originalName);
 }
-function ToString(value){
-	return (value === null || value === undefined) ? value : value.toString();
-}
+
 function RemoveProperty(entity, prefix, name){
+	if (entity === null || entity === undefined) {
+		return;
+	}
 	delete entity["Properties"][prefix+":"+name];
 }
 `
@@ -118,6 +169,7 @@ func newJavascriptTransform(log *zap.SugaredLogger, code64 string, store *server
 	transform.Runtime.Set("AssertNamespacePrefix", transform.AssertNamespacePrefix)
 	transform.Runtime.Set("Log", transform.Log)
 	transform.Runtime.Set("NewEntity", transform.NewEntity)
+	transform.Runtime.Set("ToString", transform.ToString)
 
 	_, err = transform.Runtime.RunString(string(code))
 	if err != nil {
@@ -183,6 +235,27 @@ func (javascriptTransform *JavascriptTransform) ById(entityId string, datasets [
 		return nil
 	}
 	return entity
+}
+
+func (javascriptTransform *JavascriptTransform) ToString(obj interface{}) string {
+	if obj == nil {
+		return "undefined"
+	}
+
+	switch obj.(type) {
+	case *server.Entity:
+		return fmt.Sprintf("%v", obj)
+	case map[string]interface{}:
+		return fmt.Sprintf("%v", obj)
+	case int, int32, int64:
+		return fmt.Sprintf("%d", obj)
+	case float32, float64:
+		return fmt.Sprintf("%g", obj)
+	case bool:
+		return fmt.Sprintf("%v", obj)
+	default:
+		return fmt.Sprintf("%s", obj)
+	}
 }
 
 func (javascriptTransform *JavascriptTransform) transformEntities(runner *Runner, entities []*server.Entity) ([]*server.Entity, error) {

--- a/internal/jobs/transform_test.go
+++ b/internal/jobs/transform_test.go
@@ -38,3 +38,54 @@ func TestTransform(t *testing.T) {
 		})
 	})
 }
+
+func TestJavascriptTransform_ToString(t *testing.T) {
+	g := goblin.Goblin(t)
+	g.Describe("Calling ToString from a transform", func() {
+		g.It("should return null when nil", func() {
+			transform := &JavascriptTransform{}
+			ret := transform.ToString(nil)
+
+			g.Assert(ret).Equal("undefined")
+		})
+		g.It("number should be formatted as a number", func() {
+			transform := &JavascriptTransform{}
+			ret := transform.ToString(30)
+			g.Assert(ret).Equal("30")
+
+			ret = transform.ToString(2.1)
+			g.Assert(ret).Equal("2.1")
+		})
+		g.It("bool should be formatted with true or false", func() {
+			transform := &JavascriptTransform{}
+			ret := transform.ToString(true)
+			g.Assert(ret).Equal("true")
+		})
+		g.It("a map should correctly formatted", func() {
+			transform := &JavascriptTransform{}
+
+			lemap := map[string]interface{}{
+				"field1": 1,
+				"field2": "2",
+			}
+
+			ret := transform.ToString(lemap)
+			g.Assert(ret).Equal("map[field1:1 field2:2]")
+
+		})
+		g.It("an entity should be formatted correctly", func() {
+			transform := &JavascriptTransform{}
+
+			e := transform.NewEntity()
+			e.ID = "ns1:1"
+			e.InternalID = 1
+			e.Recorded = 2
+			e.Properties = map[string]interface{}{
+				"field1": "hello",
+			}
+			ret := transform.ToString(e)
+
+			g.Assert(ret).Equal("&{ns1:1 1 2 false map[] map[field1:hello]}")
+		})
+	})
+}

--- a/last_bench.txt
+++ b/last_bench.txt
@@ -2,15 +2,15 @@ goos: linux
 goarch: amd64
 pkg: github.com/mimiro-io/datahub/internal/server
 cpu: Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-BenchmarkDatasetStoreEntities-2   	      26	  44021987 ns/op	16034169 B/op	  204692 allocs/op
-BenchmarkDatasetStoreEntities-2   	      27	  41860260 ns/op	15737715 B/op	  204718 allocs/op
-BenchmarkDatasetStoreEntities-2   	      28	  40987606 ns/op	15460696 B/op	  204738 allocs/op
-BenchmarkDatasetStoreEntities-2   	      28	  41716328 ns/op	15461044 B/op	  204741 allocs/op
-BenchmarkDatasetStoreEntities-2   	      27	  42111163 ns/op	15737109 B/op	  204715 allocs/op
-BenchmarkDatasetStoreEntities-2   	      30	  41686110 ns/op	14967383 B/op	  204794 allocs/op
-BenchmarkDatasetStoreEntities-2   	      28	  41352173 ns/op	15460579 B/op	  204738 allocs/op
-BenchmarkDatasetStoreEntities-2   	      28	  41376893 ns/op	15461552 B/op	  204742 allocs/op
-BenchmarkDatasetStoreEntities-2   	      28	  42569455 ns/op	15462253 B/op	  204744 allocs/op
-BenchmarkDatasetStoreEntities-2   	      28	  40975688 ns/op	15463320 B/op	  204750 allocs/op
+BenchmarkDatasetStoreEntities-2   	      24	  46036921 ns/op	16697642 B/op	  204615 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  44188444 ns/op	16031860 B/op	  204682 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  44814734 ns/op	16033328 B/op	  204689 allocs/op
+BenchmarkDatasetStoreEntities-2   	      27	  43297256 ns/op	15754935 B/op	  204715 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  43910460 ns/op	16031347 B/op	  204680 allocs/op
+BenchmarkDatasetStoreEntities-2   	      27	  43460594 ns/op	15737953 B/op	  204719 allocs/op
+BenchmarkDatasetStoreEntities-2   	      27	  45792111 ns/op	15737462 B/op	  204716 allocs/op
+BenchmarkDatasetStoreEntities-2   	      27	  44349402 ns/op	15736856 B/op	  204714 allocs/op
+BenchmarkDatasetStoreEntities-2   	      27	  43898685 ns/op	15737838 B/op	  204718 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  44768918 ns/op	16031877 B/op	  204683 allocs/op
 PASS
-ok  	github.com/mimiro-io/datahub/internal/server	21.809s
+ok  	github.com/mimiro-io/datahub/internal/server	22.215s


### PR DESCRIPTION
Some of the transform functions were a little bit wonky, and some useful
functions were also missing.

All JavaScript functions have been updated to prevent erroring when missing
values, either entities or fields or properties. Functions returning values
are now all returning undefined if no value can be found, rather than a mix
of null and undefined (this should have no impact, as before they would
just crash).

 * SetProperty(entity, prefix, name, value) - no longer crash
 * GetProperty(entity, prefix, name, defaultValue) - no longer crash, optional default value
 * AddReference(entity, prefix, name, value) - no longer crash
 * GetId(entity) - no longer crash
 * SetId(entity, id) - new
 * SetDeleted(entity, deleted) - new
 * GetDeleted(entity) - new
 * RenameProperty(entity, originalPrefix, originalName, newPrefix, newName) - no crash
 * RemoveProperty(entity, prefix, name) - no longer crash

In addition, the ToString function has been moved from JavaScript to Go,
this was done to be able to correctly convert Entities to string. (no longer
just [object Object]).
Also the ToString function will now return "undefined" is the underlying
object is a Go nil. Since Go makes no difference of undefined vs null, I
chose to use undefined in the logs instead of null. The user must still check
for null or undefined.

This feature is accompanied with a matching change in the Mim CLI project.