### PR TITLE
reorder response writing

### DIFF
--- a/internal/jobs/source/dataset_source.go
+++ b/internal/jobs/source/dataset_source.go
@@ -63,7 +63,7 @@ func (datasetSource *DatasetSource) ReadEntities(since DatasetContinuation, batc
 				}
 				entities = append(entities, e)
 				return nil
-			})
+			}, nil)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ func (datasetSource *DatasetSource) ReadEntities(since DatasetContinuation, batc
 				}
 				entities = append(entities, e)
 				return nil
-			})
+			}, nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Once an http response is written to, it's states code cannot be changed. Introducing the `preStream` hook allows webhandlers to delay the first writing to response so that more validation can happen beforehand