### PR TITLE
improve robustness of gc test

### DIFF
--- a/internal/server/garbagecollector_test.go
+++ b/internal/server/garbagecollector_test.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestGC(t *testing.T) {
@@ -195,14 +194,10 @@ func TestGC(t *testing.T) {
 			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-1")
 		})
 
-		g.It("Should stop on shutdown", func() {
-			g.Timeout(1 * time.Hour)
-			time.AfterFunc(1*time.Nanosecond, func() {
-				lc.Stop(context.Background())
-			})
-			time.Sleep(10 * time.Nanosecond)
-
+		g.It("Should stop when asked to", func() {
+			go func() {gc.quit <- true}()
 			err := gc.Cleandeleted()
+			g.Assert(err).IsNotZero()
 			g.Assert(err.Error()).Eql("gc cancelled")
 		})
 	})


### PR DESCRIPTION
The "stop gc" test was a little sensitive to timing problems. When running the test with a single cpu ( `go test -v ./... -cpu 1 -count 1 -run TestGC` ) it quite consistently would panic with nil reference errors.

With this change, we no longer shut down the complete datahub as part of the test-case. instead we only send a stop signal to the garbagecollector (same happens in fx OnStop lifecycle handler). This reduces the risk of timing problems.