### PR TITLE
add timings around batch steps.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,7 +6,7 @@ Semantic Graph databases are the ideal basis for an integration platform, they a
 
 Data integration is often done by writing ad-hoc code to talk to different APIs, and long running batch ETL jobs. The data hub standardises on a simple, generic protocol for exposing and updating remote systems with support for both batch, incremental and streaming modes.
 
-Combining the semantic graph database with simple synchronisation protocol delivers a generic and powerful capability for collecting, connecting and delivering data from and to many sources. 
+Combining the semantic graph database with simple synchronisation protocol delivers a generic and powerful capability for collecting, connecting and delivering data from and to many sources.
 
 Once the data is in the graph database it can be connected via queries and transformed to produce new unified data structures. These data can then be used as the basis for ML and AI, or sent to external third parties via APIs or data exports.
 
@@ -16,7 +16,7 @@ Finally, data is changing over time, it is often useful to go back to a given mo
 
 Getting started with the MIMIRO data hub is quick and easy. The data hub can be run locally with just one command. Check out the [getting started](./README.md#getting-started) section for how to get it running.
 
-Working with the data hub API can be done in many ways, but we really recommend getting and installing, `mim`, the MIMIRO data hub CLI. 
+Working with the data hub API can be done in many ways, but we really recommend getting and installing, `mim`, the MIMIRO data hub CLI.
 
 `mim` can be downloaded for any platform: linux, macos, and windows. Check out the [releases](https://github.com/mimiro-io/datahub-cli/releases) on github.
 
@@ -233,7 +233,7 @@ Now, when we retrieve entities from `namespaces.Test`, datahub will supply only 
 
 ```
 > mim dataset entities namespaces.
-                                                                                                          
+
 # Listing entities from http://localhost:4242/datasets/namespaces.Test/entities
 # Namespaces:
 
@@ -685,6 +685,19 @@ var personTypePrefix = GetNamespacePrefix("http://data.mimiro.io/schema/people/"
 var newTypePrefix = AssertNamespacePrefix("http://data.mimiro.io/schema/company/")
 ```
 
+#### Timing
+
+`Timing` can be used to create custom timing metrics around parts of a transform. The function accepts a metric name as
+first parameter and a "send" boolean as optional second parameter. When the send parameter is false or omitted, the `Timing`
+function registers a start-timestamp for the given metric name. When the send parameter is `true`, Timing sends the duration
+since start as timing value to statsd.
+
+```javascript
+Timing("hello")  //register start for metric "hello"
+// ... do something
+Timing("hello", true) // send duration since start for metric "hello"
+```
+
 #### Log
 
 Any value can be passed to `Log` and it will print it to the console. This should be used when testing and developing transforms locally. When executed in the data hub this is a noop.
@@ -766,7 +779,7 @@ SetProperty(person, personTypePrefix, "name", "bobby");
 
 `SetDeleted` takes a parameter `entity` of type Entity, and a boolean flag, and updates the deleted state on the Entity.
 
-`GetDeleted` takes a single parameter `entity` of type Entity, and returns the deleted state of the Entity. If entity is 
+`GetDeleted` takes a single parameter `entity` of type Entity, and returns the deleted state of the Entity. If entity is
 missing or null, this function returns undefined.
 
 Example:

--- a/internal/jobs/pipeline.go
+++ b/internal/jobs/pipeline.go
@@ -17,6 +17,7 @@ package jobs
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/mimiro-io/datahub/internal/server"
 )
@@ -66,9 +67,13 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 	}
 	syncJobState.ContinuationToken = ""
 
+	tags := []string{"application:datahub", "job:" + job.id }
 	for keepReading {
 
+		readTs := time.Now()
 		err := pipeline.source.readEntities(runner, syncJobState.ContinuationToken, pipeline.batchSize, func(entities []*server.Entity, continuationToken string) error {
+			_ = runner.statsdClient.Timing("pipeline.source.batch", time.Since(readTs), tags, 1)
+			readTs = time.Now()
 			select {
 			// if the cancellable context is cancelled, ctx.Done will trigger, and it will break out. The only way I
 			// found to do so, was to trigger an error, and then check for that in the jobs.Runner.
@@ -82,14 +87,18 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 				if incomingEntityCount > 0 {
 					// apply transform if it exists
 					if pipeline.transform != nil {
-						entities, err = pipeline.transform.transformEntities(runner, entities)
+						transformTs := time.Now()
+						entities, err = pipeline.transform.transformEntities(runner, entities, job.id)
+						_ = runner.statsdClient.Timing("pipeline.transform.batch", time.Since(transformTs), tags, 1)
 						if err != nil {
 							return err
 						}
 					}
 
 					// write to sink
+					sinkTs := time.Now()
 					err = pipeline.sink.processEntities(runner, entities)
+					_ = runner.statsdClient.Timing("pipeline.sink.batch", time.Since(sinkTs), tags, 1)
 					if err != nil {
 						return err
 					}
@@ -147,9 +156,13 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) error {
 
 	keepReading := true
 
+	tags := []string{"application:datahub", "job:" + job.id }
 	for keepReading {
 
+		readTs := time.Now()
 		err := pipeline.source.readEntities(runner, syncJobState.ContinuationToken, pipeline.batchSize, func(entities []*server.Entity, continuationToken string) error {
+			_ = runner.statsdClient.Timing("pipeline.source.batch", time.Since(readTs), tags, 1)
+			readTs = time.Now()
 			select {
 			// if the cancellable context is cancelled, ctx.Done will trigger, and it will break out. The only way I
 			// found to do so, was to trigger an error, and then check for that in the jobs.Runner.
@@ -163,14 +176,18 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) error {
 				if incomingEntityCount > 0 {
 					// apply transform if it exists
 					if pipeline.transform != nil {
-						entities, err = pipeline.transform.transformEntities(runner, entities)
+						transformTs := time.Now()
+						entities, err = pipeline.transform.transformEntities(runner, entities, job.id)
+						_ = runner.statsdClient.Timing("pipeline.transform.batch", time.Since(transformTs), tags, 1)
 						if err != nil {
 							return err
 						}
 					}
 
 					// write to sink
+					sinkTs := time.Now()
 					err = pipeline.sink.processEntities(runner, entities)
+					_ = runner.statsdClient.Timing("pipeline.sink.batch", time.Since(sinkTs), tags, 1)
 					if err != nil {
 						return err
 					}

--- a/internal/jobs/transform_test.go
+++ b/internal/jobs/transform_test.go
@@ -32,7 +32,7 @@ func TestTransform(t *testing.T) {
 			entities := make([]*server.Entity, 0)
 			entities = append(entities, server.NewEntity("1", 1))
 
-			_, err = transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities)
+			_, err = transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
 			g.Assert(err).IsNotNil("tranform should fail")
 			g.Assert(strings.Split(err.Error(), " (")[0]).
 				Eql("ReferenceError: prefix is not defined at transform_entities")


### PR DESCRIPTION
This change introduces 3 more new timing metrics: 

`pipeline.source.batch`
`pipeline.transform.batch`
`pipeline.sink.batch`

These metrics measure the time it takes to process a complete batch in source, transform and sink.

---

This PR also adds a `Timing` transform function, which is available to javascript transforms. It is used like this in javascript:

```
Timing('firstQuery')
var queryResult = Query([id], PrefixField(personPrefix, "rel"), false)
Timing('firstQuery', true)
```

This will produce a new metric: `transform.timing.firstQuery`.