### PR TITLE
Feat/dependency tracking

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -398,11 +398,46 @@ The dataset source reads entities from a dataset in the data hub.
 
 ```json
 {
-    ...,
     "source": {
         "Type": "DatasetSource",
         "Name": "name of the dataset to read from",
         "BatchSize" : "optional int value of how many to read at a time"
+    }
+}
+```
+
+#### Multi Source
+
+This source has one main dataset which works like a `DatasetSource`. In addition, a list of `dependency` datasets can be configured.
+
+A `dependency` is typically a dataset which is used in the job's transform queries to construct composite entities with attributes from both
+main dataset and dependency dataset(s).
+
+By declaring a dependency dataset, and defining how to link entities in the dependency dataset to entities in the main dataset via a sequence of `joins`,
+MultiSource can in incremental jobs emit entities that have not been changed themselves, but which need to be reprocessed due to changed dependencies.
+
+```json
+{
+    "source": {
+        "Type": "MultiSource",
+        "Name": "name of the main dataset",
+        "Dependencies": [
+            {
+                "dataset": "name of a dependency dataset",
+                "joins": [
+                    {
+                        "dataset": "name of a linking dataset",
+                        "predicate": "ref-name containing the link URI",
+                        "inverse": true
+                    },
+                    {
+                        "dataset": "name of main dataset. the last join in a dependency should link back to the main dataset",
+                        "predicate": "ref-name containing  link to main entity",
+                        "inverse": false
+                    }
+                ]
+            }
+        ]
     }
 }
 ```
