### PR TITLE
make sure we use namespace uris with trailing slash...

### DIFF
--- a/internal/service/entity/ids_test.go
+++ b/internal/service/entity/ids_test.go
@@ -2,10 +2,11 @@ package entity
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal/service/namespace"
 	"github.com/mimiro-io/datahub/internal/service/types"
-	"testing"
 )
 
 type nsMock struct{}
@@ -18,7 +19,7 @@ func (n nsMock) LookupNamespaceExpansion(prefix types.Prefix) (types.URI, error)
 }
 
 func (n nsMock) LookupExpansionPrefix(input types.URI) (types.Prefix, error) {
-	if input == "http://foo" {
+	if input == "http://foo/" {
 		return "foo", nil
 	}
 

--- a/internal/service/namespace/manager.go
+++ b/internal/service/namespace/manager.go
@@ -38,12 +38,16 @@ func (m BadgerManager) ExpandPrefix(input types.Prefix) (types.URI, error) {
 	return m.store.LookupNamespaceExpansion(input)
 }
 
+//ExtractNamespaceURI split given URI into namespace and value
+//  returns (
+//    namespaceURI with trailing slash,
+//    value (last path element),
+//    success flag
+//   )
 func (m BadgerManager) ExtractNamespaceURI(input string) (types.URI, string, bool) {
 	if strings.HasPrefix(input, "http") {
-		cutPosition := strings.LastIndex(input, "/")
-		ns := input[:cutPosition]
-		value := input[cutPosition+1:]
-		return types.URI(ns), value, true
+		cutPosition := strings.LastIndex(input, "/") + 1
+		return types.URI(input[:cutPosition]), input[cutPosition:], true
 	}
 	return "", "", false
 }


### PR DESCRIPTION
...  when looking up entity details