### PR TITLE
ignore invalid transform emissions

### DIFF
--- a/internal/jobs/transform.go
+++ b/internal/jobs/transform.go
@@ -383,7 +383,11 @@ func (javascriptTransform *JavascriptTransform) transformEntities(runner *Runner
 	case []interface{}:
 		resultEntities = make([]*server.Entity, 0)
 		for _, e := range v {
-			resultEntities = append(resultEntities, e.(*server.Entity))
+			if entity, ok := e.(*server.Entity); ok {
+				resultEntities = append(resultEntities, entity)
+			} else {
+				javascriptTransform.Logger.Warnf("invalid transformation result, not an entity: %v", e)
+			}
 		}
 	case []*server.Entity:
 		resultEntities = v

--- a/internal/jobs/transform.go
+++ b/internal/jobs/transform.go
@@ -386,7 +386,7 @@ func (javascriptTransform *JavascriptTransform) transformEntities(runner *Runner
 			if entity, ok := e.(*server.Entity); ok {
 				resultEntities = append(resultEntities, entity)
 			} else {
-				javascriptTransform.Logger.Warnf("invalid transformation result, not an entity: %v", e)
+				return nil, fmt.Errorf("transform emitted invalid entity: %v", e)
 			}
 		}
 	case []*server.Entity:


### PR DESCRIPTION
If a transformation script in a job emits something other than Entity instances, datahub will now fail the job run with a descriptive error.