### PR TITLE
new flag for datasetSource: LatestOnly

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -401,10 +401,13 @@ The dataset source reads entities from a dataset in the data hub.
     "source": {
         "Type": "DatasetSource",
         "Name": "name of the dataset to read from",
-        "BatchSize" : "optional int value of how many to read at a time"
+        "BatchSize" : "optional int value of how many to read at a time",
+        "LatestOnly": "true or false, indicating whether to emit all changes or only the latest change of each entity"
     }
 }
 ```
+The `LatestOnly` flag can be set to limit the number of entities emitted to only the latest version of each entity.
+The default is that all changes of each entity are emitted, so that the whole dataset can be transformed and/or copied without loss of history.
 
 #### Multi Source
 
@@ -421,6 +424,7 @@ MultiSource can in incremental jobs emit entities that have not been changed the
     "source": {
         "Type": "MultiSource",
         "Name": "name of the main dataset",
+        "LatestOnly": "true or false, indicating whether to emit all changes or only the latest change of each entity"
         "Dependencies": [
             {
                 "dataset": "name of a dependency dataset",
@@ -1487,5 +1491,3 @@ A payload with the following data is sent to the OPA service with the request:
 ```
 
 Note that the backing implementation of the OPA ruleset is outside of the scope of this documentation, and is in practice up to the OPA service maintainer in your organization. However the functions and their return values are not optional, and must confirm.
-
-

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -25,6 +25,8 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+var filePtr = flag.String("config", "", "Optional path to the config file")
+
 // NewEnv bootstraps the environment from the .env files, but also
 // takes care of getting secrets from the secrets store.
 // It will first start a logger to be able to log that it is loading