@@ -1107,7 +1142,7 @@ function transform_entities(entities) {
 
 #### NewTransaction
 
-`NewTransaction()` is used to create a new transaction object. A transaction can then be executed using the ExecuteTransaction function. Note that this function simply returns an empty transaction data structure. It does not open a transaction. 
+`NewTransaction()` is used to create a new transaction object. A transaction can then be executed using the ExecuteTransaction function. Note that this function simply returns an empty transaction data structure. It does not open a transaction.
 
 #### ExecuteTransaction
 

--- a/api/datahub.oas3.yml
+++ b/api/datahub.oas3.yml
@@ -584,7 +584,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Content'            
+              $ref: '#/components/schemas/Content'
       responses:
         '201':
           description: Created
@@ -647,7 +647,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Content'            
+              $ref: '#/components/schemas/Content'
       responses:
         '201':
           description: Created
@@ -753,25 +753,30 @@ components:
           type: string
           description: Job id
           example: sync-samplesource-to-datasetsink
-        incrementalSchedule:
-          type: string
-          description: Cron description of when to run the job incrementally
-          example: '@every 2s'
-        fullSyncSchedule:
-          type: string
-          description: Cron description of when to run a full sync
-          example: '@every 2h30m'
-        runOnce:
-          type: boolean
-          description: If true, the job is a one time job, if not, it will be repeated
-          example: false
+        triggers:
+          type: array
+          items:
+            properties:
+              triggerType:
+                type: string
+                description: can be either 'cron' or 'onchange'
+              jobType:
+                type: string
+                description: either 'fullsync' or 'incremental'. fullsync jobs always process the whole dataset from start. incremental jobs keep track of how far they go and only process new changes in each run.
+              schedule:
+                type: string
+                description: a cron expression. used with triggerType=cron to specify when the job is run periodically.
+                example: 0 1 * * *
+              monitoredDataset:
+                type: string
+                description: used with triggerType=onchange, specify the name of an existing dataset. every change to that dataset will trigger this job.
         paused:
           type: boolean
           description: If true, the job is currently paused. If a job is added with this to true, it will not start.
           example: false
         source:
           type: object
-          description: An object describing the Source of the Job          
+          description: An object describing the Source of the Job
         sink:
           type: object
           description: An object describing the Sink of the Job

--- a/internal/jobs/pipeline.go
+++ b/internal/jobs/pipeline.go
@@ -62,15 +62,13 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 	keepReading := true
 
 	//dont call source.startFullSync, just sink.startFullSync. to make sure we run on changes.
-	//exception is when the sink is http.
-	if pipeline.sink.GetConfig()["Type"] == "HttpDatasetSink" {
+	//exception is when the sink is http(we want to process entities instead of changes)
+	//or source is multisource (we need to grab watermarks at beginning of fullsync)
+	if pipeline.sink.GetConfig()["Type"] == "HttpDatasetSink" ||
+	 pipeline.source.GetConfig()["Type"] == "MultiSource" {
 		if pipeline.source.GetConfig()["Type"] == "MultiSource" {
-			return errors.New("MultiSource can only produce changes and must therefore not be used with HttpDatasetSink")
+			//return errors.New("MultiSource can only produce changes and must therefore not be used with HttpDatasetSink")
 		}
-		pipeline.source.StartFullSync()
-	}
-	//start fullsync for multisource, to avoid dependency processing until fullsync is done
-	if pipeline.source.GetConfig()["Type"] == "MultiSource" {
 		pipeline.source.StartFullSync()
 	}
 	err = pipeline.sink.startFullSync(runner)
@@ -156,7 +154,10 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 
 	//Do not store syncState when the target is an http sink.
 	//Since we use entities for httpsinks, the continuation tokens are base64 strings and not compatible with incremental tokens
-	if pipeline.sink.GetConfig()["Type"] != "HttpDatasetSink" {
+    //
+	//Exception is when used with MultiSource... MultiSource only operates on changes. also in fullsync mode.
+	//   Difference there between fullsync and incremental is whether dependencies are processed
+	if pipeline.sink.GetConfig()["Type"] != "HttpDatasetSink" || pipeline.source.GetConfig()["Type"] == "MultiSource" {
 		err = runner.store.StoreObject(server.JOB_DATA_INDEX, job.id, syncJobState)
 		if err != nil {
 			return err

--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"os"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/mimiro-io/datahub/internal/jobs/source"
 
 	"github.com/franela/goblin"
 

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -19,18 +19,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mimiro-io/datahub/internal/jobs/source"
-	"github.com/mimiro-io/datahub/internal/security"
 	"strings"
 	"time"
 
+	"github.com/mimiro-io/datahub/internal/jobs/source"
+	"github.com/mimiro-io/datahub/internal/security"
+
 	"github.com/bamzi/jobrunner"
-	"github.com/mimiro-io/datahub/internal/conf"
-	"github.com/mimiro-io/datahub/internal/server"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 // The Scheduler deals with reading and writing jobs and making sure they get added to the
@@ -532,7 +534,13 @@ func (s *Scheduler) parseSource(jobConfig *JobConfiguration) (source.Source, err
 				return src, nil
 			} else if sourceTypeName == "MultiSource" {
 				src := &source.MultiSource{}
-
+				src.Store = s.Store
+				src.DatasetManager = s.DatasetManager
+				src.DatasetName = (sourceConfig["Name"]).(string)
+				err := src.ParseDependencies(sourceConfig["Dependencies"])
+				if err != nil {
+					return nil, err
+				}
 				return src, nil
 			} else if sourceTypeName == "SampleSource" {
 				src := &source.SampleSource{}

--- a/internal/jobs/source/dataset_source.go
+++ b/internal/jobs/source/dataset_source.go
@@ -67,11 +67,3 @@ func (datasetSource *DatasetSource) GetConfig() map[string]interface{} {
 	config["Name"] = datasetSource.DatasetName
 	return config
 }
-
-func (datasetSource *DatasetSource) DecodeToken(token string) DatasetContinuation {
-	return &StringDatasetContinuation{token}
-}
-
-func (datasetSource *DatasetSource) EncodeToken(token DatasetContinuation) string {
-	return token.GetToken()
-}

--- a/internal/jobs/source/dataset_source.go
+++ b/internal/jobs/source/dataset_source.go
@@ -1,7 +1,6 @@
 package source
 
 import (
-	"encoding/json"
 	"errors"
 	"strconv"
 
@@ -70,12 +69,9 @@ func (datasetSource *DatasetSource) GetConfig() map[string]interface{} {
 }
 
 func (datasetSource *DatasetSource) DecodeToken(token string) DatasetContinuation {
-	result := &StringDatasetContinuation{}
-	_ = json.Unmarshal([]byte(token), result)
-	return result
+	return &StringDatasetContinuation{token}
 }
 
 func (datasetSource *DatasetSource) EncodeToken(token DatasetContinuation) string {
-	result, _ := json.Marshal(token)
-	return string(result)
+	return token.GetToken()
 }

--- a/internal/jobs/source/http_dataset_source.go
+++ b/internal/jobs/source/http_dataset_source.go
@@ -25,13 +25,6 @@ type HttpDatasetSource struct {
 	Store          *server.Store
 	Logger         *zap.SugaredLogger
 }
-func (httpDatasetSource *HttpDatasetSource) DecodeToken(token string) DatasetContinuation {
-	return &StringDatasetContinuation{token}
-}
-
-func (httpDatasetSource *HttpDatasetSource) EncodeToken(token DatasetContinuation) string {
-	return token.GetToken()
-}
 
 func (httpDatasetSource *HttpDatasetSource) StartFullSync() {
 	// empty for now (this makes sonar not complain)

--- a/internal/jobs/source/http_dataset_source.go
+++ b/internal/jobs/source/http_dataset_source.go
@@ -2,16 +2,19 @@ package source
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mimiro-io/datahub/internal/security"
-	"github.com/mimiro-io/datahub/internal/server"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/security"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 type HttpDatasetSource struct {
@@ -24,6 +27,17 @@ type HttpDatasetSource struct {
 	Logger         *zap.SugaredLogger
 }
 
+func (httpDatasetSource *HttpDatasetSource) DecodeToken(token string) DatasetContinuation {
+	result := &StringDatasetContinuation{}
+	_ = json.Unmarshal([]byte(token), result)
+	return result
+}
+
+func (httpDatasetSource *HttpDatasetSource) EncodeToken(token DatasetContinuation) string {
+	result, _ := json.Marshal(token)
+	return string(result)
+}
+
 func (httpDatasetSource *HttpDatasetSource) StartFullSync() {
 	// empty for now (this makes sonar not complain)
 }
@@ -32,7 +46,8 @@ func (httpDatasetSource *HttpDatasetSource) EndFullSync() {
 	// empty for now (this makes sonar not complain)
 }
 
-func (httpDatasetSource *HttpDatasetSource) ReadEntities(since string, batchSize int, processEntities func([]*server.Entity, string) error) error {
+func (httpDatasetSource *HttpDatasetSource) ReadEntities(since DatasetContinuation, batchSize int,
+	processEntities func([]*server.Entity, DatasetContinuation) error) error {
 	// open connection
 	//timeout := 60 * time.Minute
 	//client := httpclient.NewClient(httpclient.WithHTTPTimeout(timeout))
@@ -42,9 +57,9 @@ func (httpDatasetSource *HttpDatasetSource) ReadEntities(since string, batchSize
 	if err != nil {
 		return err
 	}
-	if since != "" {
+	if since.GetToken() != "" {
 		q, _ := url.ParseQuery(endpoint.RawQuery)
-		q.Add("since", since)
+		q.Add("since", since.GetToken())
 		endpoint.RawQuery = q.Encode()
 	}
 
@@ -95,11 +110,11 @@ func (httpDatasetSource *HttpDatasetSource) ReadEntities(since string, batchSize
 
 	read := 0
 	entities := make([]*server.Entity, 0)
-	continuationToken := ""
+	continuationToken := &StringDatasetContinuation{}
 	esp := server.NewEntityStreamParser(httpDatasetSource.Store)
 	err = esp.ParseStream(res.Body, func(entity *server.Entity) error {
 		if entity.ID == "@continuation" {
-			continuationToken = entity.GetStringProperty("token")
+			continuationToken.token = entity.GetStringProperty("token")
 		} else {
 			entities = append(entities, entity)
 			read++

--- a/internal/jobs/source/http_dataset_source.go
+++ b/internal/jobs/source/http_dataset_source.go
@@ -102,7 +102,7 @@ func (httpDatasetSource *HttpDatasetSource) ReadEntities(since DatasetContinuati
 	esp := server.NewEntityStreamParser(httpDatasetSource.Store)
 	err = esp.ParseStream(res.Body, func(entity *server.Entity) error {
 		if entity.ID == "@continuation" {
-			continuationToken.token = entity.GetStringProperty("token")
+			continuationToken.Token = entity.GetStringProperty("token")
 		} else {
 			entities = append(entities, entity)
 			read++

--- a/internal/jobs/source/http_dataset_source.go
+++ b/internal/jobs/source/http_dataset_source.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -26,16 +25,12 @@ type HttpDatasetSource struct {
 	Store          *server.Store
 	Logger         *zap.SugaredLogger
 }
-
 func (httpDatasetSource *HttpDatasetSource) DecodeToken(token string) DatasetContinuation {
-	result := &StringDatasetContinuation{}
-	_ = json.Unmarshal([]byte(token), result)
-	return result
+	return &StringDatasetContinuation{token}
 }
 
 func (httpDatasetSource *HttpDatasetSource) EncodeToken(token DatasetContinuation) string {
-	result, _ := json.Marshal(token)
-	return string(result)
+	return token.GetToken()
 }
 
 func (httpDatasetSource *HttpDatasetSource) StartFullSync() {

--- a/internal/jobs/source/multi_source.go
+++ b/internal/jobs/source/multi_source.go
@@ -145,8 +145,7 @@ func (multiSource *MultiSource) processDependency(dep dependency, d *MultiDatase
 	join := dep.Joins[0]
 
 	// TODO: create GetManyRelated variant that takes internal ids as "startUris" ?
-	relatedEntities, err := multiSource.Store.GetManyRelatedEntities(
-		uris, join.Predicate, join.Inverse, []string{join.Dataset})
+	relatedEntities, err := multiSource.Store.GetManyRelatedEntities(uris, join.Predicate, join.Inverse, nil)
 	if err != nil {
 		return fmt.Errorf("GetManyRelatedEntities failed for join %+v, %w", join, err)
 	}

--- a/internal/jobs/source/multi_source.go
+++ b/internal/jobs/source/multi_source.go
@@ -1,41 +1,173 @@
 package source
 
 import (
+	"errors"
+	"fmt"
+	"strconv"
+
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
 type join struct {
-	dataset  string
-	property string
-	inverse  bool
+	Dataset   string
+	Predicate string
+	Inverse   bool
 }
 
 type dependency struct {
-	dataset string // name of the dependent dataset
-	joins   []join
+	Dataset string // name of the dependent dataset
+	Joins   []join
 }
 
 type MultiSource struct {
-	mainDataset  string       // the main dataset that is read on initial sync
-	dependencies []dependency // the dependency queries
+	DatasetName    string
+	Dependencies   []dependency // the dependency queries
+	Store          *server.Store
+	DatasetManager *server.DsManager
+	isFullSync     bool
 }
 
-func (multiSource *MultiSource) GetConfig() map[string]interface{} {
+func (multiSource *MultiSource) DecodeToken(token string) DatasetContinuation {
 	panic("implement me")
 }
 
-type multiSourceContinuationToken struct {
-	dependenciesSince []string //
+func (multiSource *MultiSource) EncodeToken(token DatasetContinuation) string {
+	panic("implement me")
+}
+
+type MultiDatasetContinuation struct {
+	mainToken        string
+	dependencyTokens map[string]*StringDatasetContinuation
+	ActiveDS         string
+}
+
+func (c *MultiDatasetContinuation) GetToken() string {
+	if c.ActiveDS != "" {
+		return c.dependencyTokens[c.ActiveDS].GetToken()
+	}
+	return c.mainToken
+}
+func (c *MultiDatasetContinuation) AsIncrToken() uint64 {
+	if c.ActiveDS != "" {
+		return c.dependencyTokens[c.ActiveDS].AsIncrToken()
+	}
+	i, err := strconv.Atoi(c.mainToken)
+	if err != nil {
+		return 0
+	}
+	return uint64(i)
+}
+
+func (multiSource *MultiSource) GetConfig() map[string]interface{} {
+	config := make(map[string]interface{})
+	config["Type"] = "MultiSource"
+	config["Name"] = multiSource.DatasetName
+	return config
 }
 
 func (multiSource *MultiSource) StartFullSync() {
+	multiSource.isFullSync = true
 }
 
 func (multiSource *MultiSource) EndFullSync() {
+	multiSource.isFullSync = false
 }
 
-func (multiSource *MultiSource) ReadEntities(since string, batchSize int, processEntities func([]*server.Entity, string) error) error {
-	//
+func (multiSource *MultiSource) ReadEntities(since DatasetContinuation, batchSize int, processEntities func([]*server.Entity, DatasetContinuation) error) error {
+	exists := multiSource.DatasetManager.IsDataset(multiSource.DatasetName)
+	if !exists {
+		return errors.New("dataset is missing")
+	}
+	dataset := multiSource.DatasetManager.GetDataset(multiSource.DatasetName)
 
+	d := since.(*MultiDatasetContinuation)
+	if !multiSource.isFullSync {
+		for _, dep := range multiSource.Dependencies {
+			exists := multiSource.DatasetManager.IsDataset(dep.Dataset)
+			if !exists {
+				return errors.New("dependency dataset is missing: "+dep.Dataset)
+			}
+			depDataset := multiSource.DatasetManager.GetDataset(dep.Dataset)
+			d.ActiveDS = dep.Dataset
+			depSince := d.dependencyTokens[dep.Dataset]
+			if depSince == nil {
+				depSince = &StringDatasetContinuation{}
+			}
+			uris := make([]string, 0)
+			continuation, err := depDataset.ProcessChanges(depSince.AsIncrToken(), batchSize, func(entity *server.Entity) {
+				uris = append(uris, entity.ID)
+			})
+			//TODO: create GetManyRelated variant that takes internal ids as "starturis" ?
+			join := dep.Joins[0]
+			relatedEntities, err := multiSource.Store.GetManyRelatedEntities(uris, join.Predicate, join.Inverse, []string{join.Dataset, dep.Dataset})
+			if err != nil {
+				return err
+			}
+			entities := make([]*server.Entity, 0)
+			for _,r := range relatedEntities {
+				entities = append(entities, r[2].(*server.Entity))
+			}
+			if d.dependencyTokens == nil {
+				d.dependencyTokens = make(map[string]*StringDatasetContinuation)
+			}
+			d.dependencyTokens[dep.Dataset] = &StringDatasetContinuation{token: strconv.Itoa(int(continuation))}
+			err = processEntities(entities, since)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	d.ActiveDS = ""
+	err := multiSource.incrementalRead(since, batchSize, processEntities, dataset)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (multiSource *MultiSource) incrementalRead(since DatasetContinuation, batchSize int,
+	processEntities func([]*server.Entity, DatasetContinuation) error, dataset *server.Dataset) error {
+	entities := make([]*server.Entity, 0)
+	continuation, err := dataset.ProcessChanges(since.AsIncrToken(), batchSize, func(entity *server.Entity) {
+		entities = append(entities, entity)
+	})
+	if err != nil {
+		return err
+	}
+
+	d := since.(*MultiDatasetContinuation)
+	d.mainToken = strconv.Itoa(int(continuation))
+	err = processEntities(entities, d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ParseDependencies populates MultiSource dependencies based on given json config
+func (multiSource *MultiSource) ParseDependencies(dependenciesConfig interface{}) error {
+	if depsList, ok := dependenciesConfig.([]interface{}); ok {
+		for _, dep := range depsList {
+			if m, ok := dep.(map[string]interface{}); ok {
+				newDep := dependency{}
+				newDep.Dataset = m["dataset"].(string)
+
+				for _, j := range m["joins"].([]interface{}) {
+					newJoin := join{}
+					m := j.(map[string]interface{})
+					newJoin.Dataset = m["dataset"].(string)
+					newJoin.Predicate = m["predicate"].(string)
+					newJoin.Inverse = m["inverse"].(bool)
+					newDep.Joins = append(newDep.Joins, newJoin)
+				}
+				multiSource.Dependencies = append(multiSource.Dependencies, newDep)
+			} else {
+				return errors.New(fmt.Sprintf("dependency %+v must be json object structure, but is %t ", dep, dep))
+			}
+		}
+	} else {
+		return errors.New("dependenciesConfig must be array array")
+	}
 	return nil
 }

--- a/internal/jobs/source/multi_source.go
+++ b/internal/jobs/source/multi_source.go
@@ -25,6 +25,7 @@ type MultiSource struct {
 	Store          *server.Store
 	DatasetManager *server.DsManager
 	isFullSync     bool
+	waterMarks     map[string]uint64
 }
 
 func (multiSource *MultiSource) DecodeToken(token string) DatasetContinuation {
@@ -45,16 +46,20 @@ func (c *MultiDatasetContinuation) GetToken() string {
 	if c.ActiveDS != "" {
 		return c.dependencyTokens[c.ActiveDS].GetToken()
 	}
+
 	return c.mainToken
 }
+
 func (c *MultiDatasetContinuation) AsIncrToken() uint64 {
 	if c.ActiveDS != "" {
 		return c.dependencyTokens[c.ActiveDS].AsIncrToken()
 	}
+
 	i, err := strconv.Atoi(c.mainToken)
 	if err != nil {
 		return 0
 	}
+
 	return uint64(i)
 }
 
@@ -62,68 +67,116 @@ func (multiSource *MultiSource) GetConfig() map[string]interface{} {
 	config := make(map[string]interface{})
 	config["Type"] = "MultiSource"
 	config["Name"] = multiSource.DatasetName
+
 	return config
 }
 
 func (multiSource *MultiSource) StartFullSync() {
 	multiSource.isFullSync = true
+	_ = multiSource.grabWatermarks()
 }
 
 func (multiSource *MultiSource) EndFullSync() {
 	multiSource.isFullSync = false
 }
 
-func (multiSource *MultiSource) ReadEntities(since DatasetContinuation, batchSize int, processEntities func([]*server.Entity, DatasetContinuation) error) error {
-	exists := multiSource.DatasetManager.IsDataset(multiSource.DatasetName)
-	if !exists {
-		return errors.New("dataset is missing")
+var ErrDatasetMissing = fmt.Errorf("dataset is missing")
+var ErrTokenType = fmt.Errorf("continuation token is of wrong type")
+
+func (multiSource *MultiSource) ReadEntities(since DatasetContinuation, batchSize int,
+	processEntities func([]*server.Entity, DatasetContinuation) error) error {
+
+	if exists := multiSource.DatasetManager.IsDataset(multiSource.DatasetName); !exists {
+		return fmt.Errorf("dataset %v is missing, %w", multiSource.DatasetName, ErrDatasetMissing)
 	}
+
 	dataset := multiSource.DatasetManager.GetDataset(multiSource.DatasetName)
 
-	d := since.(*MultiDatasetContinuation)
+	d, ok := since.(*MultiDatasetContinuation)
+	if !ok {
+		return fmt.Errorf("continuation in multisource is not a *MulitDatasetContinuation, but %t, %w", since, ErrTokenType)
+	}
+
 	if !multiSource.isFullSync {
 		for _, dep := range multiSource.Dependencies {
-			exists := multiSource.DatasetManager.IsDataset(dep.Dataset)
-			if !exists {
-				return errors.New("dependency dataset is missing: "+dep.Dataset)
-			}
-			depDataset := multiSource.DatasetManager.GetDataset(dep.Dataset)
-			d.ActiveDS = dep.Dataset
-			depSince := d.dependencyTokens[dep.Dataset]
-			if depSince == nil {
-				depSince = &StringDatasetContinuation{}
-			}
-			uris := make([]string, 0)
-			continuation, err := depDataset.ProcessChanges(depSince.AsIncrToken(), batchSize, func(entity *server.Entity) {
-				uris = append(uris, entity.ID)
-			})
-			//TODO: create GetManyRelated variant that takes internal ids as "starturis" ?
-			join := dep.Joins[0]
-			relatedEntities, err := multiSource.Store.GetManyRelatedEntities(uris, join.Predicate, join.Inverse, []string{join.Dataset, dep.Dataset})
-			if err != nil {
-				return err
-			}
-			entities := make([]*server.Entity, 0)
-			for _,r := range relatedEntities {
-				entities = append(entities, r[2].(*server.Entity))
-			}
-			if d.dependencyTokens == nil {
-				d.dependencyTokens = make(map[string]*StringDatasetContinuation)
-			}
-			d.dependencyTokens[dep.Dataset] = &StringDatasetContinuation{token: strconv.Itoa(int(continuation))}
-			err = processEntities(entities, since)
+			err := multiSource.processDependency(dep, d, batchSize, processEntities)
 			if err != nil {
 				return err
 			}
 		}
+	} else {
+		//set watermarks
+		for depName, waterMark := range multiSource.waterMarks {
+			if d.dependencyTokens == nil {
+				d.dependencyTokens = make(map[string]*StringDatasetContinuation)
+			}
+
+			d.dependencyTokens[depName] = &StringDatasetContinuation{token: strconv.Itoa(int(waterMark))}
+		}
 	}
+
 	d.ActiveDS = ""
-	err := multiSource.incrementalRead(since, batchSize, processEntities, dataset)
+
+	return multiSource.incrementalRead(since, batchSize, processEntities, dataset)
+}
+
+func (multiSource *MultiSource) processDependency(dep dependency, d *MultiDatasetContinuation, batchSize int,
+	processEntities func([]*server.Entity, DatasetContinuation) error) error {
+	depDataset, err2 := multiSource.getDatasetFor(dep)
+	if err2 != nil {
+		return err2
+	}
+	d.ActiveDS = dep.Dataset
+
+	depSince := d.dependencyTokens[dep.Dataset]
+	if depSince == nil {
+		depSince = &StringDatasetContinuation{}
+	}
+
+	uris := make([]string, 0)
+	continuation, err := depDataset.ProcessChanges(depSince.AsIncrToken(), batchSize, func(entity *server.Entity) {
+		uris = append(uris, entity.ID)
+	})
+
+	if err != nil {
+		return fmt.Errorf("detecting changes in dependency dataset %+v failed, %w", dep, err)
+	}
+
+	join := dep.Joins[0]
+
+	// TODO: create GetManyRelated variant that takes internal ids as "startUris" ?
+	relatedEntities, err := multiSource.Store.GetManyRelatedEntities(
+		uris, join.Predicate, join.Inverse, []string{join.Dataset})
+	if err != nil {
+		return fmt.Errorf("GetManyRelatedEntities failed for join %+v, %w", join, err)
+	}
+
+	entities := make([]*server.Entity, 0)
+	for _, r := range relatedEntities {
+		entities = append(entities, r[2].(*server.Entity))
+	}
+
+	if d.dependencyTokens == nil {
+		d.dependencyTokens = make(map[string]*StringDatasetContinuation)
+	}
+
+	d.dependencyTokens[dep.Dataset] = &StringDatasetContinuation{token: strconv.Itoa(int(continuation))}
+
+	err = processEntities(entities, d)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (multiSource *MultiSource) getDatasetFor(dep dependency) (*server.Dataset, error) {
+	if exists := multiSource.DatasetManager.IsDataset(dep.Dataset); !exists {
+		return nil, fmt.Errorf("dependency dataset is missing: %v, %w", dep.Dataset, ErrDatasetMissing)
+	}
+
+	depDataset := multiSource.DatasetManager.GetDataset(dep.Dataset)
+	return depDataset, nil
 }
 
 func (multiSource *MultiSource) incrementalRead(since DatasetContinuation, batchSize int,
@@ -163,11 +216,31 @@ func (multiSource *MultiSource) ParseDependencies(dependenciesConfig interface{}
 				}
 				multiSource.Dependencies = append(multiSource.Dependencies, newDep)
 			} else {
-				return errors.New(fmt.Sprintf("dependency %+v must be json object structure, but is %t ", dep, dep))
+				return fmt.Errorf("dependency %+v must be json object structure, but is %t ", dep, dep)
 			}
 		}
 	} else {
 		return errors.New("dependenciesConfig must be array array")
 	}
+
+	return nil
+}
+
+func (multiSource *MultiSource) grabWatermarks() error {
+	multiSource.waterMarks = make(map[string]uint64)
+	for _, dep := range multiSource.Dependencies {
+		dataset, err := multiSource.getDatasetFor(dep)
+		if err != nil {
+			return err
+		}
+
+		waterMark, err := dataset.GetChangesWatermark()
+		if err != nil {
+			return err
+		}
+
+		multiSource.waterMarks[dep.Dataset] = waterMark
+	}
+
 	return nil
 }

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -1,0 +1,259 @@
+package source_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/jobs/source"
+	"github.com/mimiro-io/datahub/internal/server"
+)
+
+
+func TestMultiSource(t *testing.T) {
+	g := goblin.Goblin(t)
+	g.Describe("dependency tracking", func() {
+		testCnt := 0
+		var dsm *server.DsManager
+		var store *server.Store
+		var storeLocation string
+		g.BeforeEach(func() {
+			// temp redirect of stdout and stderr to swallow some annoying init messages in fx
+			devNull, _ := os.Open("/dev/null")
+			oldErr := os.Stderr
+			oldStd := os.Stdout
+			os.Stderr = devNull
+			os.Stdout = devNull
+
+			testCnt += 1
+			storeLocation = fmt.Sprintf("./test_multi_source_%v", testCnt)
+			err := os.RemoveAll(storeLocation)
+			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
+
+			e := &conf.Env{
+				Logger:        zap.NewNop().Sugar(),
+				StoreLocation: storeLocation,
+			}
+			lc := fxtest.NewLifecycle(t)
+
+			store = server.NewStore(lc, e, &statsd.NoOpClient{})
+			dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
+
+			err = lc.Start(context.Background())
+			if err != nil {
+				fmt.Println(err.Error())
+				t.FailNow()
+			}
+
+			// undo redirect of stdout and stderr after successful init of fx
+			os.Stderr = oldErr
+			os.Stdout = oldStd
+
+		})
+		g.AfterEach(func() {
+			_ = store.Close()
+			_ = os.RemoveAll(storeLocation)
+		})
+
+		g.It("should emit changes in main dataset", func() {
+			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
+
+			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+			var tokens []source.DatasetContinuation
+			var recordedEntities []server.Entity
+			token := &source.MultiDatasetContinuation{}
+			testSource.StartFullSync()
+			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			testSource.EndFullSync()
+
+			//now, modify alice and verify that we get alice emitted in next read
+			err = people.StoreEntities([]*server.Entity{
+				server.NewEntityFromMap(map[string]interface{}{
+					"id":    peoplePrefix + ":Alice",
+					"props": map[string]interface{}{"name": "Alice-changed"},
+					"refs":  map[string]interface{}{},
+				}),
+			})
+			since := tokens[len(tokens)-1]
+			tokens = []source.DatasetContinuation{}
+			recordedEntities = []server.Entity{}
+			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			g.Assert(len(recordedEntities)).Eql(1)
+			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
+		})
+
+		g.It("should emit changes in direct dependencies", func() {
+			g.Timeout(1 * time.Hour)
+			addresses, addressPrefix := createTestDataset("address", []string{"Mainstreet", "Sidealley"}, nil, dsm, g, store)
+			peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
+			createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
+				"Bob":   {peoplePrefix+":address": addressPrefix + ":Mainstreet"},
+				"Alice": {peoplePrefix+":address": addressPrefix + ":Sidealley"},
+			}, dsm, g, store)
+
+			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+							"dataset": "address",
+							"joins": [ { "dataset": "people", "predicate": "http://people/address", "inverse": true } ] } ] }`
+
+			srcConfig := map[string]interface{}{}
+			err := json.Unmarshal([]byte(srcJSON), &srcConfig)
+			g.Assert(err).IsNil()
+			err = testSource.ParseDependencies(srcConfig["Dependencies"])
+			g.Assert(err).IsNil()
+
+			var tokens []source.DatasetContinuation
+			var recordedEntities []server.Entity
+			token := &source.MultiDatasetContinuation{}
+
+			testSource.StartFullSync()
+			err = testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			testSource.EndFullSync()
+
+			//now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
+			err = addresses.StoreEntities([]*server.Entity{
+				server.NewEntityFromMap(map[string]interface{}{
+					"id":    addressPrefix + ":Mainstreet",
+					"props": map[string]interface{}{"name": "Mainstreet-changed"},
+					"refs":  map[string]interface{}{},
+				}),
+			})
+			since := tokens[len(tokens)-1]
+			tokens = []source.DatasetContinuation{}
+			recordedEntities = []server.Entity{}
+			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			t.Log(tokens)
+			t.Log(recordedEntities)
+			g.Assert(err).IsNil()
+			g.Assert(len(recordedEntities)).Eql(1)
+			//Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
+		})
+	})
+
+	g.Describe("parseDependencies", func() {
+		g.It("should translate json to config", func() {
+			s := source.MultiSource{}
+			srcJSON := `{
+				"Type" : "MultiSource",
+				"Name" : "person",
+				"Dependencies": [
+					{
+						"dataset": "product",
+						"joins": [
+							{
+								"dataset": "order",
+								"predicate": "product-ordered",
+								"inverse": true
+							},
+							{
+								"dataset": "person",
+								"predicate": "ordering-customer",
+								"inverse": false
+							}
+						]
+					},
+					{
+						"dataset": "order",
+						"joins": [
+							{
+								"dataset": "person",
+								"predicate": "ordering-customer",
+								"inverse": false
+							}
+						]
+					}
+				]
+			}`
+
+			srcConfig := map[string]interface{}{}
+			err := json.Unmarshal([]byte(srcJSON), &srcConfig)
+			g.Assert(err).IsNil()
+			err = s.ParseDependencies(srcConfig["Dependencies"])
+			g.Assert(err).IsNil()
+
+			g.Assert(s.Dependencies).IsNotZero()
+			g.Assert(len(s.Dependencies)).Eql(2)
+
+			dep := s.Dependencies[0]
+			g.Assert(dep.Dataset).Eql("product")
+			g.Assert(dep.Joins).IsNotZero()
+			g.Assert(len(dep.Joins)).Eql(2)
+			j := dep.Joins[0]
+			g.Assert(j.Dataset).Eql("order")
+			g.Assert(j.Predicate).Eql("product-ordered")
+			g.Assert(j.Inverse).IsTrue()
+			j = dep.Joins[1]
+			g.Assert(j.Dataset).Eql("person")
+			g.Assert(j.Predicate).Eql("ordering-customer")
+			g.Assert(j.Inverse).IsFalse()
+
+			dep = s.Dependencies[1]
+			g.Assert(dep.Dataset).Eql("order")
+			g.Assert(dep.Joins).IsNotZero()
+			g.Assert(len(dep.Joins)).Eql(1)
+			j = dep.Joins[0]
+			g.Assert(j.Dataset).Eql("person")
+			g.Assert(j.Predicate).Eql("ordering-customer")
+			g.Assert(j.Inverse).IsFalse()
+		})
+	})
+}
+
+func createTestDataset(dsName string, entityNames []string, refMap map[string]map[string]interface{},
+	dsm *server.DsManager, g *goblin.G, store *server.Store) (*server.Dataset, string) {
+	dataset, err := dsm.CreateDataset(dsName)
+	g.Assert(err).IsNil()
+	peoplePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion("http://" + dsName + "/")
+	g.Assert(err).IsNil()
+	var entities []*server.Entity
+
+	for _, entityName := range entityNames {
+		entities = append(entities, server.NewEntityFromMap(map[string]interface{}{
+			"id":    peoplePrefix + ":" + entityName,
+			"props": map[string]interface{}{"name": entityName},
+			"refs":  refMap[entityName],
+		}))
+	}
+
+	err = dataset.StoreEntities(entities)
+	g.Assert(err).IsNil()
+
+	return dataset, peoplePrefix
+}

--- a/internal/jobs/source/sample_source.go
+++ b/internal/jobs/source/sample_source.go
@@ -1,7 +1,6 @@
 package source
 
 import (
-	"encoding/json"
 	"strconv"
 
 	"github.com/mimiro-io/datahub/internal/server"
@@ -14,14 +13,11 @@ type SampleSource struct {
 }
 
 func (source *SampleSource) DecodeToken(token string) DatasetContinuation {
-	result := &StringDatasetContinuation{}
-	_ = json.Unmarshal([]byte(token), result)
-	return result
+	return &StringDatasetContinuation{token}
 }
 
 func (source *SampleSource) EncodeToken(token DatasetContinuation) string {
-	result, _ := json.Marshal(token)
-	return string(result)
+	return token.GetToken()
 }
 
 func (source *SampleSource) StartFullSync() {

--- a/internal/jobs/source/sample_source.go
+++ b/internal/jobs/source/sample_source.go
@@ -12,14 +12,6 @@ type SampleSource struct {
 	Store            *server.Store
 }
 
-func (source *SampleSource) DecodeToken(token string) DatasetContinuation {
-	return &StringDatasetContinuation{token}
-}
-
-func (source *SampleSource) EncodeToken(token DatasetContinuation) string {
-	return token.GetToken()
-}
-
 func (source *SampleSource) StartFullSync() {
 	// empty for now (this makes sonar not complain)
 }

--- a/internal/jobs/source/slow_source.go
+++ b/internal/jobs/source/slow_source.go
@@ -12,14 +12,6 @@ type SlowSource struct {
 	Sleep     string
 }
 
-func (source *SlowSource) DecodeToken(token string) DatasetContinuation {
-	return &StringDatasetContinuation{token}
-}
-
-func (source *SlowSource) EncodeToken(token DatasetContinuation) string {
-	return token.GetToken()
-}
-
 func (source *SlowSource) StartFullSync() {
 	// empty for now (this makes sonar not complain)
 }

--- a/internal/jobs/source/slow_source.go
+++ b/internal/jobs/source/slow_source.go
@@ -1,7 +1,6 @@
 package source
 
 import (
-	"encoding/json"
 	"strconv"
 	"time"
 
@@ -14,14 +13,11 @@ type SlowSource struct {
 }
 
 func (source *SlowSource) DecodeToken(token string) DatasetContinuation {
-	result := &StringDatasetContinuation{}
-	_ = json.Unmarshal([]byte(token), result)
-	return result
+	return &StringDatasetContinuation{token}
 }
 
 func (source *SlowSource) EncodeToken(token DatasetContinuation) string {
-	result, _ := json.Marshal(token)
-	return string(result)
+	return token.GetToken()
 }
 
 func (source *SlowSource) StartFullSync() {

--- a/internal/jobs/source/slow_source.go
+++ b/internal/jobs/source/slow_source.go
@@ -1,14 +1,27 @@
 package source
 
 import (
-	"github.com/mimiro-io/datahub/internal/server"
+	"encoding/json"
 	"strconv"
 	"time"
+
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 type SlowSource struct {
 	BatchSize int
 	Sleep     string
+}
+
+func (source *SlowSource) DecodeToken(token string) DatasetContinuation {
+	result := &StringDatasetContinuation{}
+	_ = json.Unmarshal([]byte(token), result)
+	return result
+}
+
+func (source *SlowSource) EncodeToken(token DatasetContinuation) string {
+	result, _ := json.Marshal(token)
+	return string(result)
 }
 
 func (source *SlowSource) StartFullSync() {
@@ -28,7 +41,7 @@ func (source *SlowSource) GetConfig() map[string]interface{} {
 	return config
 }
 
-func (source *SlowSource) ReadEntities(since string, batchSize int, processEntities func([]*server.Entity, string) error) error {
+func (source *SlowSource) ReadEntities(since DatasetContinuation, batchSize int, processEntities func([]*server.Entity, DatasetContinuation) error) error {
 	// assert sample source namespace
 
 	entities := make([]*server.Entity, source.BatchSize)
@@ -42,5 +55,5 @@ func (source *SlowSource) ReadEntities(since string, batchSize int, processEntit
 	}
 	time.Sleep(d)
 
-	return processEntities(entities, "")
+	return processEntities(entities, &StringDatasetContinuation{""})
 }

--- a/internal/jobs/source/source.go
+++ b/internal/jobs/source/source.go
@@ -15,13 +15,40 @@
 package source
 
 import (
+	"strconv"
+
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
 // Source interface for pulling data
 type Source interface {
 	GetConfig() map[string]interface{}
-	ReadEntities(since string, batchSize int, processEntities func([]*server.Entity, string) error) error
+	ReadEntities(since DatasetContinuation, batchSize int, processEntities func([]*server.Entity, DatasetContinuation) error) error
 	StartFullSync()
 	EndFullSync()
+	DecodeToken(token string) DatasetContinuation
+	EncodeToken(token DatasetContinuation) string
+}
+
+type DatasetContinuation interface {
+	GetToken() string
+	AsIncrToken() uint64
+}
+
+type StringDatasetContinuation struct {
+	token string
+}
+
+func (c *StringDatasetContinuation) GetToken() string {
+	return c.token
+}
+func (c *StringDatasetContinuation) AsIncrToken() uint64 {
+	if c.token != "" {
+		i, err := strconv.Atoi(c.token)
+		if err != nil {
+			return 0
+		}
+		return uint64(i)
+	}
+	return 0
 }

--- a/internal/jobs/source/source.go
+++ b/internal/jobs/source/source.go
@@ -36,15 +36,15 @@ type DatasetContinuation interface {
 }
 
 type StringDatasetContinuation struct {
-	token string
+	Token string
 }
 
 func (c *StringDatasetContinuation) GetToken() string {
-	return c.token
+	return c.Token
 }
 func (c *StringDatasetContinuation) AsIncrToken() uint64 {
-	if c.token != "" {
-		i, err := strconv.Atoi(c.token)
+	if c.Token != "" {
+		i, err := strconv.Atoi(c.Token)
 		if err != nil {
 			return 0
 		}
@@ -59,9 +59,11 @@ func (c *StringDatasetContinuation) Encode() (string, error) {
 func DecodeToken(sourceType interface{}, token string) (DatasetContinuation, error) {
 	if sourceType == "MultiSource" {
 		result := &MultiDatasetContinuation{}
-		err := json.Unmarshal([]byte(token), result)
-		if err != nil {
-			return nil, err
+		if token != "" {
+			err := json.Unmarshal([]byte(token), result)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return result, nil
 	}

--- a/internal/server/error.go
+++ b/internal/server/error.go
@@ -45,7 +45,11 @@ var (
 	HttpJobSchedulingErr    = func(detail error) error { return fmt.Errorf("failed at scheduling the job definition: %w", detail) }
 	HttpJsonParsingErr      = func(detail error) error { return fmt.Errorf("failed parsing the json body: %w", detail) }
 	HttpContentStoreErr     = func(detail error) error { return fmt.Errorf("failed updating the content: %w", detail) }
-	HttpQueryParamErr       = func(detail error) error { return fmt.Errorf("one or more of the query parameters failed its validation: %w", detail) }
-	HttpGenericErr          = func(detail error) error { return fmt.Errorf("internal failure: %w", detail) }
-	HttpFullsyncErr         = func(detail error) error { return fmt.Errorf("an error occured trying to start or update a full sync: %w", detail) }
+	HttpQueryParamErr       = func(detail error) error {
+		return fmt.Errorf("one or more of the query parameters failed its validation: %w", detail)
+	}
+	HttpGenericErr  = func(detail error) error { return fmt.Errorf("internal failure: %w", detail) }
+	HttpFullsyncErr = func(detail error) error {
+		return fmt.Errorf("an error occured trying to start or update a full sync: %w", detail)
+	}
 )

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -28,9 +28,10 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/dgraph-io/badger/v3"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 type result struct {


### PR DESCRIPTION
This PR aims to add a feature as described in https://github.com/mimiro-io/datahub/issues/73. It therefore closes #73 

With this new feature, it is possible to configure a new job-source type: MultiSource. Here an example:

```
                         {
				"Type" : "MultiSource",
				"Name" : "person",
				"Dependencies": [
					{
						"dataset": "product",
						"joins": [
							{
								"dataset": "order",
								"predicate": "product-ordered",
								"inverse": true
							},
							{
								"dataset": "person",
								"predicate": "ordering-customer",
								"inverse": false
							}
						]
					},
					{
						"dataset": "order",
						"joins": [
							{
								"dataset": "person",
								"predicate": "ordering-customer",
								"inverse": false
							}
						]
					}
				]
			}

```
Explanation:
person is the main dataset.
orders point to persons (who ordered) on one side, and products (that were ordered) on the other side.
The first dependency tracks changes in "product". for each changed product, the source finds inveresly all orders that point to the changed product. Subsequently if finds all affected persons by following the orders' "ordering-customer" relation.
The 2nd dependency tracks changes in "order". For each changed order, the source follow their "ordering-customer" relation and emits the persons found this way.

Apart from the obvious (ability to track dependencies), there are a couple of more specialties here:
  
  * jobs using MultiSource need to keep track of multiple continuation tokens: One for the main dataset and one additional token per dependency dataset. Therefore continuation tokens in general are changed to be an interface now. For all other sources, the implementaion is as before around a plain string. But for MultiSource the implementation works with a data structure that can hold all required tokens.
  * When MultiSource is read in fullsync mode, it will currently NOT emit de-duplicated entities. It will always produce the complete list of changes that are registered in a dataset. This implies that MultiSource should not be used with HttpSinks which expect entities.
  * Jobs that use MultiSource can be primed with an initial fullsync, which will process all changes in the main dataset, but will NOT process dependencies. The reasoning is that since we emit all changes already, we don't need to search for further changes via dependencies. A fullsync on MultiSource does however store the current continuation tokens for all configured dependencies so that subsequent incremental runs can pick up at the correct change position for all involved datasets.
  * MultiSource does not track joining datasets implicitly. So if you define a dependency that links back to the main dataset via several joins, the we don't track changes in the "join" datasets implicitly. These have to be declared as separate dependency if tracking is required.