### PR TITLE
use statsd.Timing instead of Count.

### DIFF
--- a/internal/jobs/transform.go
+++ b/internal/jobs/transform.go
@@ -19,8 +19,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"github.com/DataDog/datadog-go/statsd"
 	"fmt"
+	"github.com/DataDog/datadog-go/statsd"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -218,24 +218,24 @@ func (javascriptTransform *JavascriptTransform) GetNamespacePrefix(urlExpansion 
 	ts := time.Now()
 
 	prefix, _ := javascriptTransform.Store.NamespaceManager.GetPrefixMappingForExpansion(urlExpansion)
-	_ = javascriptTransform.statsDClient.Count("transform.GetNamespacePrefix.time",
-		int64(time.Since(ts)), javascriptTransform.statsDTags, 1)
+	_ = javascriptTransform.statsDClient.Timing("transform.GetNamespacePrefix.time",
+		time.Since(ts), javascriptTransform.statsDTags, 1)
 	return prefix
 }
 
 func (javascriptTransform *JavascriptTransform) AssertNamespacePrefix(urlExpansion string) string {
 	ts := time.Now()
 	prefix, _ := javascriptTransform.Store.NamespaceManager.AssertPrefixMappingForExpansion(urlExpansion)
-	_ = javascriptTransform.statsDClient.Count("transform.AssertNamespacePrefix.time",
-		int64(time.Since(ts)), javascriptTransform.statsDTags, 1)
+	_ = javascriptTransform.statsDClient.Timing("transform.AssertNamespacePrefix.time",
+		time.Since(ts), javascriptTransform.statsDTags, 1)
 	return prefix
 }
 
 func (javascriptTransform *JavascriptTransform) Query(startingEntities []string, predicate string, inverse bool, datasets []string) [][]interface{} {
 	ts := time.Now()
 	results, err := javascriptTransform.Store.GetManyRelatedEntities(startingEntities, predicate, inverse, datasets)
-	_ = javascriptTransform.statsDClient.Count("transform.Query.time",
-		int64(time.Since(ts)), javascriptTransform.statsDTags, 1)
+	_ = javascriptTransform.statsDClient.Timing("transform.Query.time",
+		time.Since(ts), javascriptTransform.statsDTags, 1)
 	if err != nil {
 		return nil
 	}
@@ -245,8 +245,8 @@ func (javascriptTransform *JavascriptTransform) Query(startingEntities []string,
 func (javascriptTransform *JavascriptTransform) ById(entityId string, datasets []string) *server.Entity {
 	ts := time.Now()
 	entity, err := javascriptTransform.Store.GetEntity(entityId, datasets)
-	_ = javascriptTransform.statsDClient.Count("transform.ById.time",
-		int64(time.Since(ts)), javascriptTransform.statsDTags, 1)
+	_ = javascriptTransform.statsDClient.Timing("transform.ById.time",
+		time.Since(ts), javascriptTransform.statsDTags, 1)
 	if err != nil {
 		return nil
 	}

--- a/internal/server/dataset.go
+++ b/internal/server/dataset.go
@@ -214,7 +214,7 @@ func (ds *Dataset) StoreEntities(entities []*Entity) (Error error) {
 	writeLockStart := time.Now()
 	// release lock at end regardless
 	defer func() {
-		_ = ds.store.statsdClient.Count("ds.writeLock.time", time.Since(writeLockStart).Nanoseconds(), tags, 1)
+		_ = ds.store.statsdClient.Timing("ds.writeLock.time", time.Since(writeLockStart), tags, 1)
 		ds.writeLock.Unlock()
 	}()
 
@@ -590,14 +590,14 @@ func (ds *Dataset) StoreEntities(entities []*Entity) (Error error) {
 
 	commitTime := time.Now()
 	err = txn.Commit()
-	_ = ds.store.statsdClient.Count("ds.commit.time", time.Since(commitTime).Nanoseconds(), tags, 1)
+	_ = ds.store.statsdClient.Timing("ds.commit.time", time.Since(commitTime), tags, 1)
 	if err != nil {
 		return err
 	}
 
 	updateDsTime := time.Now()
 	err = ds.updateDataset(newitems, entities)
-	_ = ds.store.statsdClient.Count("ds.updateDataset.time", time.Since(updateDsTime).Nanoseconds(), tags, 1)
+	_ = ds.store.statsdClient.Timing("ds.updateDataset.time", time.Since(updateDsTime), tags, 1)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Timing transmits more timeseries-data per metric, and therefore gives more granular insight than sums of durations.