### PR TITLE
reverse listing of changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: test
 SHELL := /bin/bash
 
 build:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/PaddleHQ/go-aws-ssm v0.8.0
-	github.com/aws/aws-sdk-go v1.44.108
+	github.com/aws/aws-sdk-go v1.44.111
 	github.com/bamzi/jobrunner v1.0.0
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/dop251/goja v1.0.0
@@ -50,7 +50,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
-	github.com/labstack/gommon v0.3.1 // indirect
+	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
@@ -72,9 +72,9 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/dig v1.15.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
+	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220922195421-2adab6b8c60e // indirect
-	golang.org/x/net v0.0.0-20220927171203-f486391704dc // indirect
+	golang.org/x/net v0.0.0-20221004154528-8021a29435af // indirect
 	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/aws/aws-sdk-go v1.16.24/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.44.108 h1:L8N9GmP9UYDNqBtJO6OC4zSuEkQxAR770VkbRXAUmRk=
 github.com/aws/aws-sdk-go v1.44.108/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.111 h1:AcWfOgeedSQ4gQVwcIe6aLxpQNJMloZQyqnr7Dzki+s=
+github.com/aws/aws-sdk-go v1.44.111/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bamzi/jobrunner v1.0.0 h1:80hmOkXhj0dCeJZx+dLwGvOFLr3PVEcLYpw3+YbG1YM=
 github.com/bamzi/jobrunner v1.0.0/go.mod h1:ZNk2RGqvkuB9747EVGeyyAdCiS2VKi2KBznDLxjUu9M=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
@@ -231,6 +233,8 @@ github.com/labstack/echo/v4 v4.9.0 h1:wPOF1CE6gvt/kmbMR4dGzWvHMPT+sAEUJOwOTtvITV
 github.com/labstack/echo/v4 v4.9.0/go.mod h1:xkCDAdFCIf8jsFQ5NnbK7oqaF/yU1A1X20Ltm0OvSks=
 github.com/labstack/gommon v0.3.1 h1:OomWaJXm7xR6L1HmEtGyQf26TEn7V6X88mktX9kee9o=
 github.com/labstack/gommon v0.3.1/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
+github.com/labstack/gommon v0.4.0 h1:y7cvthEAEbU0yHOf4axH8ZG2NH8knB9iNSoTO8dyIk8=
+github.com/labstack/gommon v0.4.0/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
@@ -351,6 +355,8 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b h1:huxqepDufQpLLIRXiVkTvnxrzJlpwmIWAObmcCcUFr0=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -424,6 +430,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220927171203-f486391704dc h1:FxpXZdoBqT8RjqTy6i1E8nXHhW21wK7ptQ/EPIGxzPQ=
 golang.org/x/net v0.0.0-20220927171203-f486391704dc/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/internal/jobs/source/dataset_source.go
