### PR TITLE
Use git tag for release publish

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,11 +55,16 @@ jobs:
         with:
           push: true
           tags: mimiro/datahub:${{ steps.get_version.outputs.version }}-unstable    
-    
+      
+      - name: Get Release Tag
+        if: github.event_name == 'release'
+        id: get_tag
+        run: echo ::set-output name=tag::$(echo $GITHUB_REF | cut -d / -f 3)
+      
       - name: Push Stable Image to DockerHub upon publishing github release
         id: dockerhub_push_stable
         if: github.event_name == 'release'
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: mimiro/datahub:${{ steps.get_version.outputs.version }} , mimiro/datahub:latest                
+          tags: mimiro/datahub:${{ steps.get_tag.outputs.tag }} , mimiro/datahub:latest                


### PR DESCRIPTION
Upon publishing a new release, docker image should be tagged with the tag of release instead of action run number , This will help to keep  github tag and docker tag as it is.