### PR TITLE
do not exclude event jobRuns from ticket limits any more

### DIFF
--- a/internal/jobs/raffle.go
+++ b/internal/jobs/raffle.go
@@ -75,6 +75,7 @@ func (r *raffle) borrowTicket(job *job) *ticket {
 			ctx, cancel := context.WithCancel(context.Background())
 			state := &runState{
 				started: time.Now(),
+				isEvent: job.isEvent,
 				isFull:  true,
 				id:      job.id,
 				ctx:     ctx,
@@ -83,19 +84,6 @@ func (r *raffle) borrowTicket(job *job) *ticket {
 			r.runningJobs[job.id] = state
 			return &ticket{runState: state}
 		}
-	} else if job.isEvent {
-		// you get a ticket, we dont pool these
-		ctx, cancel := context.WithCancel(context.Background())
-		state := &runState{
-			started: time.Now(),
-			isEvent: true,
-			id:      job.id,
-			ctx:     ctx,
-			cancel:  cancel,
-		}
-		r.runningJobs[job.id] = state
-		return &ticket{runState: state}
-
 	} else {
 		if r.ticketsIncr > 0 {
 			r.ticketsIncr--
@@ -103,6 +91,7 @@ func (r *raffle) borrowTicket(job *job) *ticket {
 			ctx, cancel := context.WithCancel(context.Background())
 			state := &runState{
 				started: time.Now(),
+				isEvent: job.isEvent,
 				isFull:  false,
 				id:      job.id,
 				ctx:     ctx,


### PR DESCRIPTION
currently, event jobs do not decrease the ticket counts for their respective jobTypes. However - they do return tickets and therefor unwillingly increase ticketlimits.

This change lets event job runs decrease the ticket counters just as scheduled jobs.