@@ -33,7 +35,6 @@ import (
 // You can give it a basePath, this is great for testing, but by default
 // this is set to "."
 func NewEnv() (*Env, error) {
-	filePtr := flag.String("config", "", "Optional path to the config file")
 	flag.Parse()
 	return loadEnv(filePtr, true)
 }

--- a/internal/jobs/pipeline_history_test.go
+++ b/internal/jobs/pipeline_history_test.go
@@ -303,14 +303,14 @@ func setupCheckers(g *goblin.G, t *testing.T, employees *server.Dataset, people 
 
 	checkChanges := func(changeIdx int, homerName, mimiroName, homerFriend string) {
 		friendVal := fv(homerFriend, ns)
-		changes, _ := employees.GetChanges(0, math.MaxInt)
+		changes, _ := employees.GetChanges(0, math.MaxInt, false)
 		g.Assert(changes.Entities[changeIdx].IsDeleted).IsFalse()
 		g.Assert(changes.Entities[changeIdx].Properties["name"]).Eql(homerName)
 		g.Assert(changes.Entities[changeIdx].Properties["companyname"]).Eql(mimiroName)
 		g.Assert(changes.Entities[changeIdx].References[ns+":friend"]).Eql(friendVal)
 	}
 	assertChangeCount := func(expectedCount int) {
-		changes, _ := employees.GetChanges(0, math.MaxInt)
+		changes, _ := employees.GetChanges(0, math.MaxInt, false)
 		g.Assert(len(changes.Entities)).Eql(expectedCount)
 	}
 	printState := func() {
@@ -319,17 +319,17 @@ func setupCheckers(g *goblin.G, t *testing.T, employees *server.Dataset, people 
 			return
 		}
 		// print out state
-		result, _ := people.GetChanges(0, math.MaxInt)
+		result, _ := people.GetChanges(0, math.MaxInt, false)
 		//t.Logf("\npeople change count: %v", len(result.Entities))
 		for _, e := range result.Entities {
 			t.Logf("people: %+v; %+v", e.Properties, e.References)
 		}
-		result, _ = companies.GetChanges(0, math.MaxInt)
+		result, _ = companies.GetChanges(0, math.MaxInt, false)
 		//t.Logf("\ncompanies change count: %v", len(result.Entities))
 		for _, e := range result.Entities {
 			t.Logf("companies: %+v", e.Properties)
 		}
-		result, _ = employees.GetChanges(0, math.MaxInt)
+		result, _ = employees.GetChanges(0, math.MaxInt, false)
 		//t.Log("\nexpected employees change count: 8 (baseline plus 7 changes)")
 		//t.Logf("\nemployees change count: %v", len(result.Entities))
 

--- a/internal/jobs/pipeline_history_test.go
+++ b/internal/jobs/pipeline_history_test.go
@@ -73,7 +73,7 @@ func TestPipelineHistory(t *testing.T) {
 		})
 		g.It("Should produce consistent output for single change", func() {
 			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner)
+			job := setupJob(scheduler, g, runner, false)
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
 			checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
 			//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
@@ -94,7 +94,7 @@ func TestPipelineHistory(t *testing.T) {
 		})
 		g.It("Should produce consistent output for changes in dependency dataset", func() {
 			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner)
+			job := setupJob(scheduler, g, runner, false)
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
 			checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
 			//checkChange, checkEntities, assertChangeCount, printState := setupCheckers(g, t, employees, people, companies, ns)
@@ -115,7 +115,7 @@ func TestPipelineHistory(t *testing.T) {
 		})
 		g.It("Should produce consistent output for changes in source dataset", func() {
 			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner)
+			job := setupJob(scheduler, g, runner, false)
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
 			//checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
 			checkChange, checkEntities, assertChangeCount, printState := setupCheckers(g, t, employees, people, companies, ns)
@@ -137,9 +137,30 @@ func TestPipelineHistory(t *testing.T) {
 			checkChange(9, "homer_2", "Mimiro_1", "")
 			assertChangeCount(10) //"2 changes in source, time 5 job runs"
 		})
+		g.It("Should produce consistent output for LastOnly changes in source dataset", func() {
+			ns, employees, people, companies := setupDatasets(store, dsm)
+			job := setupJob(scheduler, g, runner, true)
+			homer, _, mimiro := entityUpdaters(people, ns, companies)
+			//checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
+			checkChange, checkEntities, assertChangeCount, printState := setupCheckers(g, t, employees, people, companies, ns)
+
+			g.Assert(homer("homer_1")).IsNil()
+			g.Assert(mimiro("Mimiro_1")).IsNil()
+			//change homer
+			g.Assert(homer("homer_2")).IsNil()
+
+			// run job many times, output should not change
+			for i := 0; i < 5; i++ {
+				job.Run()
+			}
+			printState()
+			checkEntities("homer_2", "Mimiro_1", "")
+			assertChangeCount(1) //"2 changes in source, time 5 job runs"
+			checkChange(0, "homer_2", "Mimiro_1", "")
+		})
 		g.It("Should produce consistent output for 2 changes in different batches", func() {
 			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner)
+			job := setupJob(scheduler, g, runner, false)
 			// set batchsize to 2
 			job.pipeline.(*FullSyncPipeline).batchSize = 2
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
@@ -167,6 +188,31 @@ func TestPipelineHistory(t *testing.T) {
 			assertChangeCount(15) //"3 changes in source, time 5 job runs"
 
 		})
+		g.It("Should produce consistent output for 2 LastOnly changes in different batches", func() {
+			ns, employees, people, companies := setupDatasets(store, dsm)
+			job := setupJob(scheduler, g, runner, true)
+			// set batchsize to 2
+			job.pipeline.(*FullSyncPipeline).batchSize = 2
+			homer, _, mimiro := entityUpdaters(people, ns, companies)
+			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
+			//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
+
+			g.Assert(homer("homer_1")).IsNil()
+			g.Assert(mimiro("Mimiro_1")).IsNil()
+			g.Assert(homer("homer_2")).IsNil()
+			g.Assert(mimiro("Mimiro_2")).IsNil()
+			g.Assert(homer("homer_3")).IsNil()
+
+			// run job many times, output should not change
+			for i := 0; i < 5; i++ {
+				job.Run()
+			}
+			print()
+			checkEntities("homer_3", "Mimiro_2", "")
+			checkChange(0, "homer_3", "Mimiro_2", "")
+			assertChangeCount(1) //"3 changes in source, time 5 job runs"
+
+		})
 		g.It("Should preserve state of composed change products also if sources change with time", func() {
 			/*
 				Here we simulate changes in two datasets over time, and verify how these changes affect the results
@@ -179,7 +225,7 @@ func TestPipelineHistory(t *testing.T) {
 				of the joined "employee" entity if we run the transform again.
 			*/
 			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner)
+			job := setupJob(scheduler, g, runner, false)
 			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
 			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
 
@@ -232,13 +278,71 @@ func TestPipelineHistory(t *testing.T) {
 			checkChange(3, "homer_2", "Mimiro_2", "barney")
 			checkChange(23, "homer_4", "Mimiro_4", "")
 		})
+		g.It("Should preserve state of composed LatestOnly change products also if sources change with time", func() {
+			ns, employees, people, companies := setupDatasets(store, dsm)
+			job := setupJob(scheduler, g, runner, true)
+			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
+			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
+
+			// store first version of "homer"
+			// and first version of "mimiro"
+			g.Assert(homer("homer_1")).IsNil()
+			g.Assert(mimiro("Mimiro_1")).IsNil()
+
+			// now, first run with baseline
+			job.Run()
+
+			checkEntities("homer_1", "Mimiro_1", "")
+			assertChangeCount(1)
+			checkChange(0, "homer_1", "Mimiro_1", "")
+
+			///////////// first change: homer new name, add friend /////////////////
+			g.Assert(homerWithFriend("homer_2")).IsNil()
+			job.Run()
+
+			checkEntities("homer_2", "Mimiro_1", "barney")
+			assertChangeCount(2)
+			checkChange(0, "homer_1", "Mimiro_1", "")
+			checkChange(1, "homer_2", "Mimiro_1", "barney")
+
+			//////////// 2nd change: Mimiro new name //////////////////
+			g.Assert(mimiro("Mimiro_2")).IsNil()
+			job.Run()
+			/////////// 3rd change: homer new name again, rm friend
+			g.Assert(homer("homer_3")).IsNil()
+			job.Run()
+			/////////// 4th change: homer back to old name
+			g.Assert(homer("homer_1")).IsNil()
+			job.Run()
+			/////////// 5th change: Mimiro new name
+			g.Assert(mimiro("Mimiro_3")).IsNil()
+			job.Run()
+			/////////// 6th change: homer  final change
+			g.Assert(homer("homer_4")).IsNil()
+			job.Run()
+			/////////// 7th change: mimiro  final change
+			g.Assert(mimiro("Mimiro_4")).IsNil()
+			job.Run()
+
+			print()
+			checkEntities("homer_4", "Mimiro_4", "")
+			assertChangeCount(8)
+			checkChange(0, "homer_1", "Mimiro_1", "")
+			checkChange(1, "homer_2", "Mimiro_1", "barney")
+			checkChange(2, "homer_2", "Mimiro_2", "barney")
+			checkChange(3, "homer_3", "Mimiro_2", "")
+			checkChange(4, "homer_1", "Mimiro_2", "")
+			checkChange(5, "homer_1", "Mimiro_3", "")
+			checkChange(6, "homer_4", "Mimiro_3", "")
+			checkChange(7, "homer_4", "Mimiro_4", "")
+		})
 		g.It("Should compose existing changes correctly in transform with Query", func() {
 			/*
 				  This is the same order of changes as above, except for that we only run the
 					transform job once at the end.
 			*/
 			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner)
+			job := setupJob(scheduler, g, runner, false)
 			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
 			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
 
@@ -372,7 +476,7 @@ func entityUpdaters(people *server.Dataset, ns string, companies *server.Dataset
 	return homer, homerWithFriend, mimiro
 }
 
-func setupJob(scheduler *Scheduler, g *goblin.G, runner *Runner) *job {
+func setupJob(scheduler *Scheduler, g *goblin.G, runner *Runner, latestOnly bool) *job {
 	// now combine homer and mimiro into homer-the-employee
 	jsFun := `function transform_entities(entities) {
 			var result = []
@@ -396,9 +500,10 @@ func setupJob(scheduler *Scheduler, g *goblin.G, runner *Runner) *job {
 	jobConfig, _ := scheduler.Parse([]byte(fmt.Sprintf(`{
 			"id" : "sync-datasetsource-to-datasetsink-with-js-and-query",
 			"triggers": [{"triggerType": "cron", "jobType": "fullSync", "schedule": "@every 2s"}],
-			"source" : { "Type" : "DatasetSource", "Name" : "People" },
+			"source" : { "Type" : "DatasetSource", "Name" : "People", "LatestOnly": "%v" },
 			"transform" : { "Type" : "JavascriptTransform", "Code" : "%v" },
 			"sink" : { "Type" : "DatasetSink", "Name" : "Employees" }}`,
+		latestOnly,
 		base64.StdEncoding.EncodeToString([]byte(jsFun)))))
 
 	pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)

--- a/internal/jobs/pipeline_history_test.go
+++ b/internal/jobs/pipeline_history_test.go
@@ -155,7 +155,7 @@ func TestPipelineHistory(t *testing.T) {
 			}
 			printState()
 			checkEntities("homer_2", "Mimiro_1", "")
-			assertChangeCount(1) //"2 changes in source, time 5 job runs"
+			assertChangeCount(1) //only one version of homer is expected to be emitted, therefore only one resulting change version
 			checkChange(0, "homer_2", "Mimiro_1", "")
 		})
 		g.It("Should produce consistent output for 2 changes in different batches", func() {
@@ -210,7 +210,7 @@ func TestPipelineHistory(t *testing.T) {
 			print()
 			checkEntities("homer_3", "Mimiro_2", "")
 			checkChange(0, "homer_3", "Mimiro_2", "")
-			assertChangeCount(1) //"3 changes in source, time 5 job runs"
+			assertChangeCount(1) //since only one "Latest" version of homer is emitted, we expect only one result
 
 		})
 		g.It("Should preserve state of composed change products also if sources change with time", func() {

--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -660,13 +660,12 @@ func TestPipeline(t *testing.T) {
 			entities[1] = server.NewEntity(testNamespacePrefix+":barney", 0)
 			entities[1].Properties[testNamespacePrefix+":name"] = "barney"
 			entities[1].Properties[testNamespacePrefix+":address"] = map[string]interface{}{
-				"id": testNamespacePrefix+":barn",
-				"props": map[string]interface{}{ testNamespacePrefix+":street": "barnstreet" },
-				"refs": map[string]interface{}{},
+				"id":    testNamespacePrefix + ":barn",
+				"props": map[string]interface{}{testNamespacePrefix + ":street": "barnstreet"},
+				"refs":  map[string]interface{}{},
 			}
 
 			g.Assert(ds.StoreEntities(entities)).IsNil()
-
 
 			jsFun := `function transform_entities(entities) {
 		    var test_ns = GetNamespacePrefix("http://data.mimiro.io/test/");
@@ -1090,7 +1089,7 @@ func TestPipeline(t *testing.T) {
 			_ = srcDs.StoreEntities([]*server.Entity{e1})
 
 			var sourceChanges []*server.Entity
-			_, err := srcDs.ProcessChanges(0, 100, func(entity *server.Entity) {
+			_, err := srcDs.ProcessChanges(0, 100, false, func(entity *server.Entity) {
 				sourceChanges = append(sourceChanges, entity)
 			})
 			g.Assert(err).IsNil()
@@ -1118,7 +1117,7 @@ func TestPipeline(t *testing.T) {
 			_ = srcDs.StoreEntities([]*server.Entity{e1})
 
 			var sourceChanges []*server.Entity
-			_, err := srcDs.ProcessChanges(0, 100, func(entity *server.Entity) {
+			_, err := srcDs.ProcessChanges(0, 100, false, func(entity *server.Entity) {
 				sourceChanges = append(sourceChanges, entity)
 			})
 			g.Assert(err).IsNil()
@@ -1276,7 +1275,8 @@ func TestPipeline(t *testing.T) {
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
 				"Type" : "DatasetSource",
-				"Name" : "Products"
+				"Name" : "Products",
+				"LatestOnly": "true"
 			},
 			"transform" : {
 				"Type" : "JavascriptTransform",
@@ -1289,6 +1289,7 @@ func TestPipeline(t *testing.T) {
 			jobConfig, _ := scheduler.Parse([]byte(jobJson))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed")
+			g.Assert(pipeline.spec().source.(*source.DatasetSource).LatestOnly).IsTrue()
 
 			job := &job{
 				id:       jobConfig.Id,

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -542,10 +543,17 @@ func (s *Scheduler) parseSource(jobConfig *JobConfiguration) (source.Source, err
 				}
 				return src, nil
 			} else if sourceTypeName == "DatasetSource" {
+				var err error
 				src := &source.DatasetSource{}
 				src.Store = s.Store
 				src.DatasetManager = s.DatasetManager
 				src.DatasetName = (sourceConfig["Name"]).(string)
+				if sourceConfig["LatestOnly"] != nil {
+					src.LatestOnly, err = strconv.ParseBool((sourceConfig["LatestOnly"]).(string))
+				}
+				if err != nil {
+					return nil, err
+				}
 				return src, nil
 			} else if sourceTypeName == "MultiSource" {
 				src := &source.MultiSource{}
@@ -553,6 +561,13 @@ func (s *Scheduler) parseSource(jobConfig *JobConfiguration) (source.Source, err
 				src.DatasetManager = s.DatasetManager
 				src.DatasetName = (sourceConfig["Name"]).(string)
 				err := src.ParseDependencies(sourceConfig["Dependencies"])
+				if err != nil {
+					return nil, err
+				}
+				src.LatestOnly, err = strconv.ParseBool((sourceConfig["LatestOnly"]).(string))
+				if sourceConfig["LatestOnly"] != nil {
+					src.LatestOnly, err = strconv.ParseBool((sourceConfig["LatestOnly"]).(string))
+				}
 				if err != nil {
 					return nil, err
 				}

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -549,7 +549,12 @@ func (s *Scheduler) parseSource(jobConfig *JobConfiguration) (source.Source, err
 				src.DatasetManager = s.DatasetManager
 				src.DatasetName = (sourceConfig["Name"]).(string)
 				if sourceConfig["LatestOnly"] != nil {
-					src.LatestOnly, err = strconv.ParseBool((sourceConfig["LatestOnly"]).(string))
+					i := sourceConfig["LatestOnly"]
+					if boolVal, ok := i.(bool); ok {
+						src.LatestOnly = boolVal
+					} else {
+						src.LatestOnly, err = strconv.ParseBool(i.(string))
+					}
 				}
 				if err != nil {
 					return nil, err
@@ -564,9 +569,13 @@ func (s *Scheduler) parseSource(jobConfig *JobConfiguration) (source.Source, err
 				if err != nil {
 					return nil, err
 				}
-				src.LatestOnly, err = strconv.ParseBool((sourceConfig["LatestOnly"]).(string))
 				if sourceConfig["LatestOnly"] != nil {
-					src.LatestOnly, err = strconv.ParseBool((sourceConfig["LatestOnly"]).(string))
+					i := sourceConfig["LatestOnly"]
+					if boolVal, ok := i.(bool); ok {
+						src.LatestOnly = boolVal
+					} else {
+						src.LatestOnly, err = strconv.ParseBool(i.(string))
+					}
 				}
 				if err != nil {
 					return nil, err

--- a/internal/jobs/source/dataset_source.go
+++ b/internal/jobs/source/dataset_source.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source
 
 import (

--- a/internal/jobs/source/dataset_source.go
+++ b/internal/jobs/source/dataset_source.go
@@ -12,6 +12,7 @@ type DatasetSource struct {
 	Store          *server.Store
 	DatasetManager *server.DsManager
 	isFullSync     bool
+	LatestOnly     bool
 }
 
 func (datasetSource *DatasetSource) StartFullSync() {
@@ -45,9 +46,10 @@ func (datasetSource *DatasetSource) ReadEntities(since DatasetContinuation, batc
 			return err
 		}
 	} else {
-		continuation, err := dataset.ProcessChanges(since.AsIncrToken(), batchSize, func(entity *server.Entity) {
-			entities = append(entities, entity)
-		})
+		continuation, err := dataset.ProcessChanges(since.AsIncrToken(), batchSize, datasetSource.LatestOnly,
+			func(entity *server.Entity) {
+				entities = append(entities, entity)
+			})
 		if err != nil {
 			return err
 		}

--- a/internal/jobs/source/dataset_source_test.go
+++ b/internal/jobs/source/dataset_source_test.go
@@ -1,0 +1,204 @@
+package source_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/franela/goblin"
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/jobs/source"
+	"github.com/mimiro-io/datahub/internal/server"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+	"os"
+	"testing"
+)
+
+func TestDatasetSource(t *testing.T) {
+	g := goblin.Goblin(t)
+	g.Describe("a datasetSource", func() {
+		testCnt := 0
+		var dsm *server.DsManager
+		var store *server.Store
+		var storeLocation string
+		g.BeforeEach(func() {
+			// temp redirect of stdout and stderr to swallow some annoying init messages in fx
+			devNull, _ := os.Open("/dev/null")
+			oldErr := os.Stderr
+			oldStd := os.Stdout
+			os.Stderr = devNull
+			os.Stdout = devNull
+
+			testCnt += 1
+			storeLocation = fmt.Sprintf("./test_dataset_source_%v", testCnt)
+			err := os.RemoveAll(storeLocation)
+			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
+
+			e := &conf.Env{
+				Logger:        zap.NewNop().Sugar(),
+				StoreLocation: storeLocation,
+			}
+			lc := fxtest.NewLifecycle(t)
+
+			store = server.NewStore(lc, e, &statsd.NoOpClient{})
+			dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
+
+			err = lc.Start(context.Background())
+			if err != nil {
+				fmt.Println(err.Error())
+				t.FailNow()
+			}
+
+			// undo redirect of stdout and stderr after successful init of fx
+			os.Stderr = oldErr
+			os.Stdout = oldStd
+
+		})
+		g.AfterEach(func() {
+			_ = store.Close()
+			_ = os.RemoveAll(storeLocation)
+		})
+
+		g.It("should emit changes if not in fullsync mode", func() {
+			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
+			// add one change to each entity -> 4 changes
+			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+			testSource := source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+			var tokens []source.DatasetContinuation
+			var recordedEntities []server.Entity
+			token := &source.StringDatasetContinuation{}
+			//testSource.StartFullSync()
+			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			testSource.EndFullSync()
+			g.Assert(len(recordedEntities)).Eql(4, "two entities with 2 changes each expected")
+
+			//now, modify alice and verify that we get alice emitted in next read
+			err = people.StoreEntities([]*server.Entity{
+				server.NewEntityFromMap(map[string]interface{}{
+					"id":    peoplePrefix + ":Alice",
+					"props": map[string]interface{}{"name": "Alice-changed"},
+					"refs":  map[string]interface{}{},
+				}),
+			})
+			since := tokens[len(tokens)-1]
+			tokens = []source.DatasetContinuation{}
+			recordedEntities = []server.Entity{}
+			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			g.Assert(len(recordedEntities)).Eql(1)
+			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
+		})
+
+		g.It("should emit entities (latest) if in fullsync mode", func() {
+			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
+			// add one change to each entity -> 4 changes, still 2 entities
+			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+			testSource := source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+			var tokens []source.DatasetContinuation
+			var recordedEntities []server.Entity
+			token := &source.StringDatasetContinuation{}
+			testSource.StartFullSync()
+			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			testSource.EndFullSync()
+			g.Assert(len(recordedEntities)).Eql(2, "two entities")
+
+			// changing an existing entity would not emit anything. but new entities should be emitted
+			err = people.StoreEntities([]*server.Entity{
+				server.NewEntityFromMap(map[string]interface{}{
+					"id":    peoplePrefix + ":Alice",
+					"props": map[string]interface{}{"name": "Alice-changed"},
+					"refs":  map[string]interface{}{},
+				}),
+				server.NewEntityFromMap(map[string]interface{}{
+					"id":    peoplePrefix + ":Jim",
+					"props": map[string]interface{}{"name": "Jim-new"},
+					"refs":  map[string]interface{}{},
+				}),
+			})
+			g.Assert(err).IsNil()
+			since := tokens[len(tokens)-1]
+			tokens = []source.DatasetContinuation{}
+			recordedEntities = []server.Entity{}
+			testSource.StartFullSync()
+			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			testSource.EndFullSync()
+			g.Assert(len(recordedEntities)).Eql(1)
+			g.Assert(recordedEntities[0].Properties["name"]).Eql("Jim-new")
+		})
+
+		g.It("should emit only latest changes if not in fullsync mode", func() {
+			// prime dataset with 2 entities
+			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
+			// add one change to each entity -> 4 changes
+			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+			testSource := source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm,
+				LatestOnly: true}
+			var tokens []source.DatasetContinuation
+			var recordedEntities []server.Entity
+			token := &source.StringDatasetContinuation{}
+			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			testSource.EndFullSync()
+			g.Assert(len(recordedEntities)).Eql(2, "There are 4 changes present, we expect only 2 (latest) changes emitted")
+
+			//now, modify alice and verify that we get alice emitted in next read
+			err = people.StoreEntities([]*server.Entity{
+				server.NewEntityFromMap(map[string]interface{}{
+					"id":    peoplePrefix + ":Alice",
+					"props": map[string]interface{}{"name": "Alice-changed"},
+					"refs":  map[string]interface{}{},
+				}),
+			})
+			since := tokens[len(tokens)-1]
+			tokens = []source.DatasetContinuation{}
+			recordedEntities = []server.Entity{}
+			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			g.Assert(len(recordedEntities)).Eql(1)
+			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
+		})
+
+	})
+}

--- a/internal/jobs/source/dataset_source_test.go
+++ b/internal/jobs/source/dataset_source_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source_test
 
 import (

--- a/internal/jobs/source/http_dataset_source.go
+++ b/internal/jobs/source/http_dataset_source.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source
 
 import (

--- a/internal/jobs/source/multi_source.go
+++ b/internal/jobs/source/multi_source.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source
 
 import (

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source_test
 
 import (

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -64,6 +64,8 @@ func TestMultiSource(t *testing.T) {
 
 		g.It("should emit changes in main dataset", func() {
 			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
+			// add one change to each entity -> 4 changes
+			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
 
 			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
 			var tokens []source.DatasetContinuation
@@ -79,6 +81,53 @@ func TestMultiSource(t *testing.T) {
 			})
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
+			g.Assert(len(recordedEntities)).Eql(4, "two entities with 2 changes each expected")
+
+			//now, modify alice and verify that we get alice emitted in next read
+			err = people.StoreEntities([]*server.Entity{
+				server.NewEntityFromMap(map[string]interface{}{
+					"id":    peoplePrefix + ":Alice",
+					"props": map[string]interface{}{"name": "Alice-changed"},
+					"refs":  map[string]interface{}{},
+				}),
+			})
+			since := tokens[len(tokens)-1]
+			tokens = []source.DatasetContinuation{}
+			recordedEntities = []server.Entity{}
+			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			g.Assert(len(recordedEntities)).Eql(1)
+			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
+		})
+
+		g.It("should emit only latest changes in main dataset", func() {
+			// prime dataset with 2 entities
+			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
+			// add one change to each entity -> 4 changes
+			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm,
+				LatestOnly: true}
+			var tokens []source.DatasetContinuation
+			var recordedEntities []server.Entity
+			token := &source.MultiDatasetContinuation{}
+			testSource.StartFullSync()
+			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			})
+			g.Assert(err).IsNil()
+			testSource.EndFullSync()
+			g.Assert(len(recordedEntities)).Eql(2, "There are 4 changes present, we expect only 2 (latest) changes emitted")
 
 			//now, modify alice and verify that we get alice emitted in next read
 			err = people.StoreEntities([]*server.Entity{
@@ -1007,6 +1056,24 @@ func createTestDataset(dsName string, entityNames []string, refMap map[string]ma
 
 	err = dataset.StoreEntities(entities)
 	g.Assert(err).IsNil()
+
+	return dataset, peoplePrefix
+}
+
+func addChanges(dsName string, entityNames []string, dsm *server.DsManager, store *server.Store) (*server.Dataset, string) {
+	dataset := dsm.GetDataset(dsName)
+	peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://" + dsName + "/")
+	var entities []*server.Entity
+
+	for _, entityName := range entityNames {
+		entities = append(entities, server.NewEntityFromMap(map[string]interface{}{
+			"id":    peoplePrefix + ":" + entityName,
+			"props": map[string]interface{}{"name": entityName, "changed": "true"},
+			"refs":  map[string]interface{}{},
+		}))
+	}
+
+	_ = dataset.StoreEntities(entities)
 
 	return dataset, peoplePrefix
 }

--- a/internal/jobs/source/sample_source.go
+++ b/internal/jobs/source/sample_source.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source
 
 import (

--- a/internal/jobs/source/slow_source.go
+++ b/internal/jobs/source/slow_source.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source
 
 import (

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -580,22 +580,22 @@ func TestStore(test *testing.T) {
 			g.Assert(err).IsNil()
 
 			// get changes
-			changes, err := ds.GetChanges(0, 10)
+			changes, err := ds.GetChanges(0, 10, false)
 			g.Assert(err).IsNil()
 			g.Assert(len(changes.Entities)).Eql(3)
 			g.Assert(changes.NextToken).Eql(uint64(3))
 
-			changes, err = ds.GetChanges(1, 1)
+			changes, err = ds.GetChanges(1, 1, false)
 			g.Assert(err).IsNil()
 			g.Assert(len(changes.Entities)).Eql(1)
 			g.Assert(changes.NextToken).Eql(uint64(2))
 
-			changes, err = ds.GetChanges(2, 1)
+			changes, err = ds.GetChanges(2, 1, false)
 			g.Assert(err).IsNil()
 			g.Assert(len(changes.Entities)).Eql(1)
 			g.Assert(changes.NextToken).Eql(uint64(3))
 
-			changes, _ = ds.GetChanges(3, 10)
+			changes, _ = ds.GetChanges(3, 10, false)
 			g.Assert(len(changes.Entities)).Eql(0)
 			g.Assert(changes.NextToken).Eql(uint64(3))
 		})

--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -170,7 +170,7 @@ func (handler *datasetHandler) getEntitiesHandler(c echo.Context) error {
 	}
 
 	var (
-		l    int
+		l int
 	)
 	limit := c.QueryParam("limit")
 	if limit != "" {
@@ -261,7 +261,7 @@ func (handler *datasetHandler) getChangesHandler(c echo.Context) error {
 	jsonContext, _ := json.Marshal(dataset.GetContext())
 	_, _ = c.Response().Write(jsonContext)
 
-	continuationToken, err := dataset.ProcessChangesRaw(sinceNum, l, func(jsonData []byte) error {
+	continuationToken, err := dataset.ProcessChangesRaw(sinceNum, l, false, func(jsonData []byte) error {
 		_, _ = c.Response().Write([]byte(","))
 		_, _ = c.Response().Write(jsonData)
 		return nil


### PR DESCRIPTION
when set to true, the data source will only emit changes that are the
"latest" version of the given entity. 

default remains that all changes are emitted.