### PR TITLE
add `AsEntity` transform helper ...

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1140,6 +1140,27 @@ function transform_entities(entities) {
 }
 ```
 
+#### AsEntity
+
+`AsEntity(value)` can be use to convert entity-shaped properties (sub-entities) into Entity instances, which in turn enables the use of other transform helper functions.
+
+Example usage:
+```
+function transform_entities(entities) {
+    var ns = GetNamespacePrefix(...);
+    for (e of entities) {
+       var address = GetProperty(e, ns, "address");
+       // address is an entity-shaped json value, so we can apply AsEntity
+       var addressEntity = AsEntity(address);
+
+       // GetProperty and other helpers work on addressEntity
+       var street = GetProperty(addressEntity, ns, "street");
+    }
+    return entities;
+}
+```
+
+
 #### NewTransaction
 
 `NewTransaction()` is used to create a new transaction object. A transaction can then be executed using the ExecuteTransaction function. Note that this function simply returns an empty transaction data structure. It does not open a transaction.


### PR DESCRIPTION
... to convert Entity-shaped json stuctures into actual Entities.
---
Sometimes we want to embed entities inside entities. For example a shape like this:
```
{
  "id": "...",
  "props": {
      "ns:subentity": {
        "id": "...",
        "props: { "ns:subprop" : "x"},
        "refs": {}
      }
  },
  "refs": {}
}
```
If we now want to access "ns:subentity" in a transform, the recommended way to do it is using the `GetPropery` helper: `var subEntity = GetProperty(e, ns, "subentity")`
However, if we want to access properties of the subEntity, we cannot use `GetProperty`. Because subentity is not an actual entity - it is merely a json structure in the same shape as an Entity. We would have to use `var subProp = subEntity["props"]["ns:subprop"]`.


The new helper function `AsEntity` can streamline property access for subentities. Usage:
```
  var submap = GetProperty(e, ns, "subentity");
  var subEntity = AsEntity(submap);
  var subProp = GetProperty(subEntity, ns, "subprop");
```


This makes it possible to use other transform helper functions on sub-entities