### PR TITLE
Don't marshal single audience string as array

### DIFF
--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -128,6 +128,8 @@ func NewServiceCore(env *conf.Env) *ServiceCore {
 
 	serviceCore.Init()
 
+	jwt.MarshalSingleStringAsArray = false
+
 	return serviceCore
 }
 


### PR DESCRIPTION
After upgrading to golang-jwt v4, the default for marshalling single value audience claims is an array. According to https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3 this may or may not be an array. Older versions of datahub expects this as a single value, so we want to change to default behaviour.