### PR TITLE
remove timeout constrains in httpDatasetSource. And add metrics

### DIFF
--- a/internal/jobs/job.go
+++ b/internal/jobs/job.go
@@ -83,25 +83,26 @@ func (job *job) Run() {
 	tags := []string{
 		"application:datahub",
 		fmt.Sprintf("jobs:job-%s", job.id),
+		fmt.Sprintf("jobtype:%v", jobType),
 	}
-	_ = job.runner.statsdClient.Incr("jobs.count", tags, 1)
+	_ = job.runner.statsdClient.Count("jobs.count", 1, tags, 1)
 
 	sourceType := job.pipeline.spec().source.GetConfig()["Type"]
 	sinkType := job.pipeline.spec().sink.GetConfig()["Type"]
 	job.runner.logger.Infof(" > Running task '%s': %s -> %s", job.id, sourceType, sinkType)
 	err := job.pipeline.sync(job, ticket.runState.ctx)
+	timed := time.Since(ticket.runState.started)
 	if err != nil {
 		if err.Error() == "got job interrupt" { // if a job gets killed, this will trigger
+			_ = job.runner.statsdClient.Count("jobs.cancelled", timed.Nanoseconds(), tags, 1)
 			job.runner.logger.Infof("Job '%s' was terminated", job.id)
 		} else {
-			_ = job.runner.statsdClient.Count("jobs.error", 1, tags, 1) // we only want to count runtime errors
+			_ = job.runner.statsdClient.Count("jobs.error", timed.Nanoseconds(), tags, 1)
 			job.runner.logger.Warnf("Failed running task for job '%s': %s", job.id, err.Error())
 		}
 	} else {
-		_ = job.runner.statsdClient.Count("jobs.success", 1, tags, 1)
+		_ = job.runner.statsdClient.Count("jobs.success", timed.Nanoseconds(), tags, 1)
 	}
-
-	timed := time.Since(ticket.runState.started)
 
 	job.runner.logger.Infof("Finished %s with id '%s' - duration was %s", msg, job.id, timed)
 

--- a/internal/jobs/transform.go
+++ b/internal/jobs/transform.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"github.com/DataDog/datadog-go/statsd"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -133,10 +134,12 @@ func newJavascriptTransform(log *zap.SugaredLogger, code64 string, store *server
 }
 
 type JavascriptTransform struct {
-	Store   *server.Store
-	Code    []byte
-	Runtime *goja.Runtime
-	Logger  *zap.SugaredLogger
+	Store        *server.Store
+	Code         []byte
+	Runtime      *goja.Runtime
+	Logger       *zap.SugaredLogger
+	statsDClient statsd.ClientInterface
+	statsDTags   []string
 }
 
 func (javascriptTransform *JavascriptTransform) Log(thing interface{}) {
@@ -160,17 +163,27 @@ func (javascriptTransform *JavascriptTransform) NewEntity() *server.Entity {
 }
 
 func (javascriptTransform *JavascriptTransform) GetNamespacePrefix(urlExpansion string) string {
+	ts := time.Now()
+
 	prefix, _ := javascriptTransform.Store.NamespaceManager.GetPrefixMappingForExpansion(urlExpansion)
+	_ = javascriptTransform.statsDClient.Count("transform.GetNamespacePrefix.time",
+		int64(time.Since(ts)), javascriptTransform.statsDTags, 1)
 	return prefix
 }
 
 func (javascriptTransform *JavascriptTransform) AssertNamespacePrefix(urlExpansion string) string {
+	ts := time.Now()
 	prefix, _ := javascriptTransform.Store.NamespaceManager.AssertPrefixMappingForExpansion(urlExpansion)
+	_ = javascriptTransform.statsDClient.Count("transform.AssertNamespacePrefix.time",
+		int64(time.Since(ts)), javascriptTransform.statsDTags, 1)
 	return prefix
 }
 
 func (javascriptTransform *JavascriptTransform) Query(startingEntities []string, predicate string, inverse bool, datasets []string) [][]interface{} {
+	ts := time.Now()
 	results, err := javascriptTransform.Store.GetManyRelatedEntities(startingEntities, predicate, inverse, datasets)
+	_ = javascriptTransform.statsDClient.Count("transform.Query.time",
+		int64(time.Since(ts)), javascriptTransform.statsDTags, 1)
 	if err != nil {
 		return nil
 	}
@@ -178,7 +191,10 @@ func (javascriptTransform *JavascriptTransform) Query(startingEntities []string,
 }
 
 func (javascriptTransform *JavascriptTransform) ById(entityId string, datasets []string) *server.Entity {
+	ts := time.Now()
 	entity, err := javascriptTransform.Store.GetEntity(entityId, datasets)
+	_ = javascriptTransform.statsDClient.Count("transform.ById.time",
+		int64(time.Since(ts)), javascriptTransform.statsDTags, 1)
 	if err != nil {
 		return nil
 	}
@@ -189,7 +205,8 @@ func (javascriptTransform *JavascriptTransform) transformEntities(runner *Runner
 
 	var transformFunc func(entities []*server.Entity) (interface{}, error)
 	err := javascriptTransform.Runtime.ExportTo(javascriptTransform.Runtime.Get("transform_entities"), &transformFunc)
-
+	javascriptTransform.statsDClient = runner.statsdClient
+	javascriptTransform.statsDTags = []string{"application:datahub"}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jobs/transform_test.go
+++ b/internal/jobs/transform_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"encoding/base64"
+	"github.com/DataDog/datadog-go/statsd"
 	"strings"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestTransform(t *testing.T) {
 			entities := make([]*server.Entity, 0)
 			entities = append(entities, server.NewEntity("1", 1))
 
-			_, err = transform.transformEntities(nil, entities)
+			_, err = transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities)
 			g.Assert(err).IsNotNil("tranform should fail")
 			g.Assert(strings.Split(err.Error(), " (")[0]).
 				Eql("ReferenceError: prefix is not defined at transform_entities")

--- a/internal/server/dataset.go
+++ b/internal/server/dataset.go
@@ -214,7 +214,7 @@ func (ds *Dataset) StoreEntities(entities []*Entity) (Error error) {
 	writeLockStart := time.Now()
 	// release lock at end regardless
 	defer func() {
-		_ = ds.store.statsdClient.TimeInMilliseconds("ds.writeLock.time", float64(time.Since(writeLockStart).Nanoseconds())/1000, tags, 1)
+		_ = ds.store.statsdClient.Gauge("ds.writeLock.time", float64(time.Since(writeLockStart).Nanoseconds()), tags, 1)
 		ds.writeLock.Unlock()
 	}()
 
@@ -252,7 +252,6 @@ func (ds *Dataset) StoreEntities(entities []*Entity) (Error error) {
 
 	for _, e := range entities {
 
-		_ = ds.store.statsdClient.Incr("ds.entities.rate", tags, 1)
 		// entityIdBuffer buffer for lookup in main index
 		// index_id;rid;dataset;time => blob
 		// unit16;unit64;uint32;uint64
@@ -528,12 +527,14 @@ func (ds *Dataset) StoreEntities(entities []*Entity) (Error error) {
 
 	commitTime := time.Now()
 	err = txn.Commit()
-	_ = ds.store.statsdClient.TimeInMilliseconds("ds.commit.time", float64(time.Since(commitTime).Nanoseconds())/1000, tags, 1)
+	_ = ds.store.statsdClient.Gauge("ds.commit.time", float64(time.Since(commitTime).Nanoseconds()), tags, 1)
 	if err != nil {
 		return err
 	}
 
+	updateDsTime := time.Now()
 	err = ds.updateDataset(newitems, entities)
+	_ = ds.store.statsdClient.Gauge("ds.updateDataset.time", float64(time.Since(updateDsTime).Nanoseconds()), tags, 1)
 	if err != nil {
 		return err
 	}

--- a/internal/server/dataset.go
+++ b/internal/server/dataset.go
@@ -214,7 +214,7 @@ func (ds *Dataset) StoreEntities(entities []*Entity) (Error error) {
 	writeLockStart := time.Now()
 	// release lock at end regardless
 	defer func() {
-		_ = ds.store.statsdClient.Gauge("ds.writeLock.time", float64(time.Since(writeLockStart).Nanoseconds()), tags, 1)
+		_ = ds.store.statsdClient.Count("ds.writeLock.time", time.Since(writeLockStart).Nanoseconds(), tags, 1)
 		ds.writeLock.Unlock()
 	}()
 
@@ -527,14 +527,14 @@ func (ds *Dataset) StoreEntities(entities []*Entity) (Error error) {
 
 	commitTime := time.Now()
 	err = txn.Commit()
-	_ = ds.store.statsdClient.Gauge("ds.commit.time", float64(time.Since(commitTime).Nanoseconds()), tags, 1)
+	_ = ds.store.statsdClient.Count("ds.commit.time", time.Since(commitTime).Nanoseconds(), tags, 1)
 	if err != nil {
 		return err
 	}
 
 	updateDsTime := time.Now()
 	err = ds.updateDataset(newitems, entities)
-	_ = ds.store.statsdClient.Gauge("ds.updateDataset.time", float64(time.Since(updateDsTime).Nanoseconds()), tags, 1)
+	_ = ds.store.statsdClient.Count("ds.updateDataset.time", time.Since(updateDsTime).Nanoseconds(), tags, 1)
 	if err != nil {
 		return err
 	}

--- a/last_bench.txt
+++ b/last_bench.txt
@@ -1,16 +1,16 @@
 goos: linux
 goarch: amd64
 pkg: github.com/mimiro-io/datahub/internal/server
-cpu: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
-BenchmarkDatasetStoreEntities-2   	      21	  52075207 ns/op	17935135 B/op	  204492 allocs/op
-BenchmarkDatasetStoreEntities-2   	      25	  49832341 ns/op	16352411 B/op	  204652 allocs/op
-BenchmarkDatasetStoreEntities-2   	      25	  48481331 ns/op	16351663 B/op	  204649 allocs/op
-BenchmarkDatasetStoreEntities-2   	      25	  48549131 ns/op	16350466 B/op	  204643 allocs/op
-BenchmarkDatasetStoreEntities-2   	      25	  47872260 ns/op	16353501 B/op	  204656 allocs/op
-BenchmarkDatasetStoreEntities-2   	      25	  48816181 ns/op	16352374 B/op	  204652 allocs/op
-BenchmarkDatasetStoreEntities-2   	      25	  48527707 ns/op	16353877 B/op	  204658 allocs/op
-BenchmarkDatasetStoreEntities-2   	      24	  48060474 ns/op	16697943 B/op	  204616 allocs/op
-BenchmarkDatasetStoreEntities-2   	      24	  47574303 ns/op	16699457 B/op	  204623 allocs/op
-BenchmarkDatasetStoreEntities-2   	      25	  47648574 ns/op	16371696 B/op	  204653 allocs/op
+cpu: Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+BenchmarkDatasetStoreEntities-2   	      25	  47555693 ns/op	16402840 B/op	  208012 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  43516213 ns/op	16381477 B/op	  208003 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  44891125 ns/op	16065706 B/op	  208041 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  44831769 ns/op	16064768 B/op	  208037 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  44149590 ns/op	16062268 B/op	  208026 allocs/op
+BenchmarkDatasetStoreEntities-2   	      27	  44722238 ns/op	15767401 B/op	  208083 allocs/op
+BenchmarkDatasetStoreEntities-2   	      27	  45546414 ns/op	15785911 B/op	  208085 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  44254450 ns/op	16082943 B/op	  208035 allocs/op
+BenchmarkDatasetStoreEntities-2   	      26	  44141799 ns/op	16063773 B/op	  208032 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  45261842 ns/op	16384002 B/op	  208015 allocs/op
 PASS
-ok  	github.com/mimiro-io/datahub/internal/server	23.445s
+ok  	github.com/mimiro-io/datahub/internal/server	21.832s

--- a/last_bench.txt
+++ b/last_bench.txt
@@ -1,16 +1,16 @@
 goos: linux
 goarch: amd64
 pkg: github.com/mimiro-io/datahub/internal/server
-cpu: Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-BenchmarkDatasetStoreEntities-2   	      24	  46036921 ns/op	16697642 B/op	  204615 allocs/op
-BenchmarkDatasetStoreEntities-2   	      26	  44188444 ns/op	16031860 B/op	  204682 allocs/op
-BenchmarkDatasetStoreEntities-2   	      26	  44814734 ns/op	16033328 B/op	  204689 allocs/op
-BenchmarkDatasetStoreEntities-2   	      27	  43297256 ns/op	15754935 B/op	  204715 allocs/op
-BenchmarkDatasetStoreEntities-2   	      26	  43910460 ns/op	16031347 B/op	  204680 allocs/op
-BenchmarkDatasetStoreEntities-2   	      27	  43460594 ns/op	15737953 B/op	  204719 allocs/op
-BenchmarkDatasetStoreEntities-2   	      27	  45792111 ns/op	15737462 B/op	  204716 allocs/op
-BenchmarkDatasetStoreEntities-2   	      27	  44349402 ns/op	15736856 B/op	  204714 allocs/op
-BenchmarkDatasetStoreEntities-2   	      27	  43898685 ns/op	15737838 B/op	  204718 allocs/op
-BenchmarkDatasetStoreEntities-2   	      26	  44768918 ns/op	16031877 B/op	  204683 allocs/op
+cpu: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+BenchmarkDatasetStoreEntities-2   	      21	  52075207 ns/op	17935135 B/op	  204492 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  49832341 ns/op	16352411 B/op	  204652 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  48481331 ns/op	16351663 B/op	  204649 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  48549131 ns/op	16350466 B/op	  204643 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  47872260 ns/op	16353501 B/op	  204656 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  48816181 ns/op	16352374 B/op	  204652 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  48527707 ns/op	16353877 B/op	  204658 allocs/op
+BenchmarkDatasetStoreEntities-2   	      24	  48060474 ns/op	16697943 B/op	  204616 allocs/op
+BenchmarkDatasetStoreEntities-2   	      24	  47574303 ns/op	16699457 B/op	  204623 allocs/op
+BenchmarkDatasetStoreEntities-2   	      25	  47648574 ns/op	16371696 B/op	  204653 allocs/op
 PASS
-ok  	github.com/mimiro-io/datahub/internal/server	22.215s
+ok  	github.com/mimiro-io/datahub/internal/server	23.445s


### PR DESCRIPTION
The noticable change here is the timeout removal in httpDatasetSource.

The way a pipeline ties source, transform and sink together makes progress in the source dependent on writes in the sink. If our sink writes are blocked for some reason (e.g. badger compaction), we currently would hit source timeouts.

Instead of adjusting the source timeouts higher, we want to operate without timeout here. Most or all operations in the source-reading loop (mainly the streamparser) should throw errors if the connection breaks so that we should be able to avoid lockups without timeouts.

----
This change also adds and changes some metrics:
- `jobs.success`, `jobs.error` have been changed to report job runtime. `jobs.cancelled` was added as well. This allows for graphing of runtime durations over time. example:
![image](https://user-images.githubusercontent.com/674691/116993815-3fe7c780-acd8-11eb-9f3c-86cdd906b31d.png)

- `transform.GetNamespacePrefix.time`, `transform.AssertNamespacePrefix.time`, `transform.Query.time` and `transform.ById.time` sum up execution times for the respective transform operations. We use statsd `Count` over `Timing` here for simplicity and a smaller metric footprint.
![image](https://user-images.githubusercontent.com/674691/116994509-18ddc580-acd9-11eb-90df-4543558f9e8a.png)

- `ds.writeLock.time`, `ds.commit.time` and `ds.updateDataset.time` allow for visualization of various blockable operations in dataset.StoreEntities. writeLock is the duration of one complete StoreEntities call, commit is the duration of only the commit call on badger's write  transaction and updateDataset measures how long it takes to update dataset metadata.
![image](https://user-images.githubusercontent.com/674691/116997583-4298eb80-acdd-11eb-901c-07951c8d47b2.png)
