### PR TITLE
Added small change to make logs more readable when running local

### DIFF
--- a/internal/conf/logger.go
+++ b/internal/conf/logger.go
@@ -42,6 +42,7 @@ func GetLogger(env string, level zapcore.Level) *zap.SugaredLogger {
 			OutputPaths:      []string{"stderr"},
 			ErrorOutputPaths: []string{"stderr"},
 		}
+		cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		logger, _ := cfg.Build()
 		slogger = logger.Sugar()
 	default:


### PR DESCRIPTION
A Small change to the logger enables INFO, DEBUG, ERROR, WARN to be color coded and a little bit easier to read on the terminal.