+++ b/internal/jobs/source/dataset_source.go
@@ -82,7 +82,7 @@ func (datasetSource *DatasetSource) ReadEntities(since DatasetContinuation, batc
 		if dataset.IsProxy() {
 			continuation, err := dataset.AsProxy(
 				datasetSource.AuthorizeProxyRequest(dataset.ProxyConfig.AuthProviderName),
-			).StreamChangesRaw(since.GetToken(), batchSize, func(jsonData []byte) error {
+			).StreamChangesRaw(since.GetToken(), batchSize, false, func(jsonData []byte) error {
 				e := &server.Entity{}
 				err := json.Unmarshal(jsonData, e)
 				if err != nil {

--- a/internal/jobs/source/union_source.go
+++ b/internal/jobs/source/union_source.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source
 
 import (

--- a/internal/jobs/source/union_source_test.go
+++ b/internal/jobs/source/union_source_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package source_test
 
 import (

--- a/internal/security/claims.go
+++ b/internal/security/claims.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package security
 
 import (

--- a/internal/security/login_provider_test.go
+++ b/internal/security/login_provider_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package security
 
 import (

--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package security
 
 import (

--- a/internal/security/manager_test.go
+++ b/internal/security/manager_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package security
 
 import (

--- a/internal/server/badger_access.go
+++ b/internal/server/badger_access.go
@@ -1,7 +1,23 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import "github.com/dgraph-io/badger/v3"
 
+// BadgerAccess implements service/store.BadgerStore and bridges badger access
+// without cyclic dependencies
 type BadgerAccess struct {
 	b   *badger.DB
 	dsm *DsManager
@@ -11,7 +27,7 @@ func (b BadgerAccess) GetDB() *badger.DB {
 	return b.b
 }
 
-func (b BadgerAccess) LookupDatasetId(datasetName string) (uint32, bool) {
+func (b BadgerAccess) LookupDatasetID(datasetName string) (uint32, bool) {
 	ds := b.dsm.GetDataset(datasetName)
 	if ds == nil {
 		return 0, false

--- a/internal/server/badger_access.go
+++ b/internal/server/badger_access.go
@@ -1,0 +1,24 @@
+package server
+
+import "github.com/dgraph-io/badger/v3"
+
+type BadgerAccess struct {
+	b   *badger.DB
+	dsm *DsManager
+}
+
+func (b BadgerAccess) GetDB() *badger.DB {
+	return b.b
+}
+
+func (b BadgerAccess) LookupDatasetId(datasetName string) (uint32, bool) {
+	ds := b.dsm.GetDataset(datasetName)
+	if ds == nil {
+		return 0, false
+	}
+	return ds.InternalID, true
+}
+
+func NewBadgerAccess(s *Store, dsm *DsManager) BadgerAccess {
+	return BadgerAccess{s.database, dsm}
+}

--- a/internal/server/proxydataset.go
+++ b/internal/server/proxydataset.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,7 +125,7 @@ func (d *ProxyDataset) StreamEntitiesRaw(from string, limit int, f func(jsonData
 // a `preStream` function can be provided if StreamChangesRaw is used in a web handler. It allows
 // to leave the http response uncommitted until `f` is called, so that an http error handler
 // still can modify status code while the response is uncommitted
-func (d *ProxyDataset) StreamChangesRaw(since string, limit int, f func(jsonData []byte) error, preStream func()) (string, error) {
+func (d *ProxyDataset) StreamChangesRaw(since string, limit int, reverse bool, f func(jsonData []byte) error, preStream func()) (string, error) {
 	uri, err := url.Parse(d.RemoteChangesUrl)
 	if err != nil {
 		return "", err
@@ -136,6 +136,9 @@ func (d *ProxyDataset) StreamChangesRaw(since string, limit int, f func(jsonData
 	}
 	if limit > 0 {
 		q.Add("limit", strconv.Itoa(limit))
+	}
+	if reverse {
+		q.Add("reverse", "true")
 	}
 	uri.RawQuery = q.Encode()
 	fullUri := uri.String()

--- a/internal/service/dataset/iterator.go
+++ b/internal/service/dataset/iterator.go
@@ -1,0 +1,151 @@
+package dataset
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/dgraph-io/badger/v3"
+
+	"github.com/mimiro-io/datahub/internal/service/store"
+)
+
+type IterableDataset interface {
+	At(since uint64) (Iterator, error)
+}
+
+type IterableBadgerDataset struct {
+	db        *badger.DB
+	datasetID uint32
+}
+type Iterator interface {
+	io.Closer
+	Inverse() Iterator
+	LatestOnly() Iterator
+	Next() bool
+	Item() []byte
+	NextOffset() uint64
+	Error() error
+}
+type BadgerDatasetIterator struct {
+	db             *badger.DB
+	err            error
+	txn            *badger.Txn
+	it             *badger.Iterator
+	datasetID      uint32
+	startingOffset uint64
+	datasetPrefix  []byte
+	item           []byte
+	offset         uint64
+	inverse        bool
+	latestOnly     bool
+}
+
+func (b *BadgerDatasetIterator) Close() error {
+	if b.txn != nil {
+		defer b.txn.Discard()
+	}
+	if b.it != nil {
+		b.it.Close()
+	}
+	return nil
+}
+
+func (b *BadgerDatasetIterator) Inverse() Iterator {
+	if b.txn != nil || b.it != nil {
+		b.Close()
+	}
+	b.inverse = true
+	if b.startingOffset == 0 {
+		b.startingOffset = uint64(18446744073709551615) //max value, 0xFF,0xFF,0xFF,0xFF
+	}
+	return b
+}
+
+func (b *BadgerDatasetIterator) LatestOnly() Iterator {
+	if b.txn != nil || b.it != nil {
+		b.Close()
+	}
+	b.latestOnly = true
+	return b
+}
+
+func (b *BadgerDatasetIterator) Next() bool {
+	err := b.ensureTxn()
+	if err != nil {
+		b.err = err
+		return false
+	}
+	if b.it.ValidForPrefix(b.datasetPrefix) {
+		item := b.it.Item()
+		k := item.Key()
+		b.offset = binary.BigEndian.Uint64(k[6:])
+		err := item.Value(func(key []byte) error {
+			entityItem, err := b.txn.Get(key)
+			if err != nil {
+				return err
+			}
+			return entityItem.Value(func(jsonVal []byte) error {
+				b.item = jsonVal
+				return nil
+			})
+		})
+		if err != nil {
+			b.err = err
+			return false
+		}
+		b.it.Next()
+		return true
+	}
+
+	return false
+}
+
+func (b *BadgerDatasetIterator) ensureTxn() error {
+	if b.txn == nil {
+		b.txn = b.db.NewTransaction(false)
+		b.datasetPrefix = store.SeekDataset(b.datasetID)
+		opts := badger.DefaultIteratorOptions
+		searchBuffer := store.SeekChanges(b.datasetID, b.startingOffset)
+		if b.inverse {
+			opts.Reverse = true
+		}
+		b.it = b.txn.NewIterator(opts)
+		b.it.Seek(searchBuffer)
+	}
+	return nil
+}
+
+func (b *BadgerDatasetIterator) Item() []byte {
+	return b.item
+}
+
+func (b *BadgerDatasetIterator) NextOffset() uint64 {
+	if b.item == nil {
+		return b.startingOffset
+	}
+	if b.inverse {
+		return b.offset
+	}
+	return b.offset + 1
+}
+
+func (b *BadgerDatasetIterator) Error() error {
+	return b.err
+}
+
+func (d IterableBadgerDataset) At(since uint64) (Iterator, error) {
+	return &BadgerDatasetIterator{
+		db:             d.db,
+		datasetID:      d.datasetID,
+		startingOffset: since,
+	}, nil
+}
+
+func Of(store store.BadgerStore, datasetName string) (IterableDataset, error) {
+	id, b := store.LookupDatasetId(datasetName)
+	if b {
+		return IterableBadgerDataset{store.GetDB(), id}, nil
+	}
+	return nil, fmt.Errorf("dataset %v not found", datasetName)
+}

--- a/internal/service/dataset/iterator.go
+++ b/internal/service/dataset/iterator.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dataset
 
 import (
@@ -57,7 +71,7 @@ func (b *BadgerDatasetIterator) Inverse() Iterator {
 	}
 	b.inverse = true
 	if b.startingOffset == 0 {
-		b.startingOffset = uint64(18446744073709551615) //max value, 0xFF,0xFF,0xFF,0xFF
+		b.startingOffset = uint64(18446744073709551615) // max value, 0xFF,0xFF,0xFF,0xFF
 	}
 	return b
 }
@@ -143,7 +157,7 @@ func (d IterableBadgerDataset) At(since uint64) (Iterator, error) {
 }
 
 func Of(store store.BadgerStore, datasetName string) (IterableDataset, error) {
-	id, b := store.LookupDatasetId(datasetName)
+	id, b := store.LookupDatasetID(datasetName)
 	if b {
 		return IterableBadgerDataset{store.GetDB(), id}, nil
 	}

--- a/internal/service/dataset/iterator_benchmark_test.go
+++ b/internal/service/dataset/iterator_benchmark_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dataset_test
 
 import (

--- a/internal/service/dataset/iterator_benchmark_test.go
+++ b/internal/service/dataset/iterator_benchmark_test.go
@@ -1,0 +1,75 @@
+package dataset_test
+
+import (
+	"context"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/server"
+	ds "github.com/mimiro-io/datahub/internal/service/dataset"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkChangesIterator(b *testing.B) {
+	storeLocation := "./test_store_iterator_bench_2"
+	dataset, store, dsm, after := setup(storeLocation, b)
+	defer after()
+	ds, _ := ds.Of(server.NewBadgerAccess(store, dsm), dataset.ID)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for no := 0; no < b.N; no++ {
+		c := 0
+		//b.Log("run")
+		it, _ := ds.At(0)
+		for it.Next() {
+			c += len(it.Item())
+		}
+		it.Close()
+		//b.Log(c)
+		//b.Logf("found %v", raw)
+	}
+}
+func BenchmarkGetChanges(b *testing.B) {
+	storeLocation := "./test_store_iterator_bench_1"
+	dataset, _, _, after := setup(storeLocation, b)
+	defer after()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for no := 0; no < b.N; no++ {
+		//b.Log("run")
+		c := 0
+		_, err := dataset.ProcessChangesRaw(0, 10000, false, func(jsonData []byte) error {
+			c += len(jsonData)
+			return nil
+		})
+		if err != nil {
+			panic(err)
+		}
+		//b.Logf("found %v", raw)
+		//b.Log(c)
+	}
+}
+
+func setup(storeLocation string, b *testing.B) (*server.Dataset, *server.Store, *server.DsManager, func()) {
+	lc := fxtest.NewLifecycle(internal.FxTestLog(b, false))
+	env := &conf.Env{
+		Logger:        zap.NewNop().Sugar(),
+		StoreLocation: storeLocation,
+	}
+	store := server.NewStore(lc, env, &statsd.NoOpClient{})
+	dsm := server.NewDsManager(lc, env, store, server.NoOpBus())
+	lc.Start(context.Background())
+
+	ds0, _ := dsm.CreateDataset("arabic", nil)
+	for i := 1; i < 5000; i++ {
+		ds0.StoreEntities([]*server.Entity{server.NewEntity(strconv.Itoa(i), 0)})
+	}
+	return ds0, store, dsm, func() {
+		lc.Stop(context.Background())
+		os.RemoveAll(storeLocation)
+	}
+}

--- a/internal/service/dataset/iterator_test.go
+++ b/internal/service/dataset/iterator_test.go
@@ -1,0 +1,234 @@
+package dataset_test
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/franela/goblin"
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/server"
+	ds "github.com/mimiro-io/datahub/internal/service/dataset"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDatasetIterator(t *testing.T) {
+	g := goblin.Goblin(t)
+	g.Describe("A dataset iterator", func() {
+		storeLocation := "./test_service_dataset_iterator"
+		var lc *fxtest.Lifecycle
+		var dsm *server.DsManager
+		var ds0 *server.Dataset
+		var ds1 *server.Dataset
+		var ds2 *server.Dataset
+		var store *server.Store
+		g.Before(func() {
+			os.RemoveAll(storeLocation)
+			lc = fxtest.NewLifecycle(internal.FxTestLog(t, false))
+			env := &conf.Env{
+				Logger:        zap.NewNop().Sugar(),
+				StoreLocation: storeLocation,
+			}
+			store = server.NewStore(lc, env, &statsd.NoOpClient{})
+			dsm = server.NewDsManager(lc, env, store, server.NoOpBus())
+			lc.Start(context.Background())
+
+			ds0, _ = dsm.CreateDataset("arabic", nil)
+			ds0.StoreEntities([]*server.Entity{
+				server.NewEntity("1", 0),
+				server.NewEntity("2", 0),
+				server.NewEntity("3", 0),
+				server.NewEntity("4", 0),
+			})
+			ds1, _ = dsm.CreateDataset("roman", nil)
+			ds1.StoreEntities([]*server.Entity{
+				server.NewEntity("I", 0),
+				server.NewEntity("II", 0),
+				server.NewEntity("III", 0),
+				server.NewEntity("IV", 0),
+			})
+			ds2, _ = dsm.CreateDataset("letters", nil)
+			ds2.StoreEntities([]*server.Entity{
+				server.NewEntity("a", 0),
+				server.NewEntity("b", 0),
+				server.NewEntity("c", 0),
+				server.NewEntity("d", 0),
+			})
+		})
+		g.After(func() {
+			lc.Stop(context.Background())
+			os.RemoveAll(storeLocation)
+
+		})
+		g.It("should be able to create a 0 offset", func() {
+			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+			g.Assert(err).IsNil()
+			it, err := dataset.At(0)
+			g.Assert(err).IsNil()
+			g.Assert(it.Error()).IsNil()
+			var continuationToken uint64 = 0
+			var foundIds []string
+			for it.Next() {
+				jsonData := it.Item()
+				e := server.Entity{}
+				err := json.Unmarshal(jsonData, &e)
+				g.Assert(err).IsNil()
+				foundIds = append(foundIds, e.ID)
+				continuationToken = it.NextOffset()
+			}
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(foundIds).Equal([]string{"I", "II", "III", "IV"})
+			g.Assert(continuationToken).Equal(uint64(4))
+		})
+		g.It("should be able to create a 3 offset", func() {
+			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+			g.Assert(err).IsNil()
+			it, err := dataset.At(3)
+			g.Assert(err).IsNil()
+			g.Assert(it.Error()).IsNil()
+			var continuationToken uint64 = 0
+			var foundIds []string
+			for it.Next() {
+				jsonData := it.Item()
+				e := server.Entity{}
+				err := json.Unmarshal(jsonData, &e)
+				g.Assert(err).IsNil()
+				foundIds = append(foundIds, e.ID)
+				continuationToken = it.NextOffset()
+			}
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(foundIds).Equal([]string{"IV"})
+			g.Assert(continuationToken).Equal(uint64(4))
+		})
+		g.It("should produce correct nextOffsets", func() {
+			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+			g.Assert(err).IsNil()
+			it, err := dataset.At(0)
+			g.Assert(err).IsNil()
+			g.Assert(it.Error()).IsNil()
+			var continuationToken uint64 = 0
+			var foundIds []string
+			for it.Next() {
+				jsonData := it.Item()
+				e := server.Entity{}
+				err := json.Unmarshal(jsonData, &e)
+				g.Assert(err).IsNil()
+				foundIds = append(foundIds, e.ID)
+				continuationToken = it.NextOffset()
+				if len(foundIds) == 2 {
+					break
+				}
+			}
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(foundIds).Equal([]string{"I", "II"})
+			g.Assert(continuationToken).Equal(uint64(2))
+
+			it, err = dataset.At(continuationToken)
+			foundIds = []string{}
+			for it.Next() {
+				jsonData := it.Item()
+				e := server.Entity{}
+				err := json.Unmarshal(jsonData, &e)
+				g.Assert(err).IsNil()
+				foundIds = append(foundIds, e.ID)
+				continuationToken = it.NextOffset()
+			}
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(foundIds).Equal([]string{"III", "IV"})
+			g.Assert(continuationToken).Equal(uint64(4))
+		})
+		g.It("should be able to create a 4 offset", func() {
+			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+			g.Assert(err).IsNil()
+			it, err := dataset.At(4)
+			g.Assert(err).IsNil()
+			g.Assert(it.Next()).IsFalse("nothing found")
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(it.NextOffset()).Equal(uint64(4))
+		})
+		g.It("should not fail for too large offset, but emit nothing", func() {
+			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+			g.Assert(err).IsNil()
+			it, err := dataset.At(5)
+			g.Assert(err).IsNil()
+			g.Assert(it.Next()).IsFalse("nothing found")
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(it.NextOffset()).Equal(uint64(5))
+		})
+		g.It("should list inverse changes from 0", func() {
+			g.Timeout(1 * time.Hour)
+			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+			g.Assert(err).IsNil()
+			it, err := dataset.At(0)
+			g.Assert(err).IsNil()
+			it = it.Inverse()
+			g.Assert(it.Error()).IsNil()
+			var continuationToken uint64 = 0
+			var foundIds []string
+			for it.Next() {
+				jsonData := it.Item()
+				e := server.Entity{}
+				err := json.Unmarshal(jsonData, &e)
+				g.Assert(err).IsNil()
+				foundIds = append(foundIds, e.ID)
+				continuationToken = it.NextOffset()
+			}
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(foundIds).Equal([]string{"IV", "III", "II", "I"})
+			g.Assert(continuationToken).Equal(uint64(0))
+		})
+		g.It("should produce correct inverse nextOffsets", func() {
+			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+			g.Assert(err).IsNil()
+			it, err := dataset.At(0)
+			it = it.Inverse()
+			g.Assert(err).IsNil()
+			g.Assert(it.Error()).IsNil()
+			var continuationToken uint64 = 0
+			var foundIds []string
+			for it.Next() {
+				jsonData := it.Item()
+				e := server.Entity{}
+				err := json.Unmarshal(jsonData, &e)
+				g.Assert(err).IsNil()
+				foundIds = append(foundIds, e.ID)
+				continuationToken = it.NextOffset()
+				if len(foundIds) == 2 {
+					break
+				}
+			}
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(foundIds).Equal([]string{"IV", "III"})
+			g.Assert(continuationToken).Equal(uint64(2))
+
+			it, err = dataset.At(continuationToken)
+			it = it.Inverse()
+			foundIds = []string{}
+			for it.Next() {
+				jsonData := it.Item()
+				e := server.Entity{}
+				err := json.Unmarshal(jsonData, &e)
+				g.Assert(err).IsNil()
+				foundIds = append(foundIds, e.ID)
+				continuationToken = it.NextOffset()
+			}
+			it.Close()
+			g.Assert(it.Error()).IsNil()
+			g.Assert(foundIds).Equal([]string{"II", "I"})
+			g.Assert(continuationToken).Equal(uint64(0))
+		})
+
+	})
+}

--- a/internal/service/dataset/iterator_test.go
+++ b/internal/service/dataset/iterator_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dataset_test
 
 import (

--- a/internal/service/store/badger.go
+++ b/internal/service/store/badger.go
@@ -1,8 +1,22 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package store
 
 import "github.com/dgraph-io/badger/v3"
 
 type BadgerStore interface {
 	GetDB() *badger.DB
-	LookupDatasetId(datasetName string) (uint32, bool)
+	LookupDatasetID(datasetName string) (uint32, bool)
 }

--- a/internal/service/store/badger.go
+++ b/internal/service/store/badger.go
@@ -1,0 +1,8 @@
+package store
+
+import "github.com/dgraph-io/badger/v3"
+
+type BadgerStore interface {
+	GetDB() *badger.DB
+	LookupDatasetId(datasetName string) (uint32, bool)
+}

--- a/internal/service/store/idx_keys.go
+++ b/internal/service/store/idx_keys.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package store
 
 import (

--- a/internal/service/store/idx_keys.go
+++ b/internal/service/store/idx_keys.go
@@ -1,0 +1,22 @@
+package store
+
+import (
+	"encoding/binary"
+
+	"github.com/mimiro-io/datahub/internal/server"
+)
+
+func SeekChanges(datasetID uint32, since uint64) []byte {
+	searchBuffer := make([]byte, 14)
+	binary.BigEndian.PutUint16(searchBuffer, server.DATASET_ENTITY_CHANGE_LOG)
+	binary.BigEndian.PutUint32(searchBuffer[2:], datasetID)
+	binary.BigEndian.PutUint64(searchBuffer[6:], since)
+	return searchBuffer
+}
+
+func SeekDataset(datasetID uint32) []byte {
+	searchBuffer := make([]byte, 6)
+	binary.BigEndian.PutUint16(searchBuffer, server.DATASET_ENTITY_CHANGE_LOG)
+	binary.BigEndian.PutUint32(searchBuffer[2:], datasetID)
+	return searchBuffer
+}

--- a/internal/testutil.go
+++ b/internal/testutil.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import "testing"

--- a/internal/testutil.go
+++ b/internal/testutil.go
@@ -3,7 +3,7 @@ package internal
 import "testing"
 
 type FxLogger struct {
-	t      *testing.T
+	t      testing.TB
 	active bool
 }
 
@@ -20,6 +20,6 @@ func (l *FxLogger) Logf(f string, a ...interface{}) {
 		l.t.Logf(f, a...)
 	}
 }
-func FxTestLog(t *testing.T, active bool) *FxLogger {
+func FxTestLog(t testing.TB, active bool) *FxLogger {
 	return &FxLogger{t: t, active: active}
 }

--- a/internal/web/securityhandler.go
+++ b/internal/web/securityhandler.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package web
 
 import (

--- a/security_integration_test.go
+++ b/security_integration_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package datahub
 
 import (


### PR DESCRIPTION
This change introduces the ability to list dataset changes in reverse order. 

closes issue #161. only partially (changes only, not entities)