### PR TITLE
Gracefully stop garbage collector on shutdown

### DIFF
--- a/internal/server/garbagecollector_test.go
+++ b/internal/server/garbagecollector_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestGC(t *testing.T) {
@@ -21,6 +22,7 @@ func TestGC(t *testing.T) {
 		var storeLocation string
 		var gc *GarbageCollector
 
+		var lc *fxtest.Lifecycle
 		g.BeforeEach(func() {
 			testCnt += 1
 			storeLocation = fmt.Sprintf("./test_gc_%v", testCnt)
@@ -34,7 +36,7 @@ func TestGC(t *testing.T) {
 			devNull, _ := os.Open("/dev/null")
 			oldErr := os.Stderr
 			os.Stderr = devNull
-			lc := fxtest.NewLifecycle(t)
+			lc = fxtest.NewLifecycle(t)
 			store = NewStore(lc, e, &statsd.NoOpClient{})
 			dsm = NewDsManager(lc, e, store, NoOpBus())
 			gc = NewGarbageCollector(lc, store, e)
@@ -177,6 +179,17 @@ func TestGC(t *testing.T) {
 			g.Assert(len(result)).Eql(1)
 			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
 			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-1")
+		})
+
+		g.It("Should stop on shutdown", func() {
+			g.Timeout(1 * time.Hour)
+			time.AfterFunc(1*time.Nanosecond, func() {
+				lc.Stop(context.Background())
+			})
+			time.Sleep(10 * time.Nanosecond)
+
+			err := gc.Cleandeleted()
+			g.Assert(err.Error()).Eql("gc cancelled")
 		})
 	})
 }


### PR DESCRIPTION
Resolves Issue #28 

In this change, we signal the background go-routine that runs garbage collection to stop when the service is shut down. This is mostly to avoid big misleading stacktraces on shutdown.