### PR TITLE
adapt GHA Docker CI workflow for multiarch build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,13 +9,161 @@ on:
     types:
       - published
 
+env:
+  DOCKERHUB_REPOSITORY : mimiro/datahub
+  
 jobs:
-  Docker:
+  Docker_AMD64:
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.image_tag.outputs.image_tag }}
+      
     steps:
     
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2  
+
+      - name: Set up Docker Buildx (enable caching)
+        uses: docker/setup-buildx-action@v1
+            
+      - name: Set Image Tag
+        id: image_tag
+        run: |
+          if [ ${{ github.event_name }} == 'release' ]
+          then
+            echo "Setting Stable Image Tag"
+            echo ::set-output name=image_tag:: ${{ env.DOCKERHUB_REPOSITORY }}:$(echo $GITHUB_REF | cut -d / -f 3)-$(uname -m)
+          else
+            echo "Setting Unstable Image"
+            echo ::set-output name=image_tag:: ${{ env.DOCKERHUB_REPOSITORY }}:v-$(cat VERSION.txt)$GITHUB_RUN_NUMBER-unstable-$(uname -m)
+          fi
+       
+      # Login to Docker registry except on PR
+      - name: Login to DockerHub
+        id: docker_login
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}      
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v2
+        id: docker_build
+        with:
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.image_tag.outputs.image_tag }} 
+
+      - name: Trivy vulnerability scan
+        uses : aquasecurity/trivy-action@master
+        with :
+          image-ref: '${{ steps.get_version.outputs.version }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'         
+
+      - name: Push Image to DockerHub
+        id: dockerhub_push
+        if: |
+          (
+            ( github.ref == 'refs/heads/master' && github.event_name == 'push' ) 
+            || 
+            ( github.event_name == 'release')
+          ) 
+            && 
+          ( github.event_name != 'pull_request')  
+
+        run: |
+          docker image push ${{ steps.image_tag.outputs.image_tag }}
+
+  Docker_ARM64:
+    runs-on: ARM64
+    outputs:
+      image_tag: ${{ steps.image_tag.outputs.image_tag }}
+      
+    steps:
+    
+      - name: Checkout code
+        uses: actions/checkout@v2  
+
+      - name: Set up Docker Buildx (enable caching)
+        uses: docker/setup-buildx-action@v1
+            
+      - name: Set Image Tag
+        id: image_tag
+        run: |
+          if [ ${{ github.event_name }} == 'release' ]
+          then
+            echo "Setting Stable Image Tag"
+            echo ::set-output name=image_tag:: ${{ env.DOCKERHUB_REPOSITORY }}:$(echo $GITHUB_REF | cut -d / -f 3)-$(uname -m)
+          else
+            echo "Setting Unstable Image"
+            echo ::set-output name=image_tag:: ${{ env.DOCKERHUB_REPOSITORY }}:v-$(cat VERSION.txt)$GITHUB_RUN_NUMBER-unstable-$(uname -m)
+          fi
+       
+      # Login to Docker registry except on PR
+      - name: Login to DockerHub
+        id: docker_login
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}      
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v2
+        id: docker_build
+        with:
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.image_tag.outputs.image_tag }} 
+
+      - name: Trivy vulnerability scan
+        uses : aquasecurity/trivy-action@master
+        with :
+          image-ref: '${{ steps.get_version.outputs.version }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'         
+
+      - name: Push Image to DockerHub
+        id: dockerhub_push
+        if: |
+          (
+            ( github.ref == 'refs/heads/master' && github.event_name == 'push' ) 
+            || 
+            ( github.event_name == 'release')
+          ) 
+            && 
+          ( github.event_name != 'pull_request')        
+        run: |
+          docker image push ${{ steps.image_tag.outputs.image_tag }}
+    
+  Docker_Manifest:
+    runs-on: ubuntu-latest
+    needs: [Docker_AMD64,Docker_ARM64]
+    if: |
+      (
+        ( github.ref == 'refs/heads/master' && github.event_name == 'push' ) 
+        || 
+        ( github.event_name == 'release')
+      ) 
+        && 
+      ( github.event_name != 'pull_request') 
+
+    steps:   
+      
+      - name: Checkout code
+        uses: actions/checkout@v2  
 
       - name: Login to DockerHub
         id: docker_login
