### PR TITLE
[113] FIX: Login provider returning empty string

### DIFF
--- a/internal/security/login_provider.go
+++ b/internal/security/login_provider.go
@@ -101,6 +101,8 @@ func (pm *ProviderManager) LoadValue(vp *ValueReader) string {
 		v := os.Getenv(vp.Value)
 		if v == "" {
 			return viper.GetString(vp.Value)
+		} else {
+			return v
 		}
 	case "ssm":
 		if v, ok := pm.sm.Value(vp.Value); ok {


### PR DESCRIPTION
Added an else clause to prevent value from falling through and returning
empty ("") if found.

Closes #113 
