### PR TITLE
add id-query flag "details"

### DIFF
--- a/app.go
+++ b/app.go
@@ -16,6 +16,8 @@ package datahub
 
 import (
 	"context"
+	"time"
+
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/conf/secrets"
 	"github.com/mimiro-io/datahub/internal/content"
@@ -24,7 +26,6 @@ import (
 	"github.com/mimiro-io/datahub/internal/server"
 	"github.com/mimiro-io/datahub/internal/web"
 	"go.uber.org/fx"
-	"time"
 )
 
 func wire() *fx.App {

--- a/internal/service/dataset/iterator_test.go
+++ b/internal/service/dataset/iterator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/server"
 	ds "github.com/mimiro-io/datahub/internal/service/dataset"
+	"github.com/mimiro-io/datahub/internal/service/types"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 	"os"
@@ -84,7 +85,7 @@ func TestDatasetIterator(t *testing.T) {
 			it, err := dataset.At(0)
 			g.Assert(err).IsNil()
 			g.Assert(it.Error()).IsNil()
-			var continuationToken uint64 = 0
+			var continuationToken types.DatasetOffset = 0
 			var foundIds []string
 			for it.Next() {
 				jsonData := it.Item()
@@ -97,7 +98,7 @@ func TestDatasetIterator(t *testing.T) {
 			it.Close()
 			g.Assert(it.Error()).IsNil()
 			g.Assert(foundIds).Equal([]string{"I", "II", "III", "IV"})
-			g.Assert(continuationToken).Equal(uint64(4))
+			g.Assert(continuationToken).Equal(types.DatasetOffset(4))
 		})
 		g.It("should be able to create a 3 offset", func() {
 			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
@@ -105,7 +106,7 @@ func TestDatasetIterator(t *testing.T) {
 			it, err := dataset.At(3)
 			g.Assert(err).IsNil()
 			g.Assert(it.Error()).IsNil()
-			var continuationToken uint64 = 0
+			var continuationToken types.DatasetOffset = 0
 			var foundIds []string
 			for it.Next() {
 				jsonData := it.Item()
@@ -118,7 +119,7 @@ func TestDatasetIterator(t *testing.T) {
 			it.Close()
 			g.Assert(it.Error()).IsNil()
 			g.Assert(foundIds).Equal([]string{"IV"})
-			g.Assert(continuationToken).Equal(uint64(4))
+			g.Assert(continuationToken).Equal(types.DatasetOffset(4))
 		})
 		g.It("should produce correct nextOffsets", func() {
 			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
@@ -126,7 +127,7 @@ func TestDatasetIterator(t *testing.T) {
 			it, err := dataset.At(0)
 			g.Assert(err).IsNil()
 			g.Assert(it.Error()).IsNil()
-			var continuationToken uint64 = 0
+			var continuationToken types.DatasetOffset = 0
 			var foundIds []string
 			for it.Next() {
 				jsonData := it.Item()
@@ -142,7 +143,7 @@ func TestDatasetIterator(t *testing.T) {
 			it.Close()
 			g.Assert(it.Error()).IsNil()
 			g.Assert(foundIds).Equal([]string{"I", "II"})
-			g.Assert(continuationToken).Equal(uint64(2))
+			g.Assert(continuationToken).Equal(types.DatasetOffset(2))
 
 			it, err = dataset.At(continuationToken)
 			foundIds = []string{}
@@ -157,7 +158,7 @@ func TestDatasetIterator(t *testing.T) {
 			it.Close()
 			g.Assert(it.Error()).IsNil()
 			g.Assert(foundIds).Equal([]string{"III", "IV"})
-			g.Assert(continuationToken).Equal(uint64(4))
+			g.Assert(continuationToken).Equal(types.DatasetOffset(4))
 		})
 		g.It("should be able to create a 4 offset", func() {
 			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
@@ -167,7 +168,7 @@ func TestDatasetIterator(t *testing.T) {
 			g.Assert(it.Next()).IsFalse("nothing found")
 			it.Close()
 			g.Assert(it.Error()).IsNil()
-			g.Assert(it.NextOffset()).Equal(uint64(4))
+			g.Assert(it.NextOffset()).Equal(types.DatasetOffset(4))
 		})
 		g.It("should not fail for too large offset, but emit nothing", func() {
 			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
@@ -177,7 +178,7 @@ func TestDatasetIterator(t *testing.T) {
 			g.Assert(it.Next()).IsFalse("nothing found")
 			it.Close()
 			g.Assert(it.Error()).IsNil()
-			g.Assert(it.NextOffset()).Equal(uint64(5))
+			g.Assert(it.NextOffset()).Equal(types.DatasetOffset(5))
 		})
 		g.It("should list inverse changes from 0", func() {
 			g.Timeout(1 * time.Hour)
@@ -187,7 +188,7 @@ func TestDatasetIterator(t *testing.T) {
 			g.Assert(err).IsNil()
 			it = it.Inverse()
 			g.Assert(it.Error()).IsNil()
-			var continuationToken uint64 = 0
+			var continuationToken types.DatasetOffset = 0
 			var foundIds []string
 			for it.Next() {
 				jsonData := it.Item()
@@ -200,7 +201,7 @@ func TestDatasetIterator(t *testing.T) {
 			it.Close()
 			g.Assert(it.Error()).IsNil()
 			g.Assert(foundIds).Equal([]string{"IV", "III", "II", "I"})
-			g.Assert(continuationToken).Equal(uint64(0))
+			g.Assert(continuationToken).Equal(types.DatasetOffset(0))
 		})
 		g.It("should produce correct inverse nextOffsets", func() {
 			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
@@ -209,7 +210,7 @@ func TestDatasetIterator(t *testing.T) {
 			it = it.Inverse()
 			g.Assert(err).IsNil()
 			g.Assert(it.Error()).IsNil()
-			var continuationToken uint64 = 0
+			var continuationToken types.DatasetOffset = 0
 			var foundIds []string
 			for it.Next() {
 				jsonData := it.Item()
@@ -225,7 +226,7 @@ func TestDatasetIterator(t *testing.T) {
 			it.Close()
 			g.Assert(it.Error()).IsNil()
 			g.Assert(foundIds).Equal([]string{"IV", "III"})
-			g.Assert(continuationToken).Equal(uint64(2))
+			g.Assert(continuationToken).Equal(types.DatasetOffset(2))
 
 			it, err = dataset.At(continuationToken)
 			it = it.Inverse()
@@ -241,7 +242,7 @@ func TestDatasetIterator(t *testing.T) {
 			it.Close()
 			g.Assert(it.Error()).IsNil()
 			g.Assert(foundIds).Equal([]string{"II", "I"})
-			g.Assert(continuationToken).Equal(uint64(0))
+			g.Assert(continuationToken).Equal(types.DatasetOffset(0))
 		})
 
 	})

--- a/internal/service/entity/details.go
+++ b/internal/service/entity/details.go
@@ -19,6 +19,29 @@ func NewLookup(s store.BadgerStore) (Lookup, error) {
 	return Lookup{s, ns}, nil
 }
 
+// Details retrieves a nested map structure with information about all datasets that contain entities with the given entity ID
+// The optional datasetNames parameter allows to narrow down in which datasets the function searches
+//
+// The result map has the following shape
+// ```
+//
+//	{
+//	    "dataset1": {
+//	        "changes": [
+//	            "{\"id\":\"ns3:3\",\"internalId\":8,\"recorded\":1662648998417816245,\"refs\":{},\"props\":{\"ns3:name\":\"Frank\"}}"
+//	        ],
+//	        "latest": "{\"id\":\"ns3:3\",\"internalId\":8,\"recorded\":1662648998417816245,\"refs\":{},\"props\":{\"ns3:name\":\"Frank\"}}"
+//	    },
+//	    "dataset2": {
+//	        "changes": [
+//	            "{\"id\":\"ns3:3\",\"internalId\":8,\"recorded\":1663074960494865060,\"refs\":{},\"props\":{\"ns3:name\":\"Frank\"}}",
+//	            "{\"id\":\"ns3:3\",\"internalId\":8,\"recorded\":1663075373488961084,\"refs\":{},\"props\":{\"ns3:name\":\"Frank\",\"ns4:extra\":{\"refs\":{},\"props\":{}}}}"
+//	        ],
+//	        "latest": "{\"id\":\"ns3:3\",\"internalId\":8,\"recorded\":1663075373488961084,\"refs\":{},\"props\":{\"ns3:name\":\"Frank\",\"ns4:extra\":{\"refs\":{},\"props\":{}}}}"
+//	    },
+//	}
+//
+// ```
 func (l Lookup) Details(id string, datasetNames []string) (map[string]interface{}, error) {
 	curie, err := l.asCURIE(id)
 	if err != nil {
@@ -43,13 +66,6 @@ func (l Lookup) Details(id string, datasetNames []string) (map[string]interface{
 
 func (l Lookup) loadDetails(rtxn *badger.Txn, internalEntityId types.InternalID, scope []types.InternalDatasetID) (map[string]interface{}, error) {
 	result := map[string]interface{}{}
-	/*
-		binary.BigEndian.PutUint16(entityIdBuffer, ENTITY_ID_TO_JSON_INDEX_ID)
-		binary.BigEndian.PutUint64(entityIdBuffer[2:], rid)
-		binary.BigEndian.PutUint32(entityIdBuffer[10:], ds.InternalID)
-		binary.BigEndian.PutUint64(entityIdBuffer[14:], uint64(txnTime))
-		binary.BigEndian.PutUint16(entityIdBuffer[22:], uint16(jsonLength))
-	*/
 
 	opts1 := badger.DefaultIteratorOptions
 	opts1.PrefetchValues = false

--- a/internal/service/entity/details.go
+++ b/internal/service/entity/details.go
@@ -19,11 +19,11 @@ func NewLookup(s store.BadgerStore) (Lookup, error) {
 	return Lookup{s, ns}, nil
 }
 
-// Details retrieves a nested map structure with information about all datasets that contain entities with the given entity ID
+//Details retrieves a nested map structure with information about all datasets that contain entities with the given entity ID
 // The optional datasetNames parameter allows to narrow down in which datasets the function searches
 //
 // The result map has the following shape
-// ```
+//
 //
 //	{
 //	    "dataset1": {
@@ -41,7 +41,6 @@ func NewLookup(s store.BadgerStore) (Lookup, error) {
 //	    },
 //	}
 //
-// ```
 func (l Lookup) Details(id string, datasetNames []string) (map[string]interface{}, error) {
 	curie, err := l.asCURIE(id)
 	if err != nil {

--- a/internal/service/entity/details.go
+++ b/internal/service/entity/details.go
@@ -1,0 +1,133 @@
+package entity
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/dgraph-io/badger/v3"
+	"github.com/mimiro-io/datahub/internal/service/namespace"
+	"github.com/mimiro-io/datahub/internal/service/store"
+	"github.com/mimiro-io/datahub/internal/service/types"
+)
+
+type Lookup struct {
+	badger     store.BadgerStore
+	namespaces namespace.Manager
+}
+
+func NewLookup(s store.BadgerStore) (Lookup, error) {
+	ns := namespace.NewManager(s)
+	return Lookup{s, ns}, nil
+}
+
+func (l Lookup) Details(id string, datasetNames []string) (map[string]interface{}, error) {
+	curie, err := l.asCURIE(id)
+	if err != nil {
+		return nil, err
+	}
+	b := l.badger.GetDB()
+
+	rtxn := b.NewTransaction(false)
+	defer rtxn.Discard()
+	internalId, err := l.internalIdForCURIE(rtxn, curie)
+	if err != nil {
+		return nil, err
+	}
+
+	scope := l.badger.LookupDatasetIDs(datasetNames)
+	details, err := l.loadDetails(rtxn, internalId, scope)
+	if err != nil {
+		return nil, err
+	}
+	return details, nil
+}
+
+func (l Lookup) loadDetails(rtxn *badger.Txn, internalEntityId types.InternalID, scope []types.InternalDatasetID) (map[string]interface{}, error) {
+	result := map[string]interface{}{}
+	/*
+		binary.BigEndian.PutUint16(entityIdBuffer, ENTITY_ID_TO_JSON_INDEX_ID)
+		binary.BigEndian.PutUint64(entityIdBuffer[2:], rid)
+		binary.BigEndian.PutUint32(entityIdBuffer[10:], ds.InternalID)
+		binary.BigEndian.PutUint64(entityIdBuffer[14:], uint64(txnTime))
+		binary.BigEndian.PutUint16(entityIdBuffer[22:], uint16(jsonLength))
+	*/
+
+	opts1 := badger.DefaultIteratorOptions
+	opts1.PrefetchValues = false
+	entityLocatorIterator := rtxn.NewIterator(opts1)
+	defer entityLocatorIterator.Close()
+
+	entityLocatorPrefixBuffer := store.SeekEntity(internalEntityId)
+
+	var prevValueBytes []byte
+	var previousDatasetId types.InternalDatasetID = 0
+	var currentDatasetId types.InternalDatasetID = 0
+	partials := map[types.InternalDatasetID][]byte{}
+	for entityLocatorIterator.Seek(entityLocatorPrefixBuffer); entityLocatorIterator.ValidForPrefix(entityLocatorPrefixBuffer); entityLocatorIterator.Next() {
+		item := entityLocatorIterator.Item()
+		key := item.Key()
+
+		currentDatasetId = types.InternalDatasetID(binary.BigEndian.Uint32(key[10:]))
+
+		// check if dataset has been deleted, or must be excluded
+		datasetDeleted := l.badger.IsDatasetDeleted(currentDatasetId)
+		datasetIncluded := len(scope) == 0 // no specified datasets means no restriction - all datasets are allowed
+		if !datasetIncluded {
+			for _, id := range scope {
+				if id == currentDatasetId {
+					datasetIncluded = true
+					break
+				}
+			}
+		}
+		if datasetDeleted || !datasetIncluded {
+			continue
+		}
+
+		if previousDatasetId != 0 {
+			if currentDatasetId != previousDatasetId {
+				partials[previousDatasetId] = prevValueBytes
+			}
+		}
+
+		previousDatasetId = currentDatasetId
+
+		// fixme: pre alloc big ish buffer once and use value size
+		prevValueBytes, _ = item.ValueCopy(nil)
+	}
+
+	if previousDatasetId != 0 {
+		partials[previousDatasetId] = prevValueBytes
+	}
+
+	for internalDatasetId, entityBytes := range partials {
+		n, ok := l.badger.LookupDatasetName(internalDatasetId)
+		if !ok {
+			result[fmt.Sprintf("%v", internalDatasetId)] = "UNEXPECTED: dataset name not found"
+		} else {
+			result[n] = map[string]interface{}{
+				"latest":  string(entityBytes),
+				"changes": l.loadChanges(rtxn, internalEntityId, internalDatasetId),
+			}
+		}
+	}
+	return result, nil
+
+}
+
+func (l Lookup) loadChanges(rtxn *badger.Txn, internalEntityID types.InternalID, internalDatasetID types.InternalDatasetID) []string {
+	seekPrefix := store.SeekEntityChanges(internalDatasetID, internalEntityID)
+	iteratorOptions := badger.DefaultIteratorOptions
+	iteratorOptions.PrefetchValues = true
+	iteratorOptions.PrefetchSize = 1
+	iteratorOptions.Prefix = seekPrefix
+	entityChangesIterator := rtxn.NewIterator(iteratorOptions)
+	defer entityChangesIterator.Close()
+
+	result := make([]string, 0)
+	for entityChangesIterator.Rewind(); entityChangesIterator.ValidForPrefix(seekPrefix); entityChangesIterator.Next() {
+		item := entityChangesIterator.Item()
+		change, _ := item.ValueCopy(nil)
+		result = append(result, string(change))
+	}
+	return result
+}

--- a/internal/service/entity/ids.go
+++ b/internal/service/entity/ids.go
@@ -1,0 +1,50 @@
+package entity
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/dgraph-io/badger/v3"
+	"github.com/mimiro-io/datahub/internal/service/store"
+	"github.com/mimiro-io/datahub/internal/service/types"
+	"github.com/pkg/errors"
+)
+
+func (l Lookup) asCURIE(id string) (types.CURIE, error) {
+
+	if prefix, ok := l.namespaces.ExtractPrefix(id); ok {
+		if _, err := l.namespaces.ExpandPrefix(prefix); err == nil {
+			return types.CURIE(id), nil
+		} else {
+			return "", err
+		}
+	}
+	if nsUri, localValue, ok := l.namespaces.ExtractNamespaceURI(id); ok {
+		if prefix, err := l.namespaces.GetNamespacePrefix(nsUri); err == nil {
+			return types.CURIE(fmt.Sprintf("%v:%v", prefix, localValue)), nil
+		} else {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("input %v is neither in CURIE format (prefix:value) nor a URI")
+}
+
+func (l Lookup) internalIdForCURIE(txn *badger.Txn, curie types.CURIE) (types.InternalID, error) {
+	var rid uint64
+
+	// check if it exists already uri => id
+	item, err := txn.Get(store.GetCurieKey(curie))
+	if err != nil {
+		return 0, errors.WithMessagef(err, "could not load internal id for curie: %v", curie)
+	} else {
+		err := item.Value(func(val []byte) error {
+			rid = binary.BigEndian.Uint64(val)
+			return nil
+		})
+
+		if err != nil {
+			return 0, errors.WithMessagef(err, "could not process found interalId for curie: %v", curie)
+		}
+	}
+
+	return types.InternalID(rid), nil
+}

--- a/internal/service/entity/ids.go
+++ b/internal/service/entity/ids.go
@@ -7,11 +7,12 @@ import (
 	"github.com/mimiro-io/datahub/internal/service/store"
 	"github.com/mimiro-io/datahub/internal/service/types"
 	"github.com/pkg/errors"
+	"strings"
 )
 
 func (l Lookup) asCURIE(id string) (types.CURIE, error) {
 
-	if prefix, ok := l.namespaces.ExtractPrefix(id); ok {
+	if prefix, ok := l.namespaces.ExtractPrefix(id); ok && !strings.HasPrefix(id, "http") {
 		if _, err := l.namespaces.ExpandPrefix(prefix); err == nil {
 			return types.CURIE(id), nil
 		} else {
@@ -25,7 +26,7 @@ func (l Lookup) asCURIE(id string) (types.CURIE, error) {
 			return "", err
 		}
 	}
-	return "", fmt.Errorf("input %v is neither in CURIE format (prefix:value) nor a URI")
+	return "", fmt.Errorf("input %v is neither in CURIE format (prefix:value) nor a URI", id)
 }
 
 func (l Lookup) internalIdForCURIE(txn *badger.Txn, curie types.CURIE) (types.InternalID, error) {

--- a/internal/service/entity/ids_test.go
+++ b/internal/service/entity/ids_test.go
@@ -1,0 +1,66 @@
+package entity
+
+import (
+	"errors"
+	"github.com/franela/goblin"
+	"github.com/mimiro-io/datahub/internal/service/namespace"
+	"github.com/mimiro-io/datahub/internal/service/types"
+	"testing"
+)
+
+type nsMock struct{}
+
+func (n nsMock) LookupNamespaceExpansion(prefix types.Prefix) (types.URI, error) {
+	if "foo" == prefix {
+		return "http://foo", nil
+	}
+	return "", errors.New("unknown prefix")
+}
+
+func (n nsMock) LookupExpansionPrefix(input types.URI) (types.Prefix, error) {
+	if input == "http://foo" {
+		return "foo", nil
+	}
+
+	return "", errors.New("unknown namespace")
+}
+
+func TestLookup_asCURIE(t *testing.T) {
+	mockNamespaces := namespace.NewManager(nsMock{})
+	g := goblin.Goblin(t)
+	g.Describe("asCURIE", func() {
+		g.It("should return curie for valid curie string", func() {
+			res, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo:bar")
+			g.Assert(err).IsNil()
+			g.Assert(res).Equal(types.CURIE("foo:bar"))
+		})
+		g.It("should fail valid curie string with unknown prefix", func() {
+			_, err := Lookup{namespaces: mockNamespaces}.asCURIE("hello:world")
+			g.Assert(err).IsNotNil()
+			g.Assert(err.Error()).Equal("unknown prefix")
+		})
+		g.It("should return for curie with prefix only", func() {
+			res, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo:")
+			g.Assert(err).IsNil()
+			g.Assert(res).Equal(types.CURIE("foo:"))
+		})
+		g.It("should fail simple string", func() {
+			_, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo")
+			g.Assert(err).IsNotNil()
+			g.Assert(err.Error()).Equal("input foo is neither in CURIE format (prefix:value) nor a URI")
+		})
+		g.It("should return curie for uri with known namespace", func() {
+			res, err := Lookup{namespaces: mockNamespaces}.asCURIE("http://foo/bar")
+			g.Assert(err).IsNil()
+			g.Assert(res).Equal(types.CURIE("foo:bar"))
+		})
+		g.It("should fail valid uri string with unknown namespace", func() {
+			_, err := Lookup{namespaces: mockNamespaces}.asCURIE("http://hello/world")
+			g.Assert(err).IsNotNil()
+			g.Assert(err.Error()).Equal("unknown namespace")
+		})
+	})
+}
+
+func TestLookup_internalIdForCURIE(t *testing.T) {
+}

--- a/internal/service/namespace/manager.go
+++ b/internal/service/namespace/manager.go
@@ -22,7 +22,7 @@ type (
 	}
 
 	BadgerManager struct {
-		store store.BadgerStore
+		store store.LegacyNamespaceAccess
 	}
 )
 
@@ -42,7 +42,7 @@ func (m BadgerManager) ExtractNamespaceURI(input string) (types.URI, string, boo
 	if strings.HasPrefix(input, "http") {
 		cutPosition := strings.LastIndex(input, "/")
 		ns := input[:cutPosition]
-		value := input[cutPosition:]
+		value := input[cutPosition+1:]
 		return types.URI(ns), value, true
 	}
 	return "", "", false
@@ -52,6 +52,6 @@ func (m BadgerManager) GetNamespacePrefix(input types.URI) (types.Prefix, error)
 	return m.store.LookupExpansionPrefix(input)
 }
 
-func NewManager(s store.BadgerStore) Manager {
+func NewManager(s store.LegacyNamespaceAccess) Manager {
 	return BadgerManager{s}
 }

--- a/internal/service/namespace/manager.go
+++ b/internal/service/namespace/manager.go
@@ -1,0 +1,57 @@
+package namespace
+
+import (
+	"github.com/mimiro-io/datahub/internal/service/store"
+	"github.com/mimiro-io/datahub/internal/service/types"
+	"strings"
+)
+
+type (
+	Manager interface {
+		// ExtractPrefix
+		//	Assumes that the input string is a CURIE string, and attempts to parse prefix from it
+		//  the second return value is a flag indicating whether a prefix was found in the input or not
+		ExtractPrefix(input string) (types.Prefix, bool)
+		// ExpandPrefix lookup curie prefix in global namespace mapping
+		ExpandPrefix(input types.Prefix) (types.URI, error)
+		// ExtractNamespaceURI
+		//   returns extracted namespace uri and local value (last path element of input uri)
+		//   the 3rd return value indicates if namespace extraction was successful
+		ExtractNamespaceURI(input string) (types.URI, string, bool)
+		GetNamespacePrefix(input types.URI) (types.Prefix, error)
+	}
+
+	BadgerManager struct {
+		store store.BadgerStore
+	}
+)
+
+func (m BadgerManager) ExtractPrefix(input string) (types.Prefix, bool) {
+	tokens := strings.Split(input, ":")
+	if len(tokens) == 2 {
+		return types.Prefix(tokens[0]), true
+	}
+	return "", false
+}
+
+func (m BadgerManager) ExpandPrefix(input types.Prefix) (types.URI, error) {
+	return m.store.LookupNamespaceExpansion(input)
+}
+
+func (m BadgerManager) ExtractNamespaceURI(input string) (types.URI, string, bool) {
+	if strings.HasPrefix(input, "http") {
+		cutPosition := strings.LastIndex(input, "/")
+		ns := input[:cutPosition]
+		value := input[cutPosition:]
+		return types.URI(ns), value, true
+	}
+	return "", "", false
+}
+
+func (m BadgerManager) GetNamespacePrefix(input types.URI) (types.Prefix, error) {
+	return m.store.LookupExpansionPrefix(input)
+}
+
+func NewManager(s store.BadgerStore) Manager {
+	return BadgerManager{s}
+}

--- a/internal/service/store/badger.go
+++ b/internal/service/store/badger.go
@@ -14,9 +14,19 @@
 
 package store
 
-import "github.com/dgraph-io/badger/v3"
+import (
+	"github.com/dgraph-io/badger/v3"
+	"github.com/mimiro-io/datahub/internal/service/types"
+)
 
 type BadgerStore interface {
 	GetDB() *badger.DB
-	LookupDatasetID(datasetName string) (uint32, bool)
+	LookupDatasetID(datasetName string) (types.InternalDatasetID, bool)
+	LookupDatasetIDs(datasetNames []string) []types.InternalDatasetID
+	LookupDatasetName(internalDatasetID types.InternalDatasetID) (string, bool)
+
+	// need access ot in-memory mapping
+	LookupNamespaceExpansion(prefix types.Prefix) (types.URI, error)
+	LookupExpansionPrefix(input types.URI) (types.Prefix, error)
+	IsDatasetDeleted(datasetId types.InternalDatasetID) bool
 }

--- a/internal/service/store/badger.go
+++ b/internal/service/store/badger.go
@@ -19,6 +19,12 @@ import (
 	"github.com/mimiro-io/datahub/internal/service/types"
 )
 
+type LegacyNamespaceAccess interface {
+	// need access ot in-memory mapping
+	LookupNamespaceExpansion(prefix types.Prefix) (types.URI, error)
+	LookupExpansionPrefix(input types.URI) (types.Prefix, error)
+}
+
 type BadgerStore interface {
 	GetDB() *badger.DB
 	LookupDatasetID(datasetName string) (types.InternalDatasetID, bool)
@@ -26,7 +32,6 @@ type BadgerStore interface {
 	LookupDatasetName(internalDatasetID types.InternalDatasetID) (string, bool)
 
 	// need access ot in-memory mapping
-	LookupNamespaceExpansion(prefix types.Prefix) (types.URI, error)
-	LookupExpansionPrefix(input types.URI) (types.Prefix, error)
 	IsDatasetDeleted(datasetId types.InternalDatasetID) bool
+	LegacyNamespaceAccess
 }

--- a/internal/service/store/idx_keys.go
+++ b/internal/service/store/idx_keys.go
@@ -16,21 +16,45 @@ package store
 
 import (
 	"encoding/binary"
+	"github.com/mimiro-io/datahub/internal/service/types"
 
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
-func SeekChanges(datasetID uint32, since uint64) []byte {
+func SeekChanges(datasetID types.InternalDatasetID, since types.DatasetOffset) []byte {
 	searchBuffer := make([]byte, 14)
 	binary.BigEndian.PutUint16(searchBuffer, server.DATASET_ENTITY_CHANGE_LOG)
-	binary.BigEndian.PutUint32(searchBuffer[2:], datasetID)
-	binary.BigEndian.PutUint64(searchBuffer[6:], since)
+	binary.BigEndian.PutUint32(searchBuffer[2:], uint32(datasetID))
+	binary.BigEndian.PutUint64(searchBuffer[6:], uint64(since))
 	return searchBuffer
 }
 
-func SeekDataset(datasetID uint32) []byte {
+func SeekEntityChanges(datasetID types.InternalDatasetID, entityID types.InternalID) []byte {
+	entityIdBuffer := make([]byte, 14)
+	binary.BigEndian.PutUint16(entityIdBuffer, server.ENTITY_ID_TO_JSON_INDEX_ID)
+	binary.BigEndian.PutUint64(entityIdBuffer[2:], uint64(entityID))
+	binary.BigEndian.PutUint32(entityIdBuffer[10:], uint32(datasetID))
+	return entityIdBuffer
+}
+
+func SeekDataset(datasetID types.InternalDatasetID) []byte {
 	searchBuffer := make([]byte, 6)
 	binary.BigEndian.PutUint16(searchBuffer, server.DATASET_ENTITY_CHANGE_LOG)
-	binary.BigEndian.PutUint32(searchBuffer[2:], datasetID)
+	binary.BigEndian.PutUint32(searchBuffer[2:], uint32(datasetID))
 	return searchBuffer
+}
+
+func SeekEntity(intenalEntityId types.InternalID) []byte {
+	entityLocatorPrefixBuffer := make([]byte, 10)
+	binary.BigEndian.PutUint16(entityLocatorPrefixBuffer, server.ENTITY_ID_TO_JSON_INDEX_ID)
+	binary.BigEndian.PutUint64(entityLocatorPrefixBuffer[2:], uint64(intenalEntityId))
+	return entityLocatorPrefixBuffer
+}
+
+func GetCurieKey(curie types.CURIE) []byte {
+	curieAsBytes := []byte(curie)
+	buf := make([]byte, len(curieAsBytes)+2)
+	binary.BigEndian.PutUint16(buf, server.URI_TO_ID_INDEX_ID)
+	copy(buf[2:], curieAsBytes)
+	return buf
 }

--- a/internal/service/types/types.go
+++ b/internal/service/types/types.go
@@ -1,0 +1,13 @@
+package types
+
+type URI string
+type CURIE string
+
+type Prefix string
+
+type InternalID uint64
+type InternalDatasetID uint32
+
+type DatasetOffset uint64
+
+//type PointInTime uint64


### PR DESCRIPTION
when flag is set, datahub will inject "datahub_details" as extra property into the resulting entity. this is useful for debugging and understanding how data evolved inside the datahub. "datahub_details" contains information about accessed datasets and change history per dataset.

the implementation is done in a separate module tree, service, and is likely to change when more functionality is moved to service modules. The idea is to replicate functionality in a more decoupled way, while still keeping the same performance levels.