@@ -23,48 +171,49 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-     
-      - name: Get version
-        id: get_version
-        run: echo ::set-output name=version::v-$(cat VERSION.txt)$GITHUB_RUN_NUMBER
-      
-      - name: Show Version
-        run: echo ${{ steps.get_version.outputs.version }}             
 
-      - name: Build Docker Image
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          tags: mimiro/datahub:${{ steps.get_version.outputs.version }}
+      - name: Set Image Tag
+        id: image_tag
+        run: |
+          if [ ${{ github.event_name }} == 'release' ]
+          then
+            echo "Setting Stable Image Tag"
+            echo ::set-output name=image_tag:: ${{ env.DOCKERHUB_REPOSITORY }}:$(echo $GITHUB_REF | cut -d / -f 3)
+          else
+            echo "Setting Unstable Image"
+            echo ::set-output name=image_tag:: ${{ env.DOCKERHUB_REPOSITORY }}:v-$(cat VERSION.txt)$GITHUB_RUN_NUMBER-unstable
+          fi  
 
-      - name: Trivy vulnerability scan
-        uses : aquasecurity/trivy-action@master
-        with :
-          image-ref: 'mimiro/datahub:${{ steps.get_version.outputs.version }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'         
+      - name: Show Tag
+        run: echo ${{ steps.image_tag.outputs.image_tag }}  
 
-      - name: Push Unstable Image to DockerHub
-        id: dockerhub_push_unstable
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: mimiro/datahub:${{ steps.get_version.outputs.version }}-unstable    
-      
-      - name: Get Release Tag
-        if: github.event_name == 'release'
-        id: get_tag
-        run: echo ::set-output name=tag::$(echo $GITHUB_REF | cut -d / -f 3)
-      
-      - name: Push Stable Image to DockerHub upon publishing github release
-        id: dockerhub_push_stable
-        if: github.event_name == 'release'
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: mimiro/datahub:${{ steps.get_tag.outputs.tag }} , mimiro/datahub:latest                
+      - name: Docker Manifest
+        id: docker_manifest
+
+        run: |    
+
+          if [ ${{ github.event_name }} == 'release' ]
+
+          then
+
+            #tag:release version
+            docker manifest create ${{ steps.image_tag.outputs.image_tag }} \
+              ${{needs.Docker_AMD64.outputs.image_tag}} \
+              ${{needs.Docker_ARM64.outputs.image_tag}} 
+            
+            docker manifest push ${{ steps.image_tag.outputs.image_tag }}
+
+            #tag:latest
+            docker manifest create  ${{ env.DOCKERHUB_REPOSITORY }}:latest \
+              ${{needs.Docker_AMD64.outputs.image_tag}} \
+              ${{needs.Docker_ARM64.outputs.image_tag}} 
+            
+            docker manifest push  ${{ env.DOCKERHUB_REPOSITORY }}:latest
+
+          else
+             docker manifest create ${{ steps.image_tag.outputs.image_tag }} \
+              ${{needs.Docker_AMD64.outputs.image_tag}} \
+              ${{needs.Docker_ARM64.outputs.image_tag}} 
+          docker manifest push ${{ steps.image_tag.outputs.image_tag }}    
+
+          fi


### PR DESCRIPTION
### Docker build Workflow is proposed to behave as below:

#### Upon commit to branch other then `master` :
         No Action is triggered

#### Raising a PR to `master`
      -   docker build in both amd64 and arm64
      -   No image is pushed to dockerhub
      -   No docker manifest manifest
 
#### Merging a PR (or direct commit) to `master`

      -  docker build in both amd64 and arm64 machines
      
      -   2 images  are published to DockerHub with following tags
            # v-semver-unstable-aarch64    e.g  [v-0.6.56-unstable-x86_64]
            # v-semver-unstable-amd64      e.g. [v-0.6.56-unstable-aarch64]
            
      -  1 Docker multi arch manifest with both of the 2 above images combined is published
            # v-semver-unstable                    e.g. [v-0.6.56-unstable]
      
 
#### Publishing a Github release
      -   docker build in both amd64 and arm64 machines
      -   2 images  are published to DockerHub with following tags
          # release-tag-aarch64 e.g.  
          # release-tag-amd64 e.g.
      -  2 Docker multi arch manifests with both of the 2 images combined is published with following 2 tags-      
          #  release-tag                    e.g. [v-0.6.181-stable]
          #   latest tag                       e.g. [latest]
      
      