### PR TITLE
Feature/178 add support latestonly

### DIFF
--- a/internal/jobs/source/dataset_source.go
+++ b/internal/jobs/source/dataset_source.go
@@ -82,7 +82,7 @@ func (datasetSource *DatasetSource) ReadEntities(since DatasetContinuation, batc
 		if dataset.IsProxy() {
 			continuation, err := dataset.AsProxy(
 				datasetSource.AuthorizeProxyRequest(dataset.ProxyConfig.AuthProviderName),
-			).StreamChangesRaw(since.GetToken(), batchSize, false, func(jsonData []byte) error {
+			).StreamChangesRaw(since.GetToken(), batchSize, datasetSource.LatestOnly, false, func(jsonData []byte) error {
 				e := &server.Entity{}
 				err := json.Unmarshal(jsonData, e)
 				if err != nil {

--- a/internal/server/dataset.go
+++ b/internal/server/dataset.go
@@ -976,7 +976,7 @@ func (ds *Dataset) ProcessChanges(since uint64, count int, latestOnly bool, proc
 	})
 }
 
-func (ds *Dataset) ProcessChangesRaw(since uint64, count int, latestOnly bool, processChangedEntity func(entityJson []byte) error) (uint64, error) {
+func (ds *Dataset) ProcessChangesRaw(since uint64, limit int, latestOnly bool, processChangedEntity func(entityJson []byte) error) (uint64, error) {
 
 	lastSeen := since
 	foundChanges := false
@@ -1017,7 +1017,7 @@ func (ds *Dataset) ProcessChangesRaw(since uint64, count int, latestOnly bool, p
 				return err
 			}
 
-			if int(processed) == count {
+			if int(processed) == limit {
 				break
 			}
 		}

--- a/internal/server/proxydataset.go
+++ b/internal/server/proxydataset.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (
@@ -125,7 +126,7 @@ func (d *ProxyDataset) StreamEntitiesRaw(from string, limit int, f func(jsonData
 // a `preStream` function can be provided if StreamChangesRaw is used in a web handler. It allows
 // to leave the http response uncommitted until `f` is called, so that an http error handler
 // still can modify status code while the response is uncommitted
-func (d *ProxyDataset) StreamChangesRaw(since string, limit int, reverse bool, f func(jsonData []byte) error, preStream func()) (string, error) {
+func (d *ProxyDataset) StreamChangesRaw(since string, limit int, latestOnly bool, reverse bool, f func(jsonData []byte) error, preStream func()) (string, error) {
 	uri, err := url.Parse(d.RemoteChangesUrl)
 	if err != nil {
 		return "", err
@@ -140,6 +141,10 @@ func (d *ProxyDataset) StreamChangesRaw(since string, limit int, reverse bool, f
 	if reverse {
 		q.Add("reverse", "true")
 	}
+	if latestOnly {
+		q.Add("latestOnly", "true")
+	}
+
 	uri.RawQuery = q.Encode()
 	fullUri := uri.String()
 	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)

--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -347,6 +347,7 @@ func (handler *datasetHandler) getChangesHandler(c echo.Context) error {
 	limit := c.QueryParam("limit")
 	since := c.QueryParam("since")
 	reverse := c.QueryParam("reverse") == "true"
+	latestOnly := c.QueryParam("latestOnly") == "true"
 
 	var (
 		l int
@@ -378,7 +379,7 @@ func (handler *datasetHandler) getChangesHandler(c echo.Context) error {
 	if dataset.IsProxy() {
 		continuationToken, err := dataset.AsProxy(
 			handler.lookupAuth(dataset.ProxyConfig.AuthProviderName),
-		).StreamChangesRaw(since, l, reverse, func(jsonData []byte) error {
+		).StreamChangesRaw(since, l, latestOnly, reverse, func(jsonData []byte) error {
 			_, _ = c.Response().Write([]byte(","))
 			_, _ = c.Response().Write(jsonData)
 			return nil
@@ -431,7 +432,7 @@ func (handler *datasetHandler) getChangesHandler(c echo.Context) error {
 				_, _ = c.Response().Write([]byte(", {\"id\":\"@continuation\",\"token\":\"" + encodeSince(continuationToken) + "\"}]"))
 			}
 		} else {
-			continuationToken, err := dataset.ProcessChangesRaw(uint64(sinceNum), l, false, func(jsonData []byte) error {
+			continuationToken, err := dataset.ProcessChangesRaw(uint64(sinceNum), l, latestOnly, func(jsonData []byte) error {
 				_, _ = c.Response().Write([]byte(","))
 				_, _ = c.Response().Write(jsonData)
 				return nil


### PR DESCRIPTION
Added support for latestOnly in web handler and in the ProxyDataset.

The change in the ProxyDataset will forward the latestOnly flag to the backing source, the change in the /changes endpoint will allow the backing source server to respect that flag.
