### PR TITLE
Chore/lint fixes

### DIFF
--- a/api/datahub.oas3.yml
+++ b/api/datahub.oas3.yml
@@ -5,8 +5,8 @@ info:
   version: "0.5.0"
 
 servers:
-    - url: http://localhost:8080
-      description: Local development instance server
+  - url: http://localhost:8080
+    description: Local development instance server
 
 tags:
   - name: dataset
@@ -36,19 +36,19 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: A ServiceInfo object
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceInfo'
+                $ref: "#/components/schemas/ServiceInfo"
   /health:
     get:
       summary: Health
       tags:
         - server
       responses:
-        '200':
+        "200":
           description: Just returns UP
 
   /query:
@@ -64,14 +64,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Query'
+              $ref: "#/components/schemas/Query"
       responses:
-        '200':
+        "200":
           description: Returns an object with entity refs as field names and a list of Entities pr field
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QueryResponse'
+                $ref: "#/components/schemas/QueryResponse"
 
   /namespaces:
     get:
@@ -82,11 +82,11 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: Map with all namespaces to their prefixes
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
 
   /jobs:
@@ -98,15 +98,15 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: List with all configured jobs
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Jobs"
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
     post:
       summary: Add Job
@@ -120,20 +120,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Job'
+              $ref: "#/components/schemas/Job"
       responses:
-        '201':
+        "201":
           description: Created
-        '400':
+        "400":
           description: Bad Request
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
 
-  /jobs/{jobid}:
+  "/jobs/{jobid}":
     get:
       summary: Get Job
       description: Get a job with a given jobid
@@ -143,24 +143,23 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to retrieve
+          description: The id of the Job to retrieve
       tags:
         - jobs
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: The job in question
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Job'
-        '401':
+                $ref: "#/components/schemas/Job"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
     post:
       summary: Change Job state
@@ -171,24 +170,23 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to retrieve
+          description: The id of the Job to retrieve
       tags:
         - jobs
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: The job in question
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Job'
-        '401':
+                $ref: "#/components/schemas/Job"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
     delete:
       summary: Delete Job
@@ -200,22 +198,21 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to retrieve
+          description: The id of the Job to retrieve
       tags:
         - jobs
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: Ok
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
-  /job/{jobid}/status:
+  "/job/{jobid}/status":
     get:
       summary: Get Job status
       description: Given the job id, returns the job status
@@ -225,20 +222,19 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to retrieve
+          description: The id of the Job to retrieve
       tags:
         - operations
       security:
         - BearerAuth: []
       responses:
-        '501':
+        "501":
           description: Not imlemented
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-  /job/{jobid}/pause:
+  "/job/{jobid}/pause":
     put:
       summary: Pause job
       description: Given the job id, pauses a job. If the job is running, it will not be stopped.
@@ -248,26 +244,25 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to pause
+          description: The id of the Job to pause
       tags:
         - operations
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '500':
+                $ref: "#/components/schemas/JobResponse"
+        "500":
           description: Internal server error
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-  /job/{jobid}/resume:
+  "/job/{jobid}/resume":
     put:
       summary: Resume Job
       description: Given the job id, resumes a paused job. The job will run at next schedule.
@@ -277,27 +272,26 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to pause
+          description: The id of the Job to pause
       tags:
         - operations
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '500':
+                $ref: "#/components/schemas/JobResponse"
+        "500":
           description: Internal server error
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
 
-  /job/{jobid}/kill:
+  "/job/{jobid}/kill":
     put:
       summary: Kill Job
       description: Given the job id, kills a running job. If it is not running, nothing will happen.
@@ -307,25 +301,24 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to kill
+          description: The id of the Job to kill
       tags:
         - operations
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '401':
+                $ref: "#/components/schemas/JobResponse"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
 
-  /job/{jobid}/run:
+  "/job/{jobid}/run":
     put:
       summary: Run Job
       description: |
@@ -338,33 +331,31 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to kill
+          description: The id of the Job to kill
         - in: query
           name: jobType
           schema:
             type: string
             enum: [ incremental, fullsync ]
           required: false
-          description:
-            The jobType for this run. defaults to incremental
+          description: The jobType for this run. defaults to incremental
       tags:
         - operations
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '401':
+                $ref: "#/components/schemas/JobResponse"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
 
-  /job/{jobid}/reset:
+  "/job/{jobid}/reset":
     put:
       summary: Reset Job
       description: |
@@ -376,29 +367,27 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Job to reset
+          description: The id of the Job to reset
         - in: query
           name: since
           schema:
             type: string
           required: false
-          description:
-            The continuation token to reset to.
+          description: The continuation token to reset to.
       tags:
         - operations
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '401':
+                $ref: "#/components/schemas/JobResponse"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
 
   /datasets:
@@ -410,17 +399,17 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: Returns a list of Datasets
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Datasets'
-        '401':
+                $ref: "#/components/schemas/Datasets"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-  /datasets/{dataset}/entities:
+  "/datasets/{dataset}/entities":
     get:
       summary: List Entities
       description: Returns a list of Entities for the given dataset. Used for full sync.
@@ -430,34 +419,32 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The name of the Dataset to recover
+          description: The name of the Dataset to recover
         - in: query
           name: limit
           schema:
             type: number
             format: int
           required: false
-          description:
-            The limit on how many entities to return.
+          description: The limit on how many entities to return.
       tags:
         - dataset
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: A list of entities
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entities'
-        '401':
+                $ref: "#/components/schemas/Entities"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Dataset not found, either because it does not exist, or you have no access
-        '500':
+        "500":
           description: Internal server error
     post:
       summary: Create dataset
@@ -468,8 +455,7 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The name of the Dataset to recover
+          description: The name of the Dataset to recover
         - in: query
           name: proxy
           schema:
@@ -478,7 +464,7 @@ paths:
           description: if true, the dataset will forwand all user requests to configured proxy dataset. requires request body with proxyDatasetConfig
       requestBody:
         content:
-          'application/json':
+          "application/json":
             schema:
               properties:
                 proxyDatasetConfig:
@@ -500,23 +486,23 @@ paths:
               proxyDatasetConfig:
                 remoteUrl: "http://hostname/datasets/example"
                 authProviderName: "local"
-              publicNamespaces: ["http://example.com", "http://example.mimiro.io/"]
+              publicNamespaces: [ "http://example.com", "http://example.mimiro.io/" ]
       tags:
         - dataset
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
+        "400":
           description: Bad Request
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
-  /datasets/{dataset}/changes:
+  "/datasets/{dataset}/changes":
     get:
       summary: List changed Entities
       description: Given a since parameter, returns a list of changed entities since.
@@ -526,38 +512,36 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The name of the Dataset to return
+          description: The name of the Dataset to return
         - in: query
           name: since
           schema:
             type: integer
             format: int64
           required: true
-          description:
-            A continuation token
+          description: A continuation token
       tags:
         - dataset
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: List of entities since
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entities'
-        '400':
+                $ref: "#/components/schemas/Entities"
+        "400":
           description: Bad Request. Check your parameters.
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Dataset not found, either because it does not exist, or you have no access
-        '500':
+        "500":
           description: Internal server error
-  /datasets/{dataset}:
+  "/datasets/{dataset}":
     delete:
       summary: Delete Dataset
       description: Deletes the given dataset
@@ -567,22 +551,21 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The name of the Dataset to delete
+          description: The name of the Dataset to delete
       tags:
         - dataset
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
+        "400":
           description: Bad Request
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
   /content:
     get:
@@ -593,17 +576,17 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: Lists of stored contents
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Contents'
-        '401':
+                $ref: "#/components/schemas/Contents"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
     post:
       summary: Add Content
@@ -617,19 +600,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Content'
+              $ref: "#/components/schemas/Content"
       responses:
-        '201':
+        "201":
           description: Created
-        '400':
+        "400":
           description: Bad Request
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
-  /content/{contentId}:
+  "/content/{contentId}":
     get:
       summary: Show Content
       description: Given its id, retrieves a single Content
@@ -643,22 +626,21 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Content to show
+          description: The id of the Content to show
       responses:
-        '200':
+        "200":
           description: A single content object
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Content'
-        '401':
+                $ref: "#/components/schemas/Content"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
-        '500':
+        "500":
           description: Internal server error
     put:
       summary: Update Content
@@ -673,24 +655,23 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The id of the Content to update
+          description: The id of the Content to update
       requestBody:
         description: The Content object to update
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Content'
+              $ref: "#/components/schemas/Content"
       responses:
-        '201':
+        "201":
           description: Created
-        '400':
+        "400":
           description: Bad Request
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
 
     delete:
@@ -699,25 +680,24 @@ paths:
       tags:
         - content
       security:
-          - BearerAuth: []
+        - BearerAuth: []
       parameters:
         - in: path
           name: contentId
           schema:
             type: string
           required: true
-          description:
-            The id of the Content to delete
+          description: The id of the Content to delete
       responses:
-        '200':
+        "200":
           description: OK
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
-        '500':
+        "500":
           description: Internal server error
   /provider/logins:
     get:
@@ -728,17 +708,17 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: A list of login providers
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginProviders'
-        '401':
+                $ref: "#/components/schemas/LoginProviders"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
     post:
       summary: Add new provider
@@ -752,19 +732,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LoginProvider'
+              $ref: "#/components/schemas/LoginProvider"
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
+        "400":
           description: Bad Request
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
-  /provider/login/{providerName}:
+  "/provider/login/{providerName}":
     get:
       summary: Get provider by name
       description: Gets a single login provider by it's name
@@ -778,22 +758,21 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The name of the Login provider to get
+          description: The name of the Login provider to get
       responses:
-        '200':
+        "200":
           description: A login provider
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginProvider'
-        '401':
+                $ref: "#/components/schemas/LoginProvider"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
-        '500':
+        "500":
           description: Internal server error
     post:
       summary: Update provider
@@ -808,24 +787,23 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The name of the Login provider to update
+          description: The name of the Login provider to update
       requestBody:
         description: The Content object to update. The name in the body is ignored for the one in the path.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LoginProvider'
+              $ref: "#/components/schemas/LoginProvider"
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
+        "400":
           description: Bad Request
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
     delete:
       summary: Delete provider
@@ -840,20 +818,18 @@ paths:
           schema:
             type: string
           required: true
-          description:
-            The name of the Login provider to delete
+          description: The name of the Login provider to delete
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
+        "400":
           description: Bad Request
-        '401':
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '500':
+        "500":
           description: Internal server error
-
 
 components:
   securitySchemes:
@@ -894,8 +870,7 @@ components:
     LoginProviders:
       type: array
       items:
-        $ref: '#/components/schemas/LoginProvider'
-
+        $ref: "#/components/schemas/LoginProvider"
 
     LoginProvider:
       properties:
@@ -910,33 +885,33 @@ components:
           description: Must be either bearer (jwt) or basic (username+password)
         user:
           type: object
-          $ref: '#/components/schemas/Value'
+          $ref: "#/components/schemas/Value"
           description: If type is "basic" then this is the username and must be present
         password:
           type: object
-          $ref: '#/components/schemas/Value'
+          $ref: "#/components/schemas/Value"
           description: If type is "basic" then this is the password and must be present
         key:
           type: object
-          $ref: '#/components/schemas/Value'
+          $ref: "#/components/schemas/Value"
           description: If type is "bearer" then this is the id of the client
         secret:
           type: object
-          $ref: '#/components/schemas/Value'
+          $ref: "#/components/schemas/Value"
           description: If type is "bearer" then this is the secret of the client
         audience:
           type: object
-          $ref: '#/components/schemas/Value'
+          $ref: "#/components/schemas/Value"
           description: If type is "bearer" then this is the audience the token is requested for.
         grantType:
           type: object
-          $ref: '#/components/schemas/Value'
+          $ref: "#/components/schemas/Value"
           description: |
             If type is "bearer" then this is the type of the token asked for, this is client_credential for
             m2m tokens, app_credential for user application tokens.
         endpoint:
           type: object
-          $ref: '#/components/schemas/Value'
+          $ref: "#/components/schemas/Value"
           description: If type is "bearer" then this is the endpoint to request a token at.
 
     Value:
@@ -959,7 +934,7 @@ components:
     Contents:
       type: array
       items:
-        $ref: '#/components/schemas/Content'
+        $ref: "#/components/schemas/Content"
 
     Content:
       properties:
@@ -970,12 +945,12 @@ components:
           type: object
           description: An object without schema constraints.
       required:
-          - id
-          - data
+        - id
+        - data
     Jobs:
       type: array
       items:
-        $ref: '#/components/schemas/Job'
+        $ref: "#/components/schemas/Job"
     JobResponse:
       properties:
         jobId:
@@ -1019,8 +994,8 @@ components:
           description: An object describing the Transform to be added to the job
           example:
             {
-              "Type" : "HttpTransform || JavascriptTransform",
-              "Code" : "For JS transform: base64 encoded js code."
+              "Type": "HttpTransform || JavascriptTransform",
+              "Code": "For JS transform: base64 encoded js code."
             }
 
     Datasets:
@@ -1035,9 +1010,9 @@ components:
       type: array
       items:
         anyOf:
-            - $ref: '#/components/schemas/Context'
-            - $ref: '#/components/schemas/Entity'
-            - $ref: '#/components/schemas/NextToken'
+          - $ref: "#/components/schemas/Context"
+          - $ref: "#/components/schemas/Entity"
+          - $ref: "#/components/schemas/NextToken"
 
     Context:
       properties:

--- a/app.go
+++ b/app.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/fx"
+
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/conf/secrets"
 	"github.com/mimiro-io/datahub/internal/content"
@@ -25,7 +27,6 @@ import (
 	"github.com/mimiro-io/datahub/internal/security"
 	"github.com/mimiro-io/datahub/internal/server"
 	"github.com/mimiro-io/datahub/internal/web"
-	"go.uber.org/fx"
 )
 
 func wire() *fx.App {

--- a/dataset_http_integration_test.go
+++ b/dataset_http_integration_test.go
@@ -46,10 +46,10 @@ func TestHttp(t *testing.T) {
 	var mockLayer *MockLayer
 
 	location := "./http_integration_test"
-	queryUrl := "http://localhost:24997/query"
-	dsUrl := "http://localhost:24997/datasets/bananas"
-	proxyDsUrl := "http://localhost:24997/datasets/cucumbers"
-	datasetsUrl := "http://localhost:24997/datasets"
+	queryURL := "http://localhost:24997/query"
+	dsURL := "http://localhost:24997/datasets/bananas"
+	proxyDsURL := "http://localhost:24997/datasets/cucumbers"
+	datasetsURL := "http://localhost:24997/datasets"
 
 	g.Describe("The dataset endpoint", func() {
 		g.Before(func() {
@@ -87,16 +87,15 @@ func TestHttp(t *testing.T) {
 		})
 
 		g.Describe("The dataset root API", func() {
-
 			g.It("Should create a regular dataset", func() {
 				// create new dataset
-				res, err := http.Post(dsUrl, "application/json", strings.NewReader(""))
+				res, err := http.Post(dsURL, "application/json", strings.NewReader(""))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 			})
 			g.It("Should retrieve a regular dataset", func() {
-				res, err := http.Get(dsUrl)
+				res, err := http.Get(dsURL)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -122,14 +121,14 @@ func TestHttp(t *testing.T) {
 						DownstreamTransform string `json:"downstreamTransform"`
 					}
 				*/
-				res, err := http.Post(proxyDsUrl+"?proxy=true", "application/json", strings.NewReader(
+				res, err := http.Post(proxyDsURL+"?proxy=true", "application/json", strings.NewReader(
 					`{"proxyDatasetConfig": {"remoteUrl": "http://localhost:7778/datasets/tomatoes"}}`))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 			})
 			g.It("Should reject a proxy dataset if misconfigured", func() {
-				res, err := http.Post(proxyDsUrl+"2?proxy=true", "application/json", strings.NewReader(
+				res, err := http.Post(proxyDsURL+"2?proxy=true", "application/json", strings.NewReader(
 					`{"proxyDatasetConfig": {"remoteUrl": ""}}`))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
@@ -138,7 +137,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(string(b)).Eql("{\"message\":\"invalid proxy configuration provided\"}\n")
 			})
 			g.It("Should retrieve a proxy dataset", func() {
-				res, err := http.Get(proxyDsUrl)
+				res, err := http.Get(proxyDsURL)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -150,7 +149,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(refs["ns2:type"]).Eql("ns1:proxy-dataset")
 			})
 			g.It("Should list both regular and proxy datasets", func() {
-				res, err := http.Get(datasetsUrl)
+				res, err := http.Get(datasetsURL)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -161,23 +160,23 @@ func TestHttp(t *testing.T) {
 			})
 		})
 		g.Describe("The /entities and /changes API endpoints for regular datasets", func() {
-
 			g.It("Should accept a single batch of changes", func() {
 				// populate dataset
 				payload := strings.NewReader(bananasFromTo(1, 10, false))
-				res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err := http.Post(dsURL+"/entities", "application/json", payload)
 
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				// read it back
-				res, err = http.Get(dsUrl + "/changes")
+				res, err = http.Get(dsURL + "/changes")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				bodyBytes, err := ioutil.ReadAll(res.Body)
+				g.Assert(err).IsNil()
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
 				g.Assert(err).IsNil()
@@ -187,20 +186,20 @@ func TestHttp(t *testing.T) {
 			g.It("Should accept multiple overlapping batches of changes", func() {
 				// replace 5-10 and add 11-15
 				payload := strings.NewReader(bananasFromTo(5, 15, false))
-				res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err := http.Post(dsURL+"/entities", "application/json", payload)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				// replace 10-15 and add 16-20
 				payload = strings.NewReader(bananasFromTo(10, 20, false))
-				res, err = http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err = http.Post(dsURL+"/entities", "application/json", payload)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				// read it back
-				res, err = http.Get(dsUrl + "/changes")
+				res, err = http.Get(dsURL + "/changes")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -214,13 +213,13 @@ func TestHttp(t *testing.T) {
 
 			g.It("Should record deleted states", func() {
 				payload := strings.NewReader(bananasFromTo(7, 8, true))
-				res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err := http.Post(dsURL+"/entities", "application/json", payload)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				// read changes back
-				res, err = http.Get(dsUrl + "/changes")
+				res, err = http.Get(dsURL + "/changes")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -229,12 +228,13 @@ func TestHttp(t *testing.T) {
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
 				g.Assert(err).IsNil()
-				g.Assert(len(entities)).Eql(24, "expected 20 entities plus 2 deleted-changes plus @context and @continuation")
+				g.Assert(len(entities)).
+					Eql(24, "expected 20 entities plus 2 deleted-changes plus @context and @continuation")
 				g.Assert(entities[7].IsDeleted).IsFalse("original change 7 is still undeleted")
 				g.Assert(entities[22].IsDeleted).IsTrue("deleted state for 7  is a new change at end of list")
 
 				// read entities back
-				res, err = http.Get(dsUrl + "/entities")
+				res, err = http.Get(dsURL + "/entities")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -254,7 +254,7 @@ func TestHttp(t *testing.T) {
 				// first batch with "start" header
 				payload := strings.NewReader(bananasFromTo(4, 8, false))
 				ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ := http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-start", "true")
 				req.Header.Add("universal-data-api-full-sync-id", "42")
 				_, err := http.DefaultClient.Do(req)
@@ -264,7 +264,7 @@ func TestHttp(t *testing.T) {
 				// 2nd batch
 				payload = strings.NewReader(bananasFromTo(9, 12, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-id", "42")
 				_, _ = http.DefaultClient.Do(req)
 				cancel()
@@ -272,14 +272,14 @@ func TestHttp(t *testing.T) {
 				// last batch with "end" signal
 				payload = strings.NewReader(bananasFromTo(13, 16, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-id", "42")
 				req.Header.Add("universal-data-api-full-sync-end", "true")
 				_, _ = http.DefaultClient.Do(req)
 				cancel()
 
 				// read changes back
-				res, err := http.Get(dsUrl + "/changes")
+				res, err := http.Get(dsURL + "/changes")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -293,7 +293,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(entities[21].IsDeleted).IsTrue("deleted state for 7  is a new change at end of list")
 
 				// read entities back
-				res, err = http.Get(dsUrl + "/entities")
+				res, err = http.Get(dsURL + "/entities")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -323,7 +323,7 @@ func TestHttp(t *testing.T) {
 				// first batch with "start" header
 				payload := strings.NewReader(bananasFromTo(4, 4, false))
 				ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ := http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-start", "true")
 				req.Header.Add("universal-data-api-full-sync-id", "43")
 				_, _ = http.DefaultClient.Do(req)
@@ -332,17 +332,19 @@ func TestHttp(t *testing.T) {
 				// next, updated id 5 with wrong sync-id. should not be registered as "seen" and therefore be deleted after fs
 				payload = strings.NewReader(bananasFromTo(5, 5, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-id", "44")
 				res, err := http.DefaultClient.Do(req)
+				g.Assert(err).IsNil()
 				cancel()
 				g.Assert(res.StatusCode).Eql(409, "request should be rejected because fullsync is going on")
 
 				// also try to add id 5 without sync-id. should still be rejected
 				payload = strings.NewReader(bananasFromTo(5, 5, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				res, err = http.DefaultClient.Do(req)
+				g.Assert(err).IsNil()
 				cancel()
 				g.Assert(res.StatusCode).Eql(409, "request should be rejected because fullsync is going on")
 
@@ -352,12 +354,12 @@ func TestHttp(t *testing.T) {
 					wg.Add(1)
 					id := i
 					go func() {
-						payload := strings.NewReader(bananasFromTo(id, id, false))
-						ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-						req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
-						req.Header.Add("universal-data-api-full-sync-id", "43")
-						_, _ = http.DefaultClient.Do(req)
-						cancel()
+						payloadLocal := strings.NewReader(bananasFromTo(id, id, false))
+						ctxLocal, cancelLocal := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+						reqLocal, _ := http.NewRequestWithContext(ctxLocal, "POST", dsURL+"/entities", payloadLocal)
+						reqLocal.Header.Add("universal-data-api-full-sync-id", "43")
+						_, _ = http.DefaultClient.Do(reqLocal)
+						cancelLocal()
 						wg.Done()
 					}()
 				}
@@ -367,14 +369,14 @@ func TestHttp(t *testing.T) {
 				// last batch with "end" signal
 				payload = strings.NewReader(bananasFromTo(16, 16, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-id", "43")
 				req.Header.Add("universal-data-api-full-sync-end", "true")
 				_, _ = http.DefaultClient.Do(req)
 				cancel()
 
 				// read changes back
-				res, err = http.Get(dsUrl + "/changes")
+				res, err = http.Get(dsURL + "/changes")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -383,14 +385,15 @@ func TestHttp(t *testing.T) {
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
 				g.Assert(err).IsNil()
-				g.Assert(len(entities)).Eql(34, "expected 31 changes from before plus deletion of id5 and @context and @continuation")
+				g.Assert(len(entities)).
+					Eql(34, "expected 31 changes from before plus deletion of id5 and @context and @continuation")
 				g.Assert(entities[32].IsDeleted).IsTrue("deleted state for 5  is a new change at end of list")
 			})
 			g.It("should abandon fullsync when new fullsync is started", func() {
 				// start a fullsync
 				payload := strings.NewReader(bananasFromTo(1, 1, false))
 				ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ := http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-start", "true")
 				req.Header.Add("universal-data-api-full-sync-id", "45")
 				res, err := http.DefaultClient.Do(req)
@@ -402,7 +405,7 @@ func TestHttp(t *testing.T) {
 				// start another fullsync
 				payload = strings.NewReader(bananasFromTo(1, 1, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-start", "true")
 				req.Header.Add("universal-data-api-full-sync-id", "46")
 				res, err = http.DefaultClient.Do(req)
@@ -414,7 +417,7 @@ func TestHttp(t *testing.T) {
 				// try to append to first fullsync, should be rejected
 				payload = strings.NewReader(bananasFromTo(2, 2, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-id", "45")
 				res, err = http.DefaultClient.Do(req)
 				cancel()
@@ -425,7 +428,7 @@ func TestHttp(t *testing.T) {
 				// complete second sync
 				payload = strings.NewReader(bananasFromTo(16, 16, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-id", "46")
 				req.Header.Add("universal-data-api-full-sync-end", "true")
 				res, err = http.DefaultClient.Do(req)
@@ -438,7 +441,7 @@ func TestHttp(t *testing.T) {
 				// start a fullsync
 				payload := strings.NewReader(bananasFromTo(1, 1, false))
 				ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ := http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ := http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-start", "true")
 				req.Header.Add("universal-data-api-full-sync-id", "47")
 				res, err := http.DefaultClient.Do(req)
@@ -453,7 +456,7 @@ func TestHttp(t *testing.T) {
 				// send next fullsync batch. should be OK even though lease is timed out
 				payload = strings.NewReader(bananasFromTo(2, 2, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-id", "47")
 				res, err = http.DefaultClient.Do(req)
 				cancel()
@@ -464,7 +467,7 @@ func TestHttp(t *testing.T) {
 				// send next end signal. should produce error since lease should have timed out
 				payload = strings.NewReader(bananasFromTo(3, 3, false))
 				ctx, cancel = context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ = http.NewRequestWithContext(ctx, "POST", dsUrl+"/entities", payload)
+				req, _ = http.NewRequestWithContext(ctx, "POST", dsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-end", "true")
 				req.Header.Add("universal-data-api-full-sync-id", "47")
 				res, err = http.DefaultClient.Do(req)
@@ -476,13 +479,13 @@ func TestHttp(t *testing.T) {
 
 			g.It("Should pageinate over entities with continuation token", func() {
 				payload := strings.NewReader(bananasFromTo(1, 100, false))
-				res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err := http.Post(dsURL+"/entities", "application/json", payload)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				// read first page of 10 entities back
-				res, err = http.Get(dsUrl + "/entities?limit=10")
+				res, err = http.Get(dsURL + "/entities?limit=10")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -498,7 +501,7 @@ func TestHttp(t *testing.T) {
 				token := m[11]["token"].(string)
 
 				// read next page
-				res, err = http.Get(dsUrl + "/entities?limit=90&from=" + url.QueryEscape(token))
+				res, err = http.Get(dsURL + "/entities?limit=90&from=" + url.QueryEscape(token))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -512,7 +515,7 @@ func TestHttp(t *testing.T) {
 				token = m[91]["token"].(string)
 
 				// read next page after all consumed
-				res, err = http.Get(dsUrl + "/entities?limit=10&from=" + url.QueryEscape(token))
+				res, err = http.Get(dsURL + "/entities?limit=10&from=" + url.QueryEscape(token))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -527,13 +530,14 @@ func TestHttp(t *testing.T) {
 		})
 		g.Describe("The /changes and /entities endpoints for proxy datasets", func() {
 			g.It("Should fetch from remote for GET /changes without token", func() {
-				res, err := http.Get(proxyDsUrl + "/changes")
+				res, err := http.Get(proxyDsURL + "/changes")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 				b, _ := io.ReadAll(res.Body)
 				var entities []*server.Entity
 				err = json.Unmarshal(b, &entities)
+				g.Assert(err).IsNil()
 				g.Assert(len(entities)).Eql(12, "context, 10 entities and continuation")
 				g.Assert(entities[1].ID).Eql("ns4:c-0", "first page id range starts with 0")
 				g.Assert(mockLayer.RecordedURI).Eql("/datasets/tomatoes/changes")
@@ -542,48 +546,55 @@ func TestHttp(t *testing.T) {
 				g.Assert(m[11]["token"]).Eql("nextplease")
 			})
 			g.It("Should fetch from remote for GET /changes with token and limit", func() {
-				res, err := http.Get(proxyDsUrl + "/changes?since=theweekend&limit=3")
+				res, err := http.Get(proxyDsURL + "/changes?since=theweekend&limit=3")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 				b, _ := io.ReadAll(res.Body)
 				var entities []*server.Entity
 				err = json.Unmarshal(b, &entities)
+				g.Assert(err).IsNil()
 				g.Assert(len(entities)).Eql(5, "context, 3 entities and continuation")
 				g.Assert(entities[1].ID).Eql("ns4:c-100", "later page mock id range starts with 100")
 				g.Assert(mockLayer.RecordedURI).Eql("/datasets/tomatoes/changes?limit=3&since=theweekend")
 				var m []map[string]interface{}
 				_ = json.Unmarshal(b, &m)
 				g.Assert(m[4]["token"]).Eql("lastpage")
-				g.Assert(m[0]["namespaces"]).Eql(map[string]interface{}{"ns0": "http://data.mimiro.io/core/dataset/",
+				g.Assert(m[0]["namespaces"]).Eql(map[string]interface{}{
+					"ns0": "http://data.mimiro.io/core/dataset/",
 					"ns1": "http://data.mimiro.io/core/",
 					"ns2": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
 					"ns3": "http://example.com",
-					"ns4": "http://example.mimiro.io/"})
+					"ns4": "http://example.mimiro.io/",
+				})
 			})
 			g.It("Should fetch from remote for GET /entities", func() {
-				res, err := http.Get(proxyDsUrl + "/entities?from=theweekend&limit=3")
+				res, err := http.Get(proxyDsURL + "/entities?from=theweekend&limit=3")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 				b, _ := io.ReadAll(res.Body)
 				var entities []*server.Entity
 				err = json.Unmarshal(b, &entities)
-				g.Assert(len(entities)).Eql(11, "context, 10 entities (remote ignored limit) and no continuation (none returned from remote)")
+				g.Assert(err).IsNil()
+				g.Assert(len(entities)).
+					Eql(11, "context, 10 entities (remote ignored limit) and no continuation (none returned from remote)")
 				g.Assert(entities[1].ID).Eql("ns4:e-0")
 				g.Assert(mockLayer.RecordedURI).Eql("/datasets/tomatoes/entities?from=theweekend&limit=3")
 				var m []map[string]interface{}
 				_ = json.Unmarshal(b, &m)
-				g.Assert(m[0]["namespaces"]).Eql(map[string]interface{}{"ns0": "http://data.mimiro.io/core/dataset/",
+				g.Assert(m[0]["namespaces"]).Eql(map[string]interface{}{
+					"ns0": "http://data.mimiro.io/core/dataset/",
 					"ns1": "http://data.mimiro.io/core/",
 					"ns2": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
 					"ns3": "http://example.com",
-					"ns4": "http://example.mimiro.io/"})
+					"ns4": "http://example.mimiro.io/",
+				})
 			})
 			g.It("Should push to remote for POST /entities", func() {
 				payload := strings.NewReader(bananasFromTo(1, 3, false))
 				ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ := http.NewRequestWithContext(ctx, "POST", proxyDsUrl+"/entities", payload)
+				req, _ := http.NewRequestWithContext(ctx, "POST", proxyDsURL+"/entities", payload)
 				res, err := http.DefaultClient.Do(req)
 				cancel()
 				g.Assert(err).IsNil()
@@ -598,12 +609,11 @@ func TestHttp(t *testing.T) {
 				var m []map[string]interface{}
 				_ = json.Unmarshal(mockLayer.RecordedBytes["tomatoes"], &m)
 				g.Assert(m[0]["namespaces"]).Eql(map[string]interface{}{"_": "http://example.com"})
-
 			})
 			g.It("Should forward fullsync headers for POST /entities", func() {
 				payload := strings.NewReader(bananasFromTo(1, 17, false))
 				ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-				req, _ := http.NewRequestWithContext(ctx, "POST", proxyDsUrl+"/entities", payload)
+				req, _ := http.NewRequestWithContext(ctx, "POST", proxyDsURL+"/entities", payload)
 				req.Header.Add("universal-data-api-full-sync-start", "true")
 				req.Header.Add("universal-data-api-full-sync-id", "46")
 				req.Header.Add("universal-data-api-full-sync-end", "true")
@@ -617,24 +627,23 @@ func TestHttp(t *testing.T) {
 				g.Assert(mockLayer.RecordedHeaders.Get("universal-data-api-full-sync-id")).Eql("46")
 				g.Assert(mockLayer.RecordedHeaders.Get("universal-data-api-full-sync-end")).Eql("true")
 				g.Assert(len(recorded)).Eql(18, "context and 17 entities")
-
 			})
 			g.It("Should expose publicNamespaces if configured on proxy dataset", func() {
 				// delete proxy ds
-				req, _ := http.NewRequest("DELETE", proxyDsUrl, nil)
+				req, _ := http.NewRequest("DELETE", proxyDsURL, nil)
 				res, err := http.DefaultClient.Do(req)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				// make sure it's gone
-				res, err = http.Get(proxyDsUrl)
+				res, err = http.Get(proxyDsURL)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(404)
 
 				// recreate with publicNamespaces
-				res, err = http.Post(proxyDsUrl+"?proxy=true", "application/json", strings.NewReader(
+				res, err = http.Post(proxyDsURL+"?proxy=true", "application/json", strings.NewReader(
 					`{
 							"proxyDatasetConfig": {
 								"remoteUrl": "http://localhost:7778/datasets/tomatoes",
@@ -647,13 +656,14 @@ func TestHttp(t *testing.T) {
 				g.Assert(res.StatusCode).Eql(200)
 
 				// read it back, hopefully with with publicNamespaces applied
-				res, err = http.Get(proxyDsUrl + "/changes?limit=1")
+				res, err = http.Get(proxyDsURL + "/changes?limit=1")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 				b, _ := io.ReadAll(res.Body)
 				var entities []*server.Entity
 				err = json.Unmarshal(b, &entities)
+				g.Assert(err).IsNil()
 				g.Assert(len(entities)).Eql(3, "context, 1 entity and continuation")
 				g.Assert(entities[1].ID).Eql("ns4:c-0")
 				g.Assert(mockLayer.RecordedURI).Eql("/datasets/tomatoes/changes?limit=1")
@@ -661,7 +671,8 @@ func TestHttp(t *testing.T) {
 				_ = json.Unmarshal(b, &m)
 				g.Assert(m[0]["namespaces"]).Eql(map[string]interface{}{
 					"ns3": "http://example.com",
-					"ns4": "http://example.mimiro.io/"})
+					"ns4": "http://example.mimiro.io/",
+				})
 				g.Assert(mockLayer.RecordedHeaders.Get("Authorization")).IsZero(
 					"there is no authProvider, fallback to unauthed")
 			})
@@ -683,13 +694,14 @@ func TestHttp(t *testing.T) {
 				g.Assert(res.StatusCode).Eql(200)
 
 				// read changes and verify auth is applied
-				res, err = http.Get(proxyDsUrl + "/changes?limit=1")
+				res, err = http.Get(proxyDsURL + "/changes?limit=1")
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 				b, _ := io.ReadAll(res.Body)
 				var entities []*server.Entity
 				err = json.Unmarshal(b, &entities)
+				g.Assert(err).IsNil()
 				g.Assert(len(entities)).Eql(3, "context, 1 entity and continuation")
 				g.Assert(entities[1].ID).Eql("ns4:c-0")
 				g.Assert(mockLayer.RecordedURI).Eql("/datasets/tomatoes/changes?limit=1")
@@ -713,18 +725,17 @@ func TestHttp(t *testing.T) {
 				query := map[string]any{"query": queryEncoded}
 				queryBytes, _ := json.Marshal(query)
 
-				res, err := http.Post(queryUrl, "application/x-javascript-query", bytes.NewReader(queryBytes))
+				res, err := http.Post(queryURL, "application/x-javascript-query", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 				body, _ := io.ReadAll(res.Body)
 				g.Assert(string(body)).Eql("[{\"bananaCount\":100}]")
-
 			})
 			g.It("can find single ids", func() {
 				query := map[string]any{"entityId": "ns3:16"}
 				queryBytes, _ := json.Marshal(query)
-				res, err := http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err := http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -737,19 +748,18 @@ func TestHttp(t *testing.T) {
 				g.Assert(rMap[1]["recorded"]).IsNotZero()
 			})
 			g.It("can find outgoing relations from startUri", func() {
-
 				payload := strings.NewReader(bananaRelations(
 					bananaRel{fromBanana: 1, toBananas: []int{2, 3}},
 					bananaRel{fromBanana: 2, toBananas: []int{3, 4, 5, 6, 7}},
 				))
-				res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err := http.Post(dsURL+"/entities", "application/json", payload)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				query := map[string]any{"startingEntities": []string{"ns3:2"}, "predicate": "*"}
 				queryBytes, _ := json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -767,19 +777,18 @@ func TestHttp(t *testing.T) {
 				g.Assert(result[0].([]any)[2].(map[string]any)["id"]).Eql("ns3:7")
 			})
 			g.It("can page through queried outgoing relations", func() {
-
 				payload := strings.NewReader(bananaRelations(
 					bananaRel{fromBanana: 1, toBananas: []int{2, 3}},
 					bananaRel{fromBanana: 2, toBananas: []int{3, 4, 5, 6, 7}},
 				))
-				res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err := http.Post(dsURL+"/entities", "application/json", payload)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				query := map[string]any{"startingEntities": []string{"ns3:2"}, "predicate": "*", "limit": 2}
 				queryBytes, _ := json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -795,7 +804,7 @@ func TestHttp(t *testing.T) {
 				cont := rArr[2]
 				query = map[string]any{"continuations": cont, "limit": 2}
 				queryBytes, _ = json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -812,7 +821,7 @@ func TestHttp(t *testing.T) {
 				cont = rArr[2]
 				query = map[string]any{"continuations": cont, "limit": 2}
 				queryBytes, _ = json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -828,20 +837,19 @@ func TestHttp(t *testing.T) {
 				g.Assert(len(cont.([]any))).Eql(0)
 			})
 			g.It("can find inverse relations from startUri", func() {
-
 				payload := strings.NewReader(bananaRelations(
 					bananaRel{fromBanana: 1, toBananas: []int{2, 3}},
 					bananaRel{fromBanana: 2, toBananas: []int{3, 4}},
 					bananaRel{fromBanana: 4, toBananas: []int{3, 2, 1}},
 				))
-				res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err := http.Post(dsURL+"/entities", "application/json", payload)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
 				query := map[string]any{"startingEntities": []string{"ns3:3"}, "predicate": "*", "inverse": true}
 				queryBytes, _ := json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -867,14 +875,19 @@ func TestHttp(t *testing.T) {
 					bananaRel{fromBanana: 6, toBananas: []int{3, 2, 1}},
 					bananaRel{fromBanana: 7, toBananas: []int{3, 2, 1}},
 				))
-				res, err := http.Post(dsUrl+"/entities", "application/json", payload)
+				res, err := http.Post(dsURL+"/entities", "application/json", payload)
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
-				query := map[string]any{"startingEntities": []string{"ns3:3"}, "predicate": "*", "inverse": true, "limit": 2}
+				query := map[string]any{
+					"startingEntities": []string{"ns3:3"},
+					"predicate":        "*",
+					"inverse":          true,
+					"limit":            2,
+				}
 				queryBytes, _ := json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -892,7 +905,7 @@ func TestHttp(t *testing.T) {
 				savedCont := cont
 				query = map[string]any{"continuations": cont, "limit": 2}
 				queryBytes, _ = json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -909,7 +922,7 @@ func TestHttp(t *testing.T) {
 				cont = rArr[2]
 				query = map[string]any{"continuations": cont, "limit": 2}
 				queryBytes, _ = json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -926,7 +939,7 @@ func TestHttp(t *testing.T) {
 				// go through last pages with different batch sizes
 				query = map[string]any{"continuations": savedCont, "limit": 3}
 				queryBytes, _ = json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -944,7 +957,7 @@ func TestHttp(t *testing.T) {
 				cont = rArr[2]
 				query = map[string]any{"continuations": cont, "limit": 2}
 				queryBytes, _ = json.Marshal(query)
-				res, err = http.Post(queryUrl, "application/javascript", bytes.NewReader(queryBytes))
+				res, err = http.Post(queryURL, "application/javascript", bytes.NewReader(queryBytes))
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
@@ -978,7 +991,6 @@ func bananaRelations(rels ...bananaRel) string {
 	}
 
 	return prefix + strings.Join(bananas, ",") + "]"
-
 }
 
 func bananasFromTo(from, to int, deleted bool) string {

--- a/dataset_http_integration_test.go
+++ b/dataset_http_integration_test.go
@@ -30,9 +30,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/labstack/echo/v4"
-
 	"github.com/franela/goblin"
+	"github.com/labstack/echo/v4"
 	"go.uber.org/fx"
 
 	"github.com/mimiro-io/datahub"

--- a/dataset_http_integration_test.go
+++ b/dataset_http_integration_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package datahub
+package datahub_test
 
 import (
 	"bytes"
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -36,6 +35,7 @@ import (
 	"github.com/franela/goblin"
 	"go.uber.org/fx"
 
+	"github.com/mimiro-io/datahub"
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
@@ -64,7 +64,7 @@ func TestHttp(t *testing.T) {
 			devNull, _ := os.Open("/dev/null")
 			os.Stdout = devNull
 			os.Stderr = devNull
-			app, _ = Start(context.Background())
+			app, _ = datahub.Start(context.Background())
 			os.Stdout = oldOut
 			os.Stderr = oldErr
 			mockLayer = NewMockLayer()
@@ -73,7 +73,7 @@ func TestHttp(t *testing.T) {
 			}()
 		})
 		g.After(func() {
-			mockLayer.echo.Shutdown(context.Background())
+			_ = mockLayer.echo.Shutdown(context.Background())
 			ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
 			err := app.Stop(ctx)
 			defer cancel()
@@ -175,7 +175,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
 
-				bodyBytes, err := ioutil.ReadAll(res.Body)
+				bodyBytes, err := io.ReadAll(res.Body)
 				g.Assert(err).IsNil()
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
@@ -203,7 +203,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ := ioutil.ReadAll(res.Body)
+				bodyBytes, _ := io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
@@ -223,7 +223,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ := ioutil.ReadAll(res.Body)
+				bodyBytes, _ := io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
@@ -238,7 +238,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ = ioutil.ReadAll(res.Body)
+				bodyBytes, _ = io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				entities = nil
 				err = json.Unmarshal(bodyBytes, &entities)
@@ -283,7 +283,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ := ioutil.ReadAll(res.Body)
+				bodyBytes, _ := io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
@@ -297,7 +297,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ = ioutil.ReadAll(res.Body)
+				bodyBytes, _ = io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				entities = nil
 				err = json.Unmarshal(bodyBytes, &entities)
@@ -380,7 +380,7 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ := ioutil.ReadAll(res.Body)
+				bodyBytes, _ := io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
@@ -489,12 +489,12 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ := ioutil.ReadAll(res.Body)
+				bodyBytes, _ := io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				var entities []*server.Entity
 				err = json.Unmarshal(bodyBytes, &entities)
 				var m []map[string]interface{}
-				json.Unmarshal(bodyBytes, &m)
+				_ = json.Unmarshal(bodyBytes, &m)
 				g.Assert(err).IsNil()
 				g.Assert(len(entities)).Eql(12, "expected 10 entities plus @context and @continuation")
 				g.Assert(entities[1].ID).Eql("ns3:1")
@@ -505,10 +505,10 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ = ioutil.ReadAll(res.Body)
+				bodyBytes, _ = io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				err = json.Unmarshal(bodyBytes, &entities)
-				json.Unmarshal(bodyBytes, &m)
+				_ = json.Unmarshal(bodyBytes, &m)
 				g.Assert(err).IsNil()
 				g.Assert(len(entities)).Eql(92, "expected 90 entities plus @context and @continuation")
 				g.Assert(entities[1].ID).Eql("ns3:11")
@@ -519,10 +519,10 @@ func TestHttp(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotZero()
 				g.Assert(res.StatusCode).Eql(200)
-				bodyBytes, _ = ioutil.ReadAll(res.Body)
+				bodyBytes, _ = io.ReadAll(res.Body)
 				_ = res.Body.Close()
 				err = json.Unmarshal(bodyBytes, &entities)
-				json.Unmarshal(bodyBytes, &m)
+				_ = json.Unmarshal(bodyBytes, &m)
 				g.Assert(err).IsNil()
 				g.Assert(len(entities)).Eql(2, "expected 0 entities plus @context and @continuation")
 				g.Assert(entities[1].ID).Eql("@continuation")
@@ -1023,7 +1023,7 @@ type MockLayer struct {
 }
 
 type Continuation struct {
-	Id    string `json:"id"`
+	ID    string `json:"id"`
 	Token string `json:"token"`
 }
 
@@ -1045,7 +1045,7 @@ func NewMockLayer() *MockLayer {
 	e.POST("/datasets/tomatoes/entities", func(context echo.Context) error {
 		b, _ := io.ReadAll(context.Request().Body)
 		entities := []*server.Entity{}
-		json.Unmarshal(b, &entities)
+		_ = json.Unmarshal(b, &entities)
 		result.RecordedEntities["tomatoes"] = entities
 		result.RecordedBytes["tomatoes"] = b
 		result.RecordedHeaders = context.Request().Header
@@ -1078,24 +1078,25 @@ func NewMockLayer() *MockLayer {
 		if limit, ok := strconv.Atoi(l); ok == nil {
 			cnt = limit
 		}
-		if since == "" {
+		switch since {
+		case "":
 			// add some objects
 			for i := 0; i < cnt; i++ {
 				e := server.NewEntity("ex:c-"+strconv.Itoa(i), 0)
 				r = append(r, e)
 			}
-			c := &Continuation{Id: "@continuation", Token: "nextplease"}
+			c := &Continuation{ID: "@continuation", Token: "nextplease"}
 			r = append(r, c)
-		} else if since == "lastpage" {
-			c := &Continuation{Id: "@continuation", Token: "lastpage"}
+		case "lastpage":
+			c := &Continuation{ID: "@continuation", Token: "lastpage"}
 			r = append(r, c)
-		} else {
+		default:
 			// return more objects
 			for i := 100; i < 100+cnt; i++ {
 				e := server.NewEntity("ex:c-"+strconv.Itoa(i), 0)
 				r = append(r, e)
 			}
-			c := &Continuation{Id: "@continuation", Token: "lastpage"}
+			c := &Continuation{ID: "@continuation", Token: "lastpage"}
 			r = append(r, c)
 		}
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -70,7 +70,7 @@ func loadEnv(basePath *string, loadFromHome bool) (*Env, error) {
 			Middleware: viper.GetString("AUTHORIZATION_MIDDLEWARE"),
 		},
 		DlJwtConfig: &DatalayerJwtConfig{
-			ClientId:     viper.GetString("DL_JWT_CLIENT_ID"),
+			ClientID:     viper.GetString("DL_JWT_CLIENT_ID"),
 			ClientSecret: viper.GetString("DL_JWT_CLIENT_SECRET"),
 			Audience:     viper.GetString("DL_JWT_AUDIENCE"),
 			GrantType:    viper.GetString("DL_JWT_GRANT_TYPE"),
@@ -83,7 +83,7 @@ func loadEnv(basePath *string, loadFromHome bool) (*Env, error) {
 		MaxCompactionLevels:     viper.GetInt("MAX_COMPACTION_LEVELS"),
 		AdminUserName:           viper.GetString("ADMIN_USERNAME"),
 		AdminPassword:           viper.GetString("ADMIN_PASSWORD"),
-		NodeId:                  viper.GetString("NODE_ID"),
+		NodeID:                  viper.GetString("NODE_ID"),
 		SecurityStorageLocation: viper.GetString("SECURITY_STORAGE_LOCATION"),
 		BackupSourceLocation:    viper.GetString("BACKUP_SOURCE_LOCATION"),
 		RunnerConfig: &RunnerConfig{

--- a/internal/conf/config_test.go
+++ b/internal/conf/config_test.go
@@ -36,7 +36,6 @@ func TestLoadEnv(t *testing.T) {
 				g.Fail(err)
 			}
 			currentDir = d + "/../../.env-test"
-
 		})
 		g.It("should parse the test env file", func() {
 			env, err := loadEnv(&currentDir, false)
@@ -51,7 +50,6 @@ func TestLoadEnv(t *testing.T) {
 			_ = os.Unsetenv("PROFILE")
 		})
 	})
-
 }
 
 func TestParseEnvFromFile(t *testing.T) {
@@ -78,11 +76,10 @@ func TestParseEnvFromFile(t *testing.T) {
 			g.Assert(env.Port).Equal("9999")
 			g.Assert(env.StoreLocation).Equal("./test")
 			g.Assert(env.AgentHost).Equal("127.0.0.1:8125")
-
 		})
 
 		g.It("should have correct dl jwt values", func() {
-			g.Assert(env.DlJwtConfig.ClientId).Equal("id1")
+			g.Assert(env.DlJwtConfig.ClientID).Equal("id1")
 			g.Assert(env.DlJwtConfig.ClientSecret).Equal("some-secret")
 			g.Assert(env.DlJwtConfig.Audience).Equal("yes")
 			g.Assert(env.DlJwtConfig.GrantType).Equal("test")
@@ -94,7 +91,6 @@ func TestParseEnvFromFile(t *testing.T) {
 			g.Assert(env.Auth.Audience).Equal([]string{"https://example.io"})
 			g.Assert(env.Auth.Issuer).Equal([]string{"https://example.io"})
 			g.Assert(env.Auth.Middleware).Equal("noop")
-
 		})
 
 		g.It("should have opa configuration", func() {
@@ -152,7 +148,7 @@ func TestLoadEnvVariables(t *testing.T) {
 
 		g.It("should have read some env variables", func() {
 			g.Assert(c.Auth.WellKnown).Equal("https://example.io/jwks/.well-known/jwks.json")
-			g.Assert(c.DlJwtConfig.ClientId).Equal("12345")
+			g.Assert(c.DlJwtConfig.ClientID).Equal("12345")
 		})
 
 		g.It("should have set some default values", func() {

--- a/internal/conf/environment.go
+++ b/internal/conf/environment.go
@@ -39,7 +39,7 @@ type Env struct {
 	MaxCompactionLevels     int
 	AdminUserName           string
 	AdminPassword           string
-	NodeId                  string
+	NodeID                  string
 	SecurityStorageLocation string
 	BackupSourceLocation    string
 	RunnerConfig            *RunnerConfig
@@ -53,7 +53,7 @@ type AuthConfig struct {
 }
 
 type DatalayerJwtConfig struct {
-	ClientId     string
+	ClientID     string
 	ClientSecret string
 	Audience     string
 	GrantType    string

--- a/internal/conf/logger.go
+++ b/internal/conf/logger.go
@@ -60,7 +60,8 @@ func GetLogger(env string, level zapcore.Level) *zap.SugaredLogger {
 		}
 
 		logger, _ := cfg.Build()
-		slogger = logger.With(zap.String("service", "datahub"), zap.String("source", "go")).Sugar() // reconfigure with default field
+		// reconfigure with default field
+		slogger = logger.With(zap.String("service", "datahub"), zap.String("source", "go")).Sugar()
 	}
 
 	return slogger

--- a/internal/conf/logger_test.go
+++ b/internal/conf/logger_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/franela/goblin"
-
 	"go.uber.org/zap/zapcore"
 )
 

--- a/internal/conf/metrics.go
+++ b/internal/conf/metrics.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )

--- a/internal/conf/metrics.go
+++ b/internal/conf/metrics.go
@@ -16,12 +16,13 @@ package conf
 
 import (
 	"context"
-	"github.com/DataDog/datadog-go/v5/statsd"
 	"math"
 	"runtime"
 	"runtime/metrics"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"
@@ -44,7 +45,7 @@ func NewMetricsClient(lc fx.Lifecycle, env *Env, logger *zap.SugaredLogger) (sta
 	}
 
 	lc.Append(fx.Hook{
-		OnStop: func(ctx context.Context) error {
+		OnStop: func(_ context.Context) error {
 			env.Logger.Infof("Flushing statsd")
 			return client.Flush()
 		},
@@ -64,7 +65,7 @@ func NewMemoryReporter(lc fx.Lifecycle, statsd statsd.ClientInterface, logger *z
 		logger: logger,
 	}
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			mr.init()
 			return nil
 		},
@@ -87,11 +88,9 @@ func (mr *memoryReporter) init() {
 			mr.run(samples)
 		}
 	}()
-
 }
 
 func (mr *memoryReporter) run(samples []metrics.Sample) {
-
 	// Sample the metrics. Re-use the samples slice if you can!
 	metrics.Read(samples)
 

--- a/internal/conf/metrics_test.go
+++ b/internal/conf/metrics_test.go
@@ -15,9 +15,10 @@
 package conf
 
 import (
-	"github.com/mimiro-io/datahub/internal"
 	"reflect"
 	"testing"
+
+	"github.com/mimiro-io/datahub/internal"
 
 	"github.com/franela/goblin"
 	"go.uber.org/fx"

--- a/internal/conf/metrics_test.go
+++ b/internal/conf/metrics_test.go
@@ -18,13 +18,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mimiro-io/datahub/internal"
-
 	"github.com/franela/goblin"
 	"go.uber.org/fx"
-
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
 )
 
 func TestStatsdClient(t *testing.T) {

--- a/internal/conf/secrets/manager.go
+++ b/internal/conf/secrets/manager.go
@@ -15,10 +15,11 @@
 package secrets
 
 import (
+	"strings"
+
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
-	"strings"
 )
 
 type SecretStore interface {

--- a/internal/conf/secrets/manager.go
+++ b/internal/conf/secrets/manager.go
@@ -17,9 +17,10 @@ package secrets
 import (
 	"strings"
 
-	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 type SecretStore interface {

--- a/internal/conf/secrets/manager_test.go
+++ b/internal/conf/secrets/manager_test.go
@@ -16,10 +16,11 @@ package secrets
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestNewManager(t *testing.T) {
@@ -42,6 +43,5 @@ func TestNewManager(t *testing.T) {
 				g.Fail(errors.New("store is not NoopStore"))
 			}
 		})
-
 	})
 }

--- a/internal/conf/secrets/manager_test.go
+++ b/internal/conf/secrets/manager_test.go
@@ -19,8 +19,9 @@ import (
 	"testing"
 
 	"github.com/franela/goblin"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 func TestNewManager(t *testing.T) {

--- a/internal/conf/secrets/ssm.go
+++ b/internal/conf/secrets/ssm.go
@@ -95,7 +95,6 @@ func (p *SsmProperties) Value(key string) (string, bool) {
 		p.config.cache[key] = val
 		return val, true
 	}
-
 }
 
 // Params returns the full cached set of parameters as a map.
@@ -113,7 +112,6 @@ func (p *SsmProperties) loadParam(key string) (string, error) {
 	} else {
 		return *param.Value, nil
 	}
-
 }
 
 func (c *SsmManagerConfig) loadParams() (map[string]interface{}, error) {
@@ -152,7 +150,6 @@ func (c *SsmManagerConfig) getClient() (*awsssm.ParameterStore, error) {
 		store, err := awsssm.NewParameterStore(&aws.Config{
 			Region: aws.String("eu-west-1"),
 		})
-
 		if err != nil {
 			return nil, err
 		}

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -18,9 +18,10 @@ import (
 	"encoding/json"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/server"
-	"go.uber.org/zap"
 )
 
 type Content struct {

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -24,7 +24,7 @@ import (
 )
 
 type Content struct {
-	Id   string                 `json:"id"`
+	ID   string                 `json:"id"`
 	Data map[string]interface{} `json:"data"`
 }
 
@@ -53,14 +53,14 @@ func (contentConfig *Config) UpdateContent(id string, payload *Content) error {
 	return contentConfig.AddContent(id, payload)
 }
 
-// GetContentById returns a single content by its id
-func (contentConfig *Config) GetContentById(id string) (*Content, error) {
+// GetContentByID returns a single content by its id
+func (contentConfig *Config) GetContentByID(id string) (*Content, error) {
 	content := &Content{}
 	err := contentConfig.store.GetObject(server.CONTENT_INDEX, id, &content)
 	if err != nil {
 		return nil, err
 	}
-	if content.Id == "" {
+	if content.ID == "" {
 		return nil, nil
 	}
 	return content, nil

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -44,7 +44,7 @@ func NewContent(env *conf.Env, store *server.Store, statsd statsd.ClientInterfac
 
 // AddContent adds or replaces a new content entity to the store
 func (contentConfig *Config) AddContent(id string, payload *Content) error {
-	return contentConfig.store.StoreObject(server.CONTENT_INDEX, id, payload)
+	return contentConfig.store.StoreObject(server.ContentIndex, id, payload)
 }
 
 // UpdateContent updates an existing content (by calling AddContent)
@@ -56,7 +56,7 @@ func (contentConfig *Config) UpdateContent(id string, payload *Content) error {
 // GetContentByID returns a single content by its id
 func (contentConfig *Config) GetContentByID(id string) (*Content, error) {
 	content := &Content{}
-	err := contentConfig.store.GetObject(server.CONTENT_INDEX, id, &content)
+	err := contentConfig.store.GetObject(server.ContentIndex, id, &content)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (contentConfig *Config) GetContentByID(id string) (*Content, error) {
 // ListContents returns all content entities, in random order
 func (contentConfig *Config) ListContents() ([]*Content, error) {
 	var contents []*Content
-	err := contentConfig.store.IterateObjectsRaw(server.CONTENT_INDEX_BYTES, func(bytes []byte) error {
+	err := contentConfig.store.IterateObjectsRaw(server.ContentIndexBytes, func(bytes []byte) error {
 		content := &Content{}
 		err := json.Unmarshal(bytes, content)
 		if err != nil {
@@ -84,5 +84,5 @@ func (contentConfig *Config) ListContents() ([]*Content, error) {
 
 // DeleteContent deletes a single content from the store
 func (contentConfig *Config) DeleteContent(id string) error {
-	return contentConfig.store.DeleteObject(server.CONTENT_INDEX, id)
+	return contentConfig.store.DeleteObject(server.ContentIndex, id)
 }

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -72,7 +72,7 @@ func TestContent(t *testing.T) {
 			g.Assert(err).IsNil()
 
 			content2 := &Content{}
-			err = store.GetObject(server.CONTENT_INDEX, "test-import-content", content2)
+			err = store.GetObject(server.ContentIndex, "test-import-content", content2)
 			g.Assert(err).IsNil()
 
 			g.Assert(content2.ID).Eql("test-import-content")
@@ -95,7 +95,7 @@ func TestContent(t *testing.T) {
 
 			// read it back
 			content2 := &Content{}
-			err = store.GetObject(server.CONTENT_INDEX, "test-import-content", content2)
+			err = store.GetObject(server.ContentIndex, "test-import-content", content2)
 			g.Assert(err).IsNil()
 			g.Assert(content2.ID).Eql(content.ID)
 			g.Assert(content2.Data["baseUri"]).Eql("http://data.mimiro.io/test/")

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -20,15 +20,14 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/mimiro-io/datahub/internal"
-
-	"github.com/franela/goblin"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/mimiro-io/datahub/internal/conf"
-	"github.com/mimiro-io/datahub/internal/server"
+	"github.com/franela/goblin"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 func TestContent(t *testing.T) {

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -16,10 +16,11 @@ package content
 
 import (
 	"encoding/json"
-	"github.com/mimiro-io/datahub/internal"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/mimiro-io/datahub/internal"
 
 	"github.com/franela/goblin"
 
@@ -37,7 +38,7 @@ func TestContent(t *testing.T) {
 		var contentConfig *Config
 		var e *conf.Env
 		testCnt := 0
-		var js = ` {
+		js := ` {
 		  "id": "test-import-content",
 		  "data": {
 			  "databaseServer" : "example",
@@ -74,7 +75,7 @@ func TestContent(t *testing.T) {
 			err = store.GetObject(server.CONTENT_INDEX, "test-import-content", content2)
 			g.Assert(err).IsNil()
 
-			g.Assert(content2.Id).Eql("test-import-content")
+			g.Assert(content2.ID).Eql("test-import-content")
 		})
 
 		g.It("Should update content", func() {
@@ -82,21 +83,21 @@ func TestContent(t *testing.T) {
 			err := json.Unmarshal([]byte(js), content)
 			g.Assert(err).IsNil()
 
-			//save new content
+			// save new content
 			err = contentConfig.AddContent("test-import-content", content)
 			g.Assert(err).IsNil()
 			g.Assert(content.Data["baseUri"]).Eql("https://servers.example.io/")
 
-			//update content
+			// update content
 			content.Data["baseUri"] = "http://data.mimiro.io/test/"
 			err = contentConfig.UpdateContent("test-import-content", content)
 			g.Assert(err).IsNil()
 
-			//read it back
+			// read it back
 			content2 := &Content{}
 			err = store.GetObject(server.CONTENT_INDEX, "test-import-content", content2)
 			g.Assert(err).IsNil()
-			g.Assert(content2.Id).Eql(content.Id)
+			g.Assert(content2.ID).Eql(content.ID)
 			g.Assert(content2.Data["baseUri"]).Eql("http://data.mimiro.io/test/")
 		})
 
@@ -112,7 +113,7 @@ func TestContent(t *testing.T) {
 			err = json.Unmarshal([]byte(js), content2)
 			g.Assert(err).IsNil()
 
-			content2.Id = "test-2"
+			content2.ID = "test-2"
 			err = contentConfig.AddContent("test2", content2)
 			g.Assert(err).IsNil()
 

--- a/internal/jobs/job.go
+++ b/internal/jobs/job.go
@@ -153,7 +153,7 @@ func (job *job) Run() {
 		lastRun.LastError = err.Error()
 	}
 	// its not really a problem to ignore this error
-	_ = job.runner.store.StoreObject(server.JOB_RESULT_INDEX, job.id, lastRun)
+	_ = job.runner.store.StoreObject(server.JobResultIndex, job.id, lastRun)
 }
 
 var retryJobIds sync.Map

--- a/internal/jobs/job.go
+++ b/internal/jobs/job.go
@@ -16,10 +16,11 @@ package jobs
 
 import (
 	"fmt"
-	"github.com/bamzi/jobrunner"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/bamzi/jobrunner"
 
 	"github.com/mimiro-io/datahub/internal/server"
 )
@@ -35,7 +36,7 @@ type job struct {
 }
 
 type jobResult struct {
-	Id        string    `json:"id"`
+	ID        string    `json:"id"`
 	Title     string    `json:"title"`
 	Start     time.Time `json:"start"`
 	End       time.Time `json:"end"`
@@ -54,7 +55,7 @@ func (job *job) Run() {
 	if ticket == nil {
 		if job.pipeline.isFullSync() { // reschedule to try again in a bit
 			duration := 5 * time.Second
-			//TODO: read this through viper into env.Config? curretnly only used in unit test but could be useful as general config?
+			// TODO: read this through viper into env.Config? curretnly only used in unit test but could be useful as general config?
 			durationOverride, found := os.LookupEnv("JOB_FULLSYNC_RETRY_INTERVAL")
 			if found {
 				d, err := time.ParseDuration(durationOverride)
@@ -132,15 +133,17 @@ func (job *job) Run() {
 		_ = job.runner.statsdClient.Count("jobs.success", timed.Nanoseconds(), tags, 1)
 	}
 
-	job.runner.logger.Infow(fmt.Sprintf("Finished %s with id '%s' (%s) - duration was %s", msg, job.title, job.id, timed),
+	job.runner.logger.Infow(
+		fmt.Sprintf("Finished %s with id '%s' (%s) - duration was %s", msg, job.title, job.id, timed),
 		"job.jobId", job.id,
 		"job.jobTitle", job.title,
 		"job.state", "Finished",
-		"job.jobType", jobType)
+		"job.jobType", jobType,
+	)
 
 	// we store the last run info
 	lastRun := &jobResult{
-		Id:        job.id,
+		ID:        job.id,
 		Title:     job.title,
 		Start:     ticket.runState.started,
 		End:       time.Now(),

--- a/internal/jobs/pipeline.go
+++ b/internal/jobs/pipeline.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	jobSource "github.com/mimiro-io/datahub/internal/jobs/source"
-
 	"github.com/mimiro-io/datahub/internal/server"
 )
 

--- a/internal/jobs/pipeline.go
+++ b/internal/jobs/pipeline.go
@@ -55,7 +55,7 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 	runner := job.runner
 
 	syncJobState := &SyncJobState{}
-	err := runner.store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+	err := runner.store.GetObject(server.JobDataIndex, job.id, syncJobState)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 	//Exception is when used with MultiSource... MultiSource only operates on changes. also in fullsync mode.
 	//   Difference there between fullsync and incremental is whether dependencies are processed
 	if pipeline.sink.GetConfig()["Type"] != "HttpDatasetSink" || pipeline.source.GetConfig()["Type"] == "MultiSource" {
-		err = runner.store.StoreObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+		err = runner.store.StoreObject(server.JobDataIndex, job.id, syncJobState)
 		if err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) error {
 	runner := job.runner
 
 	syncJobState := &SyncJobState{}
-	err := runner.store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+	err := runner.store.GetObject(server.JobDataIndex, job.id, syncJobState)
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) error {
 						return err
 					}
 
-					err = runner.store.StoreObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+					err = runner.store.StoreObject(server.JobDataIndex, job.id, syncJobState)
 					if err != nil {
 						return err
 					}

--- a/internal/jobs/pipeline.go
+++ b/internal/jobs/pipeline.go
@@ -44,8 +44,10 @@ type PipelineSpec struct {
 	transform Transform
 	batchSize int
 }
-type FullSyncPipeline struct{ PipelineSpec }
-type IncrementalPipeline struct{ PipelineSpec }
+type (
+	FullSyncPipeline    struct{ PipelineSpec }
+	IncrementalPipeline struct{ PipelineSpec }
+)
 
 func (pipeline *FullSyncPipeline) spec() PipelineSpec { return pipeline.PipelineSpec }
 func (pipeline *FullSyncPipeline) isFullSync() bool   { return true }
@@ -61,14 +63,14 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 
 	keepReading := true
 
-	//dont call source.startFullSync, just sink.startFullSync. to make sure we run on changes.
-	//exception is when the sink is http(we want to process entities instead of changes)
-	//or source is multisource (we need to grab watermarks at beginning of fullsync)
+	// dont call source.startFullSync, just sink.startFullSync. to make sure we run on changes.
+	// exception is when the sink is http(we want to process entities instead of changes)
+	// or source is multisource (we need to grab watermarks at beginning of fullsync)
 	if pipeline.sink.GetConfig()["Type"] == "HttpDatasetSink" ||
 		pipeline.source.GetConfig()["Type"] == "MultiSource" {
-		if pipeline.source.GetConfig()["Type"] == "MultiSource" {
-			//return errors.New("MultiSource can only produce changes and must therefore not be used with HttpDatasetSink")
-		}
+		// if pipeline.source.GetConfig()["Type"] == "MultiSource" {
+		// 	return errors.New("MultiSource can only produce changes and must therefore not be used with HttpDatasetSink")
+		// }
 		pipeline.source.StartFullSync()
 	}
 	err = pipeline.sink.startFullSync(runner)
@@ -88,34 +90,34 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 				keepReading = false
 				return errors.New("got job interrupt")
 			default:
-				var err error
+				var err2 error
 				incomingEntityCount := len(entities)
 
 				if incomingEntityCount > 0 {
 					// apply transform if it exists
 					if pipeline.transform != nil {
-						transformTs := time.Now()
-						entities, err = pipeline.transform.transformEntities(runner, entities, job.title)
-						_ = runner.statsdClient.Timing("pipeline.transform.batch", time.Since(transformTs), tags, 1)
-						if err != nil {
-							return err
+						transformTS := time.Now()
+						entities, err2 = pipeline.transform.transformEntities(runner, entities, job.title)
+						_ = runner.statsdClient.Timing("pipeline.transform.batch", time.Since(transformTS), tags, 1)
+						if err2 != nil {
+							return err2
 						}
 					}
 
 					// write to sink
-					sinkTs := time.Now()
-					err = pipeline.sink.processEntities(runner, entities)
-					_ = runner.statsdClient.Timing("pipeline.sink.batch", time.Since(sinkTs), tags, 1)
-					if err != nil {
-						return err
+					sinkTS := time.Now()
+					err2 = pipeline.sink.processEntities(runner, entities)
+					_ = runner.statsdClient.Timing("pipeline.sink.batch", time.Since(sinkTS), tags, 1)
+					if err2 != nil {
+						return err2
 					}
 				}
 
 				// capture token if there is one
 				if continuationToken.GetToken() != "" {
-					syncJobState.ContinuationToken, err = continuationToken.Encode()
-					if err != nil {
-						return err
+					syncJobState.ContinuationToken, err2 = continuationToken.Encode()
+					if err2 != nil {
+						return err2
 					}
 				}
 
@@ -127,17 +129,17 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) error {
 			return nil
 		}
 
-		readTs := time.Now()
-		token, err := jobSource.DecodeToken(pipeline.source.GetConfig()["Type"], syncJobState.ContinuationToken)
-		if err != nil {
-			return err
+		readTS := time.Now()
+		token, err2 := jobSource.DecodeToken(pipeline.source.GetConfig()["Type"], syncJobState.ContinuationToken)
+		if err2 != nil {
+			return err2
 		}
 
 		err = pipeline.source.ReadEntities(token, pipeline.batchSize,
 			func(entities []*server.Entity, c jobSource.DatasetContinuation) error {
-				_ = runner.statsdClient.Timing("pipeline.source.batch", time.Since(readTs), tags, 1)
+				_ = runner.statsdClient.Timing("pipeline.source.batch", time.Since(readTS), tags, 1)
 				result := processEntities(entities, c)
-				readTs = time.Now()
+				readTS = time.Now()
 				return result
 			})
 
@@ -204,7 +206,7 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) error {
 				if incomingEntityCount > 0 {
 					// apply transform if it exists
 					if pipeline.transform != nil {
-						transformTs := time.Now()
+						transformTS := time.Now()
 
 						parallelisms := pipeline.transform.getParallelism()
 						if len(entities) < parallelisms {
@@ -263,16 +265,16 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) error {
 							entities = append(entities, res.entities...)
 						}
 
-						err = runner.statsdClient.Timing("pipeline.transform.batch", time.Since(transformTs), tags, 1)
+						err = runner.statsdClient.Timing("pipeline.transform.batch", time.Since(transformTS), tags, 1)
 						if err != nil {
 							return err
 						}
 					}
 
 					// write to sink
-					sinkTs := time.Now()
+					sinkTS := time.Now()
 					err = pipeline.sink.processEntities(runner, entities)
-					_ = runner.statsdClient.Timing("pipeline.sink.batch", time.Since(sinkTs), tags, 1)
+					_ = runner.statsdClient.Timing("pipeline.sink.batch", time.Since(sinkTS), tags, 1)
 					if err != nil {
 						return err
 					}
@@ -299,7 +301,7 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) error {
 			return nil
 		}
 
-		readTs := time.Now()
+		readTS := time.Now()
 		since, err := jobSource.DecodeToken(pipeline.source.GetConfig()["Type"], syncJobState.ContinuationToken)
 		if err != nil {
 			return err
@@ -307,9 +309,9 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) error {
 		err = pipeline.source.ReadEntities(since,
 			pipeline.batchSize,
 			func(entities []*server.Entity, c jobSource.DatasetContinuation) error {
-				_ = runner.statsdClient.Timing("pipeline.source.batch", time.Since(readTs), tags, 1)
+				_ = runner.statsdClient.Timing("pipeline.source.batch", time.Since(readTS), tags, 1)
 				result := processEntities(entities, c)
-				readTs = time.Now()
+				readTS = time.Now()
 				return result
 			})
 

--- a/internal/jobs/pipeline_history_test.go
+++ b/internal/jobs/pipeline_history_test.go
@@ -17,11 +17,12 @@ package jobs
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/franela/goblin"
 	"math"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/franela/goblin"
 
 	"github.com/mimiro-io/datahub/internal/server"
 )
@@ -53,7 +54,6 @@ func TestPipelineHistory(t *testing.T) {
 			// undo redirect of stdout and stderr after successful init of fx and jobrunner
 			os.Stderr = oldErr
 			os.Stdout = oldStd
-
 		})
 		g.AfterEach(func() {
 			runner.Stop()
@@ -79,25 +79,24 @@ func TestPipelineHistory(t *testing.T) {
 			checkEntities("homer_1", "Mimiro_1", "")
 			checkChange(0, "homer_1", "Mimiro_1", "")
 			assertChangeCount(1)
-
 		})
 		g.It("Should produce consistent output for changes in dependency dataset", func() {
 			ns, employees, people, companies := setupDatasets(store, dsm)
 			job := setupJob(scheduler, g, runner, false)
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
 			checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
-			//checkChange, checkEntities, assertChangeCount, printState := setupCheckers(g, t, employees, people, companies, ns)
+			// checkChange, checkEntities, assertChangeCount, printState := setupCheckers(g, t, employees, people, companies, ns)
 
 			g.Assert(homer("homer_1")).IsNil()
 			g.Assert(mimiro("Mimiro_1")).IsNil()
-			//change company
+			// change company
 			g.Assert(mimiro("Mimiro_2")).IsNil()
 
 			// run job many times, output should not change
 			for i := 0; i < 10; i++ {
 				job.Run()
 			}
-			//printState()
+			// printState()
 			checkEntities("homer_1", "Mimiro_2", "")
 			checkChange(0, "homer_1", "Mimiro_2", "")
 			assertChangeCount(1)
@@ -106,12 +105,13 @@ func TestPipelineHistory(t *testing.T) {
 			ns, employees, people, companies := setupDatasets(store, dsm)
 			job := setupJob(scheduler, g, runner, false)
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			//checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
-			checkChange, checkEntities, assertChangeCount, printState := setupCheckers(g, t, employees, people, companies, ns)
+			// checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
+			checkChange, checkEntities, assertChangeCount, printState := setupCheckers(
+				g, t, employees, people, companies, ns)
 
 			g.Assert(homer("homer_1")).IsNil()
 			g.Assert(mimiro("Mimiro_1")).IsNil()
-			//change homer
+			// change homer
 			g.Assert(homer("homer_2")).IsNil()
 
 			// run job many times, output should not change
@@ -130,12 +130,13 @@ func TestPipelineHistory(t *testing.T) {
 			ns, employees, people, companies := setupDatasets(store, dsm)
 			job := setupJob(scheduler, g, runner, true)
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			//checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
-			checkChange, checkEntities, assertChangeCount, printState := setupCheckers(g, t, employees, people, companies, ns)
+			// checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
+			checkChange, checkEntities, assertChangeCount, printState := setupCheckers(
+				g, t, employees, people, companies, ns)
 
 			g.Assert(homer("homer_1")).IsNil()
 			g.Assert(mimiro("Mimiro_1")).IsNil()
-			//change homer
+			// change homer
 			g.Assert(homer("homer_2")).IsNil()
 
 			// run job many times, output should not change
@@ -144,7 +145,9 @@ func TestPipelineHistory(t *testing.T) {
 			}
 			printState()
 			checkEntities("homer_2", "Mimiro_1", "")
-			assertChangeCount(1) //only one version of homer is expected to be emitted, therefore only one resulting change version
+			assertChangeCount(
+				1,
+			) // only one version of homer is expected to be emitted, therefore only one resulting change version
 			checkChange(0, "homer_2", "Mimiro_1", "")
 		})
 		g.It("Should produce consistent output for 2 changes in different batches", func() {
@@ -153,7 +156,8 @@ func TestPipelineHistory(t *testing.T) {
 			// set batchsize to 2
 			job.pipeline.(*FullSyncPipeline).batchSize = 2
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
+			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+				g, t, employees, people, companies, ns)
 			//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
 
 			g.Assert(homer("homer_1")).IsNil()
@@ -175,7 +179,6 @@ func TestPipelineHistory(t *testing.T) {
 			checkChange(13, "homer_2", "Mimiro_2", "")
 			checkChange(14, "homer_3", "Mimiro_2", "")
 			assertChangeCount(15) //"3 changes in source, time 5 job runs"
-
 		})
 		g.It("Should produce consistent output for 2 LastOnly changes in different batches", func() {
 			ns, employees, people, companies := setupDatasets(store, dsm)
@@ -183,7 +186,8 @@ func TestPipelineHistory(t *testing.T) {
 			// set batchsize to 2
 			job.pipeline.(*FullSyncPipeline).batchSize = 2
 			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
+			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+				g, t, employees, people, companies, ns)
 			//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
 
 			g.Assert(homer("homer_1")).IsNil()
@@ -199,8 +203,7 @@ func TestPipelineHistory(t *testing.T) {
 			print()
 			checkEntities("homer_3", "Mimiro_2", "")
 			checkChange(0, "homer_3", "Mimiro_2", "")
-			assertChangeCount(1) //since only one "Latest" version of homer is emitted, we expect only one result
-
+			assertChangeCount(1) // since only one "Latest" version of homer is emitted, we expect only one result
 		})
 		g.It("Should preserve state of composed change products also if sources change with time", func() {
 			/*
@@ -216,7 +219,8 @@ func TestPipelineHistory(t *testing.T) {
 			ns, employees, people, companies := setupDatasets(store, dsm)
 			job := setupJob(scheduler, g, runner, false)
 			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
+			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+				g, t, employees, people, companies, ns)
 
 			// store first version of "homer"
 			// and first version of "mimiro"
@@ -271,7 +275,8 @@ func TestPipelineHistory(t *testing.T) {
 			ns, employees, people, companies := setupDatasets(store, dsm)
 			job := setupJob(scheduler, g, runner, true)
 			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
+			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+				g, t, employees, people, companies, ns)
 
 			// store first version of "homer"
 			// and first version of "mimiro"
@@ -333,7 +338,8 @@ func TestPipelineHistory(t *testing.T) {
 			ns, employees, people, companies := setupDatasets(store, dsm)
 			job := setupJob(scheduler, g, runner, false)
 			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(g, t, employees, people, companies, ns)
+			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+				g, t, employees, people, companies, ns)
 
 			// store first version of "homer"
 			// and first version of "mimiro"
@@ -368,11 +374,18 @@ func TestPipelineHistory(t *testing.T) {
 	})
 }
 
-func setupCheckers(g *goblin.G, t *testing.T, employees *server.Dataset, people *server.Dataset, companies *server.Dataset, ns string) (
+func setupCheckers(
+	g *goblin.G,
+	t *testing.T,
+	employees *server.Dataset,
+	people *server.Dataset,
+	companies *server.Dataset,
+	ns string,
+) (
 	func(changeIdx int, expectedHomerName string, expedtedMimiroName string, expectedHomerFriend string),
 	func(expectedHomerName string, expedtedMimiroName string, expectedHomerFriend string),
-	func(expectedCount int), func()) {
-
+	func(expectedCount int), func(),
+) {
 	fv := func(homerFriend string, ns string) interface{} {
 		var friendVal interface{}
 		if homerFriend != "" {
@@ -390,7 +403,8 @@ func setupCheckers(g *goblin.G, t *testing.T, employees *server.Dataset, people 
 		g.Assert(entities.Entities[0].IsDeleted).IsFalse()
 		g.Assert(entities.Entities[0].Properties).Eql(map[string]interface{}{
 			"companyname": mimiroName,
-			"name":        homerName})
+			"name":        homerName,
+		})
 		g.Assert(entities.Entities[0].References[ns+":friend"]).Eql(friendVal)
 	}
 
@@ -413,18 +427,18 @@ func setupCheckers(g *goblin.G, t *testing.T, employees *server.Dataset, people 
 		}
 		// print out state
 		result, _ := people.GetChanges(0, math.MaxInt, false)
-		//t.Logf("\npeople change count: %v", len(result.Entities))
+		// t.Logf("\npeople change count: %v", len(result.Entities))
 		for _, e := range result.Entities {
 			t.Logf("people: %+v; %+v", e.Properties, e.References)
 		}
 		result, _ = companies.GetChanges(0, math.MaxInt, false)
-		//t.Logf("\ncompanies change count: %v", len(result.Entities))
+		// t.Logf("\ncompanies change count: %v", len(result.Entities))
 		for _, e := range result.Entities {
 			t.Logf("companies: %+v", e.Properties)
 		}
 		result, _ = employees.GetChanges(0, math.MaxInt, false)
-		//t.Log("\nexpected employees change count: 8 (baseline plus 7 changes)")
-		//t.Logf("\nemployees change count: %v", len(result.Entities))
+		// t.Log("\nexpected employees change count: 8 (baseline plus 7 changes)")
+		// t.Logf("\nemployees change count: %v", len(result.Entities))
 
 		for _, e := range result.Entities {
 			t.Logf("changes: %+v; %+v", e.Properties, e.References)
@@ -439,8 +453,11 @@ func setupCheckers(g *goblin.G, t *testing.T, employees *server.Dataset, people 
 	return checkChanges, checkEntities, assertChangeCount, printState
 }
 
-func entityUpdaters(people *server.Dataset, ns string, companies *server.Dataset) (func(name string) error,
-	func(name string) error, func(name string) error) {
+func entityUpdaters(people *server.Dataset, ns string, companies *server.Dataset) (
+	func(name string) error,
+	func(name string) error,
+	func(name string) error,
+) {
 	homer := func(name string) error {
 		return people.StoreEntities([]*server.Entity{server.NewEntityFromMap(map[string]interface{}{
 			"id":    ns + ":homer",
@@ -498,7 +515,7 @@ func setupJob(scheduler *Scheduler, g *goblin.G, runner *Runner, latestOnly bool
 	pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
 	g.Assert(err).IsNil()
 	job := &job{
-		id:       jobConfig.Id,
+		id:       jobConfig.ID,
 		pipeline: pipeline,
 		schedule: jobConfig.Triggers[0].Schedule,
 		runner:   runner,
@@ -506,7 +523,10 @@ func setupJob(scheduler *Scheduler, g *goblin.G, runner *Runner, latestOnly bool
 	return job
 }
 
-func setupDatasets(store *server.Store, dsm *server.DsManager) (string, *server.Dataset, *server.Dataset, *server.Dataset) {
+func setupDatasets(
+	store *server.Store,
+	dsm *server.DsManager,
+) (string, *server.Dataset, *server.Dataset, *server.Dataset) {
 	ns, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://namespace/")
 	// we have two source datasets: People and Companies
 	people, _ := dsm.CreateDataset("People", nil)

--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -63,7 +63,6 @@ func TestPipeline(t *testing.T) {
 			// undo redirect of stdout and stderr after successful init of fx and jobrunner
 			os.Stderr = oldErr
 			os.Stdout = oldStd
-
 		})
 		g.AfterEach(func() {
 			runner.Stop()
@@ -106,7 +105,7 @@ func TestPipeline(t *testing.T) {
 			jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
 
 			// define job
-			jobJson := `
+			jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -122,12 +121,12 @@ func TestPipeline(t *testing.T) {
 				"Type" : "DevNullSink"
 			}
 		}`
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -182,7 +181,7 @@ func TestPipeline(t *testing.T) {
 			jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
 
 			// define job
-			jobJson := `
+			jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -198,12 +197,12 @@ func TestPipeline(t *testing.T) {
 				"Type" : "DevNullSink"
 			}
 		}`
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -238,7 +237,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(err).IsNil("dataset.StoreEntites returns no error")
 
 			dsName := "fstohttp"
-			jobJson := `{
+			jobJSON := `{
 			"id" : "sync-datasetssource-to-httpdatasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
 			"fullSyncSchedule" : "@every 2s",
@@ -253,12 +252,12 @@ func TestPipeline(t *testing.T) {
 				"Url" : "http://localhost:7777/datasets/` + dsName + `/fullsync"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
 			g.Assert(err).IsNil("jobConfig to Pipeline returns no error")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -276,7 +275,7 @@ func TestPipeline(t *testing.T) {
 			ds, _ := dsm.CreateDataset("People", nil)
 
 			// define job
-			jobJson := `{
+			jobJSON := `{
 			"id" : "sync-httpdatasetsource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
 			"source" : {
@@ -288,12 +287,12 @@ func TestPipeline(t *testing.T) {
 				"Name" : "People"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
 			g.Assert(err).IsNil("jobConfig to Pipeline returns no error")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -311,7 +310,7 @@ func TestPipeline(t *testing.T) {
 			ds, _ := dsm.CreateDataset("People", nil)
 
 			// define job
-			jobJson := `
+			jobJSON := `
 		{
 			"id" : "sync-httpdatasetsource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
@@ -325,12 +324,12 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
 			g.Assert(err).IsNil("jobConfig to Pipeline returns no error")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -343,7 +342,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(len(rs.Entities)).Eql(20, "we found 10 entites (MockService generates 20 results)")
 		})
 
-		//func TestDatasetToHttpDatasetSink(m *testing.T) {
+		// func TestDatasetToHttpDatasetSink(m *testing.T) {
 		g.It("Should incrementally sync to an HttpDatasetSink", func() {
 			// populate dataset with some entities
 			ds, _ := dsm.CreateDataset("Products", nil)
@@ -359,7 +358,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(err).IsNil("Entities are stored correctly")
 
 			// define job
-			jobJson := `
+			jobJSON := `
 		{
 			"id" : "sync-datasetssource-to-httpdatasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -373,12 +372,12 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed correctly")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -406,7 +405,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(err).IsNil("entities are stored")
 
 			// define job
-			jobJson := `
+			jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -425,12 +424,12 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -467,7 +466,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(err).IsNil("entities are stored")
 
 			// define job
-			jobJson := `
+			jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -485,12 +484,12 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -508,7 +507,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(len(result.Entities)).Eql(2, "correct number of entities retrieved")
 		})
 
-		//func TestDatasetToDatasetWithJavascriptTransformJob(m *testing.T) {
+		// func TestDatasetToDatasetWithJavascriptTransformJob(m *testing.T) {
 		g.It("Should incrementally do internal sync with js transform", func() {
 			// populate dataset with some entities
 			ds, _ := dsm.CreateDataset("Products", nil)
@@ -525,7 +524,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(err).IsNil("entities are stored")
 
 			// define job
-			jobJson := `
+			jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -543,12 +542,12 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -566,8 +565,10 @@ func TestPipeline(t *testing.T) {
 			g.Assert(len(result.Entities)).Eql(1, "correct number of entities retrieved")
 		})
 		g.It("Should run a transform with query in internal jobs", func() {
-			testNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/test/")
-
+			testNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion(
+				"http://data.mimiro.io/test/",
+			)
+			g.Assert(err).IsNil()
 			// populate dataset with some entities
 			ds, _ := dsm.CreateDataset("People", nil)
 			ds1, _ := dsm.CreateDataset("Companies", nil)
@@ -604,7 +605,7 @@ func TestPipeline(t *testing.T) {
 		    return entities;
 		}`
 			// define job
-			jobJson := fmt.Sprintf(`{
+			jobJSON := fmt.Sprintf(`{
 			"id" : "sync-datasetsource-to-datasetsink-with-js-and-query",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -620,12 +621,12 @@ func TestPipeline(t *testing.T) {
                 "Name" : "NewPeople"
 			}}`, base64.StdEncoding.EncodeToString([]byte(jsFun)))
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil()
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -641,7 +642,10 @@ func TestPipeline(t *testing.T) {
 			g.Assert(result.Entities[0].Properties["ns3:companyname"]).Eql("Mimiro")
 		})
 		g.It("Should run a transform with subentities in internal jobs", func() {
-			testNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/test/")
+			testNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion(
+				"http://data.mimiro.io/test/",
+			)
+			g.Assert(err).IsNil()
 
 			// populate dataset with some entities
 			ds, _ := dsm.CreateDataset("People", nil)
@@ -691,7 +695,7 @@ func TestPipeline(t *testing.T) {
 		    return result;
 		}`
 			// define job
-			jobJson := fmt.Sprintf(`{
+			jobJSON := fmt.Sprintf(`{
 			"id" : "sync-datasetsource-to-datasetsink-with-js-and-query",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -707,12 +711,12 @@ func TestPipeline(t *testing.T) {
                 "Name" : "NewPeople"
 			}}`, base64.StdEncoding.EncodeToString([]byte(jsFun)))
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil()
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -745,7 +749,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(ds.StoreEntities(entities)).IsNil()
 
 			// define job
-			jobJson := `{
+			jobJSON := `{
 			"id" : "sync-datasetsource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -761,12 +765,12 @@ func TestPipeline(t *testing.T) {
                 "Name" : "NewProducts"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil()
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -782,7 +786,7 @@ func TestPipeline(t *testing.T) {
 		})
 
 		g.It("Should not write to the sink if an external transform endpoint is 404", func() {
-			jobJson := ` {
+			jobJSON := ` {
 			"id" : "sync-httpdatasetsource-to-datasetsink-1",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -794,12 +798,12 @@ func TestPipeline(t *testing.T) {
 				"Name" : "People"
 			} }`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil()
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -822,7 +826,7 @@ func TestPipeline(t *testing.T) {
 
 			g.Assert(ds.StoreEntities(entities)).IsNil()
 
-			jobJson := ` {
+			jobJSON := ` {
 			"id" : "sync-datasetsource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -834,12 +838,12 @@ func TestPipeline(t *testing.T) {
                 "Name" : "NewProducts"
 			} }`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil()
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -857,7 +861,7 @@ func TestPipeline(t *testing.T) {
 		g.It("Should copy from samplesource to datasetsink in first run of new job", func() {
 			_, _ = dsm.CreateDataset("People", nil)
 
-			jobJson := `{
+			jobJSON := `{
 			"id" : "sync-samplesource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -869,12 +873,12 @@ func TestPipeline(t *testing.T) {
 				"Name" : "People"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil()
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -892,7 +896,7 @@ func TestPipeline(t *testing.T) {
 		g.It("Should copy from HttpDatasetSource to datasetSink in first run of new job", func() {
 			_, _ = dsm.CreateDataset("People", nil)
 
-			jobJson := `{
+			jobJSON := `{
 			"id" : "sync-httpdatasetsource-to-datasetsink-1",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -904,12 +908,12 @@ func TestPipeline(t *testing.T) {
 				"Name" : "People"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil()
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -923,92 +927,97 @@ func TestPipeline(t *testing.T) {
 			g.Assert(err).IsNil()
 			g.Assert(len(result.Entities)).Eql(10)
 		})
-		g.It("Should copy all pages using continuatin tokens from httpDatasetSource to datasetSink if first run", func() {
-			_, _ = dsm.CreateDataset("People", nil)
+		g.It(
+			"Should copy all pages using continuatin tokens from httpDatasetSource to datasetSink if first run",
+			func() {
+				_, _ = dsm.CreateDataset("People", nil)
 
-			jobJson := `{
-			"id" : "sync-httpdatasetsource-to-datasetsink-1",
-			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
-			"source" : {
-				"Type" : "HttpDatasetSource",
-				"Url" : "http://localhost:7777/datasets/people/changeswithcontinuation"
+				jobJSON := `{
+					"id" : "sync-httpdatasetsource-to-datasetsink-1",
+					"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
+					"source" : {
+						"Type" : "HttpDatasetSource",
+						"Url" : "http://localhost:7777/datasets/people/changeswithcontinuation"
+					},
+					"sink" : {
+						"Type" : "DatasetSink",
+						"Name" : "People"
+					} }`
+
+				jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+				pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+				g.Assert(err).IsNil()
+
+				job := &job{
+					id:       jobConfig.ID,
+					pipeline: pipeline,
+					schedule: jobConfig.Triggers[0].Schedule,
+					runner:   runner,
+				}
+
+				// run once
+				job.Run()
+
+				// get entities from people dataset
+				peopleDataset := dsm.GetDataset("People")
+				result, err := peopleDataset.GetEntities("", 50)
+				g.Assert(err).IsNil()
+				g.Assert(len(result.Entities)).Eql(20)
+
+				// run again
+				job.Run()
+				peopleDataset = dsm.GetDataset("People")
+				result, err = peopleDataset.GetEntities("", 50)
+				g.Assert(err).IsNil()
+				g.Assert(len(result.Entities)).Eql(20, "results should stay the same")
 			},
-			"sink" : {
-				"Type" : "DatasetSink",
-				"Name" : "People"
-			} }`
+		)
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
+		g.It(
+			"Should mark entities that have not been received again during fullsync to internal dataset as deleted",
+			func() {
+				sourceDs, _ := dsm.CreateDataset("people", nil)
+				sinkDs, _ := dsm.CreateDataset("people2", nil)
 
-			job := &job{
-				id:       jobConfig.Id,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+				e1 := server.NewEntity("1", 0)
+				e2 := server.NewEntity("2", 0)
+				_ = sourceDs.StoreEntities([]*server.Entity{e1, e2})
 
-			// run once
-			job.Run()
+				pipeline := &FullSyncPipeline{PipelineSpec{
+					source: &source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm},
+					sink:   &datasetSink{DatasetName: "people2", Store: store, DatasetManager: dsm},
+				}}
 
-			// get entities from people dataset
-			peopleDataset := dsm.GetDataset("People")
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(20)
+				job := &job{id: "fullsync-1", pipeline: pipeline, runner: runner}
 
-			// run again
-			job.Run()
-			peopleDataset = dsm.GetDataset("People")
-			result, err = peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(20, "results should stay the same")
-		})
+				// run once, both entities should sync
+				job.Run()
 
-		g.It("Should mark entities that have not been received again during fullsync to internal dataset as deleted", func() {
-			sourceDs, _ := dsm.CreateDataset("people", nil)
-			sinkDs, _ := dsm.CreateDataset("people2", nil)
+				res, err := sinkDs.GetEntities("", 100)
+				g.Assert(err).IsNil()
+				g.Assert(len(res.Entities)).Eql(2)
+				g.Assert(res.Entities[0].ID).Eql("1")
+				g.Assert(res.Entities[0].IsDeleted).Eql(false)
+				g.Assert(res.Entities[1].ID).Eql("2")
+				g.Assert(res.Entities[1].IsDeleted).Eql(false)
 
-			e1 := server.NewEntity("1", 0)
-			e2 := server.NewEntity("2", 0)
-			_ = sourceDs.StoreEntities([]*server.Entity{e1, e2})
+				// delete ds and recreate with only 1 entity
+				g.Assert(dsm.DeleteDataset("people")).IsNil()
+				sourceDs, _ = dsm.CreateDataset("people", nil)
+				g.Assert(sourceDs.StoreEntities([]*server.Entity{e2})).IsNil()
 
-			pipeline := &FullSyncPipeline{PipelineSpec{
-				source: &source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm},
-				sink:   &datasetSink{DatasetName: "people2", Store: store, DatasetManager: dsm},
-			}}
+				// run again. deletion detection should apply
+				job.Run()
 
-			job := &job{id: "fullsync-1", pipeline: pipeline, runner: runner}
-
-			// run once, both entities should sync
-			job.Run()
-
-			res, err := sinkDs.GetEntities("", 100)
-			g.Assert(err).IsNil()
-			g.Assert(len(res.Entities)).Eql(2)
-			g.Assert(res.Entities[0].ID).Eql("1")
-			g.Assert(res.Entities[0].IsDeleted).Eql(false)
-			g.Assert(res.Entities[1].ID).Eql("2")
-			g.Assert(res.Entities[1].IsDeleted).Eql(false)
-
-			// delete ds and recreate with only 1 entity
-			g.Assert(dsm.DeleteDataset("people")).IsNil()
-			sourceDs, _ = dsm.CreateDataset("people", nil)
-			g.Assert(sourceDs.StoreEntities([]*server.Entity{e2})).IsNil()
-
-			// run again. deletion detection should apply
-			job.Run()
-
-			res, err = sinkDs.GetEntities("", 100)
-			g.Assert(err).IsNil()
-			g.Assert(len(res.Entities)).Eql(2)
-			g.Assert(res.Entities[0].ID).Eql("1")
-			g.Assert(res.Entities[0].IsDeleted).Eql(true, "Entity 1 should be deleted now")
-			g.Assert(res.Entities[1].ID).Eql("2")
-			g.Assert(res.Entities[1].IsDeleted).Eql(false)
-
-		})
+				res, err = sinkDs.GetEntities("", 100)
+				g.Assert(err).IsNil()
+				g.Assert(len(res.Entities)).Eql(2)
+				g.Assert(res.Entities[0].ID).Eql("1")
+				g.Assert(res.Entities[0].IsDeleted).Eql(true, "Entity 1 should be deleted now")
+				g.Assert(res.Entities[1].ID).Eql("2")
+				g.Assert(res.Entities[1].IsDeleted).Eql(false)
+			},
+		)
 		g.It("Should store continuation token after every page in incremental job", func() {
 			pipeline := &IncrementalPipeline{PipelineSpec{
 				batchSize: 5,
@@ -1017,7 +1026,7 @@ func TestPipeline(t *testing.T) {
 			}}
 			job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
 
-			//run async, so we can verify tokens in parallel
+			// run async, so we can verify tokens in parallel
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			go func() {
@@ -1025,13 +1034,13 @@ func TestPipeline(t *testing.T) {
 				wg.Done()
 			}()
 
-			//block and wait for channel notification - indicating the first page/batch has been received
-			_ = <-mockService.HttpNotificationChannel
+			// block and wait for channel notification - indicating the first page/batch has been received
+			<-mockService.HttpNotificationChannel
 			g.Assert(len(mockService.getRecordedEntitiesForDataset("inctest"))).
 				Eql(5, "After first batch, 5 entities should have been postet to httpSink")
 
-			//block for next batch request finished - this should be before syncState is updated
-			_ = <-mockService.HttpNotificationChannel
+			// block for next batch request finished - this should be before syncState is updated
+			<-mockService.HttpNotificationChannel
 			syncJobState := &SyncJobState{}
 			err := store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
 			g.Assert(err).IsNil()
@@ -1049,12 +1058,12 @@ func TestPipeline(t *testing.T) {
 			pipeline := &FullSyncPipeline{PipelineSpec{
 				batchSize: 5,
 				source:    &source.SampleSource{NumberOfEntities: 10, Store: store},
-				//sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
+				// sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
 				sink: &devNullSink{},
 			}}
 			job := &job{id: "full-1", pipeline: pipeline, runner: runner}
 
-			//run async, so we can verify tokens in parallel
+			// run async, so we can verify tokens in parallel
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			go func() {
@@ -1074,7 +1083,7 @@ func TestPipeline(t *testing.T) {
 			token := syncJobState.ContinuationToken
 			g.Assert(token).Eql("", "there should not be a token stored after first batch")
 
-			//wait for job to finish
+			// wait for job to finish
 			wg.Wait()
 			syncJobState = &SyncJobState{}
 			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
@@ -1137,26 +1146,35 @@ func TestPipeline(t *testing.T) {
 			job.Run()
 			sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
 			g.Assert(len(sinkChanges)).Eql(2, "Expected only 2 entities in current state in fullsync")
-
 		})
 
 		g.It("Should store dependency watermarks after fullsync in MultiSource jobs", func() {
 			srcDs, _ := dsm.CreateDataset("src", nil)
 			_ = srcDs.StoreEntities([]*server.Entity{
 				server.NewEntity("1", 0),
-				server.NewEntity("2", 0)})
+				server.NewEntity("2", 0),
+			})
 
 			depDs, _ := dsm.CreateDataset("dep", nil)
 			_ = depDs.StoreEntities([]*server.Entity{
 				server.NewEntity("3", 0),
 				server.NewEntity("4", 0),
-				server.NewEntity("5", 0)})
+				server.NewEntity("5", 0),
+			})
 
 			pipeline := &FullSyncPipeline{PipelineSpec{
 				batchSize: 5,
-				source: &source.MultiSource{DatasetName: "src", Store: store, DatasetManager: dsm, Dependencies: []source.Dependency{
-					{Dataset: "dep", Joins: []source.Join{{Dataset: "src", Predicate: "http:/a/predicate", Inverse: false}}},
-				}},
+				source: &source.MultiSource{
+					DatasetName:    "src",
+					Store:          store,
+					DatasetManager: dsm,
+					Dependencies: []source.Dependency{
+						{
+							Dataset: "dep",
+							Joins:   []source.Join{{Dataset: "src", Predicate: "http:/a/predicate", Inverse: false}},
+						},
+					},
+				},
 				sink: &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
 			}}
 			job := &job{id: "fs-1", pipeline: pipeline, runner: runner}
@@ -1171,7 +1189,6 @@ func TestPipeline(t *testing.T) {
 			token := syncJobState.ContinuationToken
 			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"3\"}}}",
 				"after job there should be a token")
-
 		})
 
 		g.It("Should store dependency watermarks after incremental in MultiSource jobs", func() {
@@ -1179,19 +1196,29 @@ func TestPipeline(t *testing.T) {
 			ns, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://namespace/")
 			_ = srcDs.StoreEntities([]*server.Entity{
 				server.NewEntity(ns+":1", 0),
-				server.NewEntity(ns+":2", 0)})
+				server.NewEntity(ns+":2", 0),
+			})
 
 			depDs, _ := dsm.CreateDataset("dep", nil)
 			_ = depDs.StoreEntities([]*server.Entity{
 				server.NewEntity(ns+":3", 0),
 				server.NewEntity(ns+":4", 0),
-				server.NewEntity(ns+":5", 0)})
+				server.NewEntity(ns+":5", 0),
+			})
 
 			pipeline := &IncrementalPipeline{PipelineSpec{
 				batchSize: 5,
-				source: &source.MultiSource{DatasetName: "src", Store: store, DatasetManager: dsm, Dependencies: []source.Dependency{
-					{Dataset: "dep", Joins: []source.Join{{Dataset: "src", Predicate: ns + ":predicate", Inverse: false}}},
-				}},
+				source: &source.MultiSource{
+					DatasetName:    "src",
+					Store:          store,
+					DatasetManager: dsm,
+					Dependencies: []source.Dependency{
+						{
+							Dataset: "dep",
+							Joins:   []source.Join{{Dataset: "src", Predicate: ns + ":predicate", Inverse: false}},
+						},
+					},
+				},
 				sink: &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
 			}}
 			job := &job{id: "fs-1", pipeline: pipeline, runner: runner}
@@ -1207,11 +1234,11 @@ func TestPipeline(t *testing.T) {
 			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"3\"}}}",
 				"after job there should be a token")
 
-			//reset recorder
-			for k, _ := range mockService.RecordedEntities {
+			// reset recorder
+			for k := range mockService.RecordedEntities {
 				delete(mockService.RecordedEntities, k)
 			}
-			//add dependency link
+			// add dependency link
 			e := server.NewEntity(ns+":5", 0)
 			e.References[ns+":predicate"] = ns + ":1"
 			_ = depDs.StoreEntities([]*server.Entity{e})
@@ -1229,8 +1256,8 @@ func TestPipeline(t *testing.T) {
 			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"4\"}}}",
 				"dependency watermarks should be forwarded by 1")
 
-			//reset recorder
-			for k, _ := range mockService.RecordedEntities {
+			// reset recorder
+			for k := range mockService.RecordedEntities {
 				delete(mockService.RecordedEntities, k)
 			}
 
@@ -1251,14 +1278,16 @@ func TestPipeline(t *testing.T) {
 			ds1, _ := dsm.CreateDataset("src1", nil)
 			_ = ds1.StoreEntities([]*server.Entity{
 				server.NewEntity("1", 0),
-				server.NewEntity("2", 0)})
+				server.NewEntity("2", 0),
+			})
 			ds2, _ := dsm.CreateDataset("src2", nil)
 			_ = ds2.StoreEntities([]*server.Entity{
 				server.NewEntity("3", 0),
 				server.NewEntity("4", 0),
-				server.NewEntity("5", 0)})
+				server.NewEntity("5", 0),
+			})
 
-			jobJson := ` {
+			jobJSON := ` {
 			"id" : "sync-uniondatasetsource-to-nullsink",
 			"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
 			"source" : {
@@ -1270,7 +1299,7 @@ func TestPipeline(t *testing.T) {
 				"Url":"http://localhost:7777/datasets/fulltest/fullsync"
 			} }`
 
-			jobConfig, err := scheduler.Parse([]byte(jobJson))
+			jobConfig, err := scheduler.Parse([]byte(jobJSON))
 			g.Assert(err).IsNil()
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
 			g.Assert(err).IsNil()
@@ -1286,20 +1315,21 @@ func TestPipeline(t *testing.T) {
 			token := syncJobState.ContinuationToken
 			g.Assert(token).Eql("",
 				"after job there should be NO token because fullsync uses entities towards httpsink")
-
 		})
 		g.It("Should store UnionDatasetContinuation after incremental on UnionDatasetSource", func() {
 			ds1, _ := dsm.CreateDataset("src1", nil)
 			_ = ds1.StoreEntities([]*server.Entity{
 				server.NewEntity("1", 0),
-				server.NewEntity("2", 0)})
+				server.NewEntity("2", 0),
+			})
 			ds2, _ := dsm.CreateDataset("src2", nil)
 			_ = ds2.StoreEntities([]*server.Entity{
 				server.NewEntity("3", 0),
 				server.NewEntity("4", 0),
-				server.NewEntity("5", 0)})
+				server.NewEntity("5", 0),
+			})
 
-			jobJson := ` {
+			jobJSON := ` {
 			"id" : "sync-uniondatasetsource-to-nullsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -1311,7 +1341,7 @@ func TestPipeline(t *testing.T) {
 				"Url":"http://localhost:7777/datasets/inctest/fullsync"
 			} }`
 
-			jobConfig, err := scheduler.Parse([]byte(jobJson))
+			jobConfig, err := scheduler.Parse([]byte(jobJSON))
 			g.Assert(err).IsNil()
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil()
@@ -1325,9 +1355,9 @@ func TestPipeline(t *testing.T) {
 			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token := syncJobState.ContinuationToken
-			g.Assert(token).Eql("{\"Tokens\":[{\"Token\":\"2\"},{\"Token\":\"3\"}],\"DatasetNames\":[\"src1\",\"src2\"]}",
-				"after job there should be a token stored")
-
+			g.Assert(token).
+				Eql("{\"Tokens\":[{\"Token\":\"2\"},{\"Token\":\"3\"}],\"DatasetNames\":[\"src1\",\"src2\"]}",
+					"after job there should be a token stored")
 		})
 		g.It("Should fail run and return error when error in transform js", func() {
 			// populate dataset with some entities
@@ -1354,30 +1384,30 @@ func TestPipeline(t *testing.T) {
 			jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
 
 			// define job
-			jobJson := `
-		{
-			"id" : "sync-datasetsource-to-datasetsink-with-js",
-			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
-			"source" : {
-				"Type" : "DatasetSource",
-				"Name" : "Products",
-				"LatestOnly": "true"
-			},
-			"transform" : {
-				"Type" : "JavascriptTransform",
-				"Code" : "` + jscriptEnc + `"
-			},
-			"sink" : {
-				"Type" : "DevNullSink"
-			}
-		}`
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobJSON := `
+			{
+				"id" : "sync-datasetsource-to-datasetsink-with-js",
+				"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
+				"source" : {
+					"Type" : "DatasetSource",
+					"Name" : "Products",
+					"LatestOnly": "true"
+				},
+				"transform" : {
+					"Type" : "JavascriptTransform",
+					"Code" : "` + jscriptEnc + `"
+				},
+				"sink" : {
+					"Type" : "DevNullSink"
+				}
+			}`
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed")
 			g.Assert(pipeline.spec().source.(*source.DatasetSource).LatestOnly).IsTrue()
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -1399,11 +1429,13 @@ func TestPipeline(t *testing.T) {
 		g.It("Should support proxy dataset as incremental datasetSource", func() {
 			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
 				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteUrl: "http://localhost:7777/datasets/people"}})
+					RemoteUrl: "http://localhost:7777/datasets/people",
+				},
+			})
 			g.Assert(err).IsNil()
 
 			// define job
-			jobJson := `
+			jobJSON := `
 			{
 				"id" : "sync-proxydatasetsource-to-httpdatasetsink",
 				"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -1417,12 +1449,12 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed correctly")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -1436,11 +1468,13 @@ func TestPipeline(t *testing.T) {
 		g.It("Should support proxy dataset as fullsync datasetSource", func() {
 			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
 				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteUrl: "http://localhost:7777/datasets/people"}})
+					RemoteUrl: "http://localhost:7777/datasets/people",
+				},
+			})
 			g.Assert(err).IsNil()
 
 			// define job
-			jobJson := `
+			jobJSON := `
 			{
 				"id" : "sync-proxydatasetsource-to-httpdatasetsink",
 				"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
@@ -1454,12 +1488,12 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
 			g.Assert(err).IsNil("pipeline is parsed correctly")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -1476,11 +1510,12 @@ func TestPipeline(t *testing.T) {
 				ProxyDatasetConfig: &server.ProxyDatasetConfig{
 					RemoteUrl:        "http://localhost:7777/datasets/people",
 					AuthProviderName: "local",
-				}})
+				},
+			})
 			g.Assert(err).IsNil()
 
 			// define job
-			jobJson := `
+			jobJSON := `
 			{
 				"id" : "sync-proxydatasetsource-to-httpdatasetsink",
 				"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -1494,12 +1529,12 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
 			g.Assert(err).IsNil("pipeline is parsed correctly")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -1535,11 +1570,12 @@ func TestPipeline(t *testing.T) {
 				ProxyDatasetConfig: &server.ProxyDatasetConfig{
 					RemoteUrl:        "http://localhost:7777/datasets/people",
 					AuthProviderName: "local",
-				}})
+				},
+			})
 			g.Assert(err).IsNil()
 
 			// define job
-			jobJson := `
+			jobJSON := `
 			{
 				"id" : "sync-proxydatasetsource-to-httpdatasetsink",
 				"triggers": [{"triggerType": "cron", "jobType": "fullSync", "schedule": "@every 2s"}],
@@ -1553,12 +1589,12 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
 			g.Assert(err).IsNil("pipeline is parsed correctly")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,
@@ -1605,7 +1641,7 @@ func TestPipeline(t *testing.T) {
 
 		g.It("Should not panic when pipeline sink dataset is missing", func() {
 			// define job where datasets in source and sink are missing
-			jobJson := `
+			jobJSON := `
 			{
 				"id" : "sync-multi-to-dataset",
 				"triggers": [{"triggerType": "cron", "jobType": "fullSync", "schedule": "@every 2s"}],
@@ -1626,12 +1662,12 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJson))
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
 			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
 			g.Assert(err).IsNil("pipeline is parsed correctly")
 
 			job := &job{
-				id:       jobConfig.Id,
+				id:       jobConfig.ID,
 				pipeline: pipeline,
 				schedule: jobConfig.Triggers[0].Schedule,
 				runner:   runner,

--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -69,7 +69,7 @@ func TestPipeline(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			_ = mockService.echo.Shutdown(ctx)
 			cancel()
-			mockService.HttpNotificationChannel = nil
+			mockService.HTTPNotificationChannel = nil
 			_ = store.Close()
 			_ = os.RemoveAll(storeLocation)
 		})
@@ -1035,12 +1035,12 @@ func TestPipeline(t *testing.T) {
 			}()
 
 			// block and wait for channel notification - indicating the first page/batch has been received
-			<-mockService.HttpNotificationChannel
+			<-mockService.HTTPNotificationChannel
 			g.Assert(len(mockService.getRecordedEntitiesForDataset("inctest"))).
 				Eql(5, "After first batch, 5 entities should have been postet to httpSink")
 
 			// block for next batch request finished - this should be before syncState is updated
-			<-mockService.HttpNotificationChannel
+			<-mockService.HTTPNotificationChannel
 			syncJobState := &SyncJobState{}
 			err := store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
 			g.Assert(err).IsNil()
@@ -1548,7 +1548,7 @@ func TestPipeline(t *testing.T) {
 				defer wg.Done()
 				for afterCh := time.After(100 * time.Millisecond); ; {
 					select {
-					case d := <-mockService.HttpNotificationChannel:
+					case d := <-mockService.HTTPNotificationChannel:
 						receivedMockRequests = append(receivedMockRequests, d)
 					case <-afterCh:
 						return
@@ -1608,7 +1608,7 @@ func TestPipeline(t *testing.T) {
 				defer wg.Done()
 				for afterCh := time.After(100 * time.Millisecond); ; {
 					select {
-					case d := <-mockService.HttpNotificationChannel:
+					case d := <-mockService.HTTPNotificationChannel:
 						receivedMockRequests = append(receivedMockRequests, d)
 					case <-afterCh:
 						return

--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -25,10 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mimiro-io/datahub/internal/jobs/source"
-
 	"github.com/franela/goblin"
 
+	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"github.com/mimiro-io/datahub/internal/server"
 )
 

--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -1042,14 +1042,14 @@ func TestPipeline(t *testing.T) {
 			// block for next batch request finished - this should be before syncState is updated
 			<-mockService.HTTPNotificationChannel
 			syncJobState := &SyncJobState{}
-			err := store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token := syncJobState.ContinuationToken
 			g.Assert(token).Eql("5", "Between batch 1 and 2, token should be continuation of batch 1")
 
 			wg.Wait()
 			syncJobState = &SyncJobState{}
-			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token = syncJobState.ContinuationToken
 			g.Assert(token).Eql("10")
@@ -1078,7 +1078,7 @@ func TestPipeline(t *testing.T) {
 			//wait for first syncState (token) update in badger (should be in db when 2nd batch arrives)
 			//_ = <-mockService.HttpNotificationChannel
 			syncJobState := &SyncJobState{}
-			err := store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token := syncJobState.ContinuationToken
 			g.Assert(token).Eql("", "there should not be a token stored after first batch")
@@ -1086,7 +1086,7 @@ func TestPipeline(t *testing.T) {
 			// wait for job to finish
 			wg.Wait()
 			syncJobState = &SyncJobState{}
-			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token = syncJobState.ContinuationToken
 			g.Assert(token).Eql("10", "First after job there should be a token")
@@ -1184,7 +1184,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(len(sinkChanges)).Eql(2, "Expected only 2 entities in current state in fullsync")
 
 			syncJobState := &SyncJobState{}
-			err := store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token := syncJobState.ContinuationToken
 			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"3\"}}}",
@@ -1228,7 +1228,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(len(sinkChanges)).Eql(2, "Expected only 2 entities")
 
 			syncJobState := &SyncJobState{}
-			err := store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token := syncJobState.ContinuationToken
 			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"3\"}}}",
@@ -1250,7 +1250,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(sinkChanges[0].ID).Eql(ns+":1", "new dependency points to id 1")
 
 			syncJobState = &SyncJobState{}
-			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token = syncJobState.ContinuationToken
 			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"4\"}}}",
@@ -1268,7 +1268,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(len(sinkChanges)).Eql(0)
 
 			syncJobState = &SyncJobState{}
-			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token = syncJobState.ContinuationToken
 			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"4\"}}}",
@@ -1310,7 +1310,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(len(sinkChanges)).Eql(5, "Expected 5 entities in current state in fullsync")
 
 			syncJobState := &SyncJobState{}
-			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token := syncJobState.ContinuationToken
 			g.Assert(token).Eql("",
@@ -1352,7 +1352,7 @@ func TestPipeline(t *testing.T) {
 			g.Assert(len(sinkChanges)).Eql(5, "Expected 5 entities in current state")
 
 			syncJobState := &SyncJobState{}
-			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			token := syncJobState.ContinuationToken
 			g.Assert(token).
@@ -1416,12 +1416,12 @@ func TestPipeline(t *testing.T) {
 			job.Run()
 
 			syncJobState := &SyncJobState{}
-			err = store.GetObject(server.JOB_DATA_INDEX, job.id, syncJobState)
+			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
 			g.Assert(err).IsNil()
 			g.Assert(syncJobState.LastRunCompletedOk).IsFalse()
 
 			jobResult := &jobResult{}
-			err = store.GetObject(server.JOB_RESULT_INDEX, job.id, jobResult)
+			err = store.GetObject(server.JobResultIndex, job.id, jobResult)
 			g.Assert(err).IsNil()
 			g.Assert(jobResult.LastError == "").IsFalse()
 		})
@@ -1429,7 +1429,7 @@ func TestPipeline(t *testing.T) {
 		g.It("Should support proxy dataset as incremental datasetSource", func() {
 			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
 				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteUrl: "http://localhost:7777/datasets/people",
+					RemoteURL: "http://localhost:7777/datasets/people",
 				},
 			})
 			g.Assert(err).IsNil()
@@ -1468,7 +1468,7 @@ func TestPipeline(t *testing.T) {
 		g.It("Should support proxy dataset as fullsync datasetSource", func() {
 			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
 				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteUrl: "http://localhost:7777/datasets/people",
+					RemoteURL: "http://localhost:7777/datasets/people",
 				},
 			})
 			g.Assert(err).IsNil()
@@ -1508,7 +1508,7 @@ func TestPipeline(t *testing.T) {
 		g.It("Should support proxy dataset as incremental datasetSink", func() {
 			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
 				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteUrl:        "http://localhost:7777/datasets/people",
+					RemoteURL:        "http://localhost:7777/datasets/people",
 					AuthProviderName: "local",
 				},
 			})
@@ -1568,7 +1568,7 @@ func TestPipeline(t *testing.T) {
 		g.It("Should support proxy dataset as fullsync datasetSink", func() {
 			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
 				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteUrl:        "http://localhost:7777/datasets/people",
+					RemoteURL:        "http://localhost:7777/datasets/people",
 					AuthProviderName: "local",
 				},
 			})

--- a/internal/jobs/query_test.go
+++ b/internal/jobs/query_test.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/server"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 // implements QueryResultWriter interface

--- a/internal/jobs/query_test.go
+++ b/internal/jobs/query_test.go
@@ -60,7 +60,6 @@ func TestQuery(test *testing.T) {
 		})
 
 		g.It("Should support js query that just writes to the response writer", func() {
-
 			// transform js
 			js := `
 			function do_query() {
@@ -85,7 +84,6 @@ func TestQuery(test *testing.T) {
 			// check result
 			g.Assert(len(resultWriter.Results)).Equal(1)
 			g.Assert(resultWriter.Results[0]).Equal(map[string]interface{}{"name": "homer"})
-
 		})
 
 		g.It("Should support js query that can access dataset changes", func() {
@@ -132,7 +130,6 @@ func TestQuery(test *testing.T) {
 			// check result
 			g.Assert(len(resultWriter.Results)).Equal(1)
 			g.Assert(resultWriter.Results[0]).Equal(map[string]interface{}{"count": 1})
-
 		})
 
 		g.It("Should support js query that can access dataset changes with continuation token", func() {
@@ -195,8 +192,8 @@ func TestQuery(test *testing.T) {
 
 			// check result
 			g.Assert(len(resultWriter.Results)).Equal(1)
-			g.Assert(resultWriter.Results[0]).Equal(map[string]interface{}{"count": 2, "names": []interface{}{"http://data.mimiro.io/people/homer", "http://data.mimiro.io/people/marge"}})
-
+			g.Assert(resultWriter.Results[0]).
+				Equal(map[string]interface{}{"count": 2, "names": []interface{}{"http://data.mimiro.io/people/homer", "http://data.mimiro.io/people/marge"}})
 		})
 	})
 }

--- a/internal/jobs/raffle.go
+++ b/internal/jobs/raffle.go
@@ -46,7 +46,12 @@ type ticket struct {
 	runState *runState
 }
 
-func NewRaffle(ticketsFull int, ticketsIncr int, logger *zap.SugaredLogger, statsdClient statsd.ClientInterface) *raffle {
+func NewRaffle(
+	ticketsFull int,
+	ticketsIncr int,
+	logger *zap.SugaredLogger,
+	statsdClient statsd.ClientInterface,
+) *raffle {
 	return &raffle{
 		logger:       logger,
 		statsdClient: statsdClient,
@@ -122,7 +127,6 @@ func (r *raffle) returnTicket(ticket *ticket) {
 		r.ticketsIncr++
 		_ = r.statsdClient.Gauge("jobs.tickets.incr", float64(r.ticketsIncr), tags, 1)
 	}
-
 }
 
 func (r *raffle) runningJob(jobid string) *runState {

--- a/internal/jobs/raffle_test.go
+++ b/internal/jobs/raffle_test.go
@@ -20,9 +20,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/franela/goblin"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/franela/goblin"
 	"go.uber.org/zap"
 )
 

--- a/internal/jobs/raffle_test.go
+++ b/internal/jobs/raffle_test.go
@@ -73,7 +73,7 @@ func TestRaffle(t *testing.T) {
 			// start 30 jobs
 			for i := 0; i < 30; i++ {
 				if running == 3 {
-					//make sure we only start 3 at a time by using a wait-group
+					// make sure we only start 3 at a time by using a wait-group
 					wg.Wait()
 					running = 0
 				} else {
@@ -84,7 +84,7 @@ func TestRaffle(t *testing.T) {
 						job := &job{id: "test" + id, pipeline: &IncrementalPipeline{}}
 						ticket := raffle.borrowTicket(job)
 						g.Assert(ticket).IsNotZero("Expected to get ticket for job " + id)
-						//simulate work
+						// simulate work
 						time.Sleep(10 * time.Millisecond)
 						raffle.returnTicket(ticket)
 						wg.Done()

--- a/internal/jobs/runner.go
+++ b/internal/jobs/runner.go
@@ -131,7 +131,7 @@ func (runner *Runner) deleteJob(jobID string) error {
 		clearCrontab(runner.scheduledJobs, jobID)
 		runner.eventBus.UnsubscribeToDataset(jobID)
 	}()
-	err := runner.store.DeleteObject(server.JOB_CONFIGS_INDEX, jobID)
+	err := runner.store.DeleteObject(server.JobConfigIndex, jobID)
 	if err != nil {
 		return err
 	}

--- a/internal/jobs/runner.go
+++ b/internal/jobs/runner.go
@@ -17,12 +17,13 @@ package jobs
 import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/bamzi/jobrunner"
-	"github.com/mimiro-io/datahub/internal/conf"
-	"github.com/mimiro-io/datahub/internal/security"
-	"github.com/mimiro-io/datahub/internal/server"
 	"github.com/mustafaturan/bus"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/security"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 // The Runner is used to organize and keep track of configured jobs. It is also responsible for running (duh) jobs.

--- a/internal/jobs/runner.go
+++ b/internal/jobs/runner.go
@@ -46,11 +46,20 @@ type SyncJobState struct {
 }
 
 // NewRunner creates a new job runner. It should only be used from the main.go
-func NewRunner(env *conf.Env, store *server.Store, tokenProviders *security.TokenProviders, eb server.EventBus, statsdClient statsd.ClientInterface) *Runner {
+func NewRunner(
+	env *conf.Env,
+	store *server.Store,
+	tokenProviders *security.TokenProviders,
+	eb server.EventBus,
+	statsdClient statsd.ClientInterface,
+) *Runner {
 	logger := env.Logger.Named("jobrunner")
 	config := env.RunnerConfig
 	logger.Infof("Starting the JobRunner with config %+v", config)
-	jobrunner.Start(config.PoolIncremental+config.PoolFull+3, config.Concurrent) // we add 3 extra to be able to postpone pipelines
+	jobrunner.Start(
+		config.PoolIncremental+config.PoolFull+3,
+		config.Concurrent,
+	) // we add 3 extra to be able to postpone pipelines
 	return &Runner{
 		logger:         logger,
 		store:          store,
@@ -92,23 +101,22 @@ func (runner *Runner) startJob(j *job) {
 // TODO: add protection against adding an already processing job
 func (runner *Runner) addScheduledJob(job *job) error {
 	runner.logger.Infof("Adding job with id '%s'(%s) to schedule '%s'", job.id, job.title, job.schedule)
-	entryId, err := runner.schedule(job.schedule, job)
+	entryID, err := runner.schedule(job.schedule, job)
 	if err != nil {
 		runner.logger.Errorf("Error scheduling job %v (%s): %w", job.id, job.title, err)
 		return err
 	}
-	runner.scheduledJobs[job.id] = append(runner.scheduledJobs[job.id], entryId)
+	runner.scheduledJobs[job.id] = append(runner.scheduledJobs[job.id], entryID)
 
 	return nil
 }
 
 // addEventJob adds a event subscription to run the job on an event
 func (runner *Runner) addEventJob(job *job) error {
-	runner.eventBus.SubscribeToDataset(job.id, job.topic, func(e *bus.Event) {
+	runner.eventBus.SubscribeToDataset(job.id, job.topic, func(_ *bus.Event) {
 		go func() { // this prevents blocking on the event bus
 			job.Run()
 		}()
-
 	})
 	return nil
 }
@@ -116,14 +124,14 @@ func (runner *Runner) addEventJob(job *job) error {
 // deleteJob deletes a job with the given jobId. It will delete the job configuration
 // from the store, and clean up future scheduled jobs from the cron.
 // TODO: extend to interrupt running jobs
-func (runner *Runner) deleteJob(jobId string) error {
-	runner.logger.Infof("Deleting job with id '%s'", jobId)
+func (runner *Runner) deleteJob(jobID string) error {
+	runner.logger.Infof("Deleting job with id '%s'", jobID)
 	defer func() {
 		// make sure the schedules are removed from the crontab
-		clearCrontab(runner.scheduledJobs, jobId)
-		runner.eventBus.UnsubscribeToDataset(jobId)
+		clearCrontab(runner.scheduledJobs, jobID)
+		runner.eventBus.UnsubscribeToDataset(jobID)
 	}()
-	err := runner.store.DeleteObject(server.JOB_CONFIGS_INDEX, jobId)
+	err := runner.store.DeleteObject(server.JOB_CONFIGS_INDEX, jobID)
 	if err != nil {
 		return err
 	}
@@ -131,23 +139,22 @@ func (runner *Runner) deleteJob(jobId string) error {
 }
 
 // killJob stops a running job as soon as possible
-func (runner *Runner) killJob(jobId string) {
-	running := runner.raffle.runningJob(jobId)
+func (runner *Runner) killJob(jobID string) {
+	running := runner.raffle.runningJob(jobID)
 	if running != nil {
-		runner.logger.Infof("Killing job with id '%s'", jobId)
+		runner.logger.Infof("Killing job with id '%s'", jobID)
 		running.cancel()
 	}
-
 }
 
 // clearCrontab makes sure old entries are removed from the list before new are added
-func clearCrontab(jobs map[string][]cron.EntryID, jobId string) {
-	entryIds, ok := jobs[jobId]
+func clearCrontab(jobs map[string][]cron.EntryID, jobID string) {
+	entryIds, ok := jobs[jobID]
 	if ok {
 		for _, id := range entryIds {
 			jobrunner.Remove(id)
 		}
-		delete(jobs, jobId)
+		delete(jobs, jobID)
 	}
 }
 

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mimiro-io/datahub/internal/jobs/source"
-
 	"github.com/bamzi/jobrunner"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/fx"
@@ -33,6 +31,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"github.com/mimiro-io/datahub/internal/server"
 )
 

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -147,7 +147,7 @@ func (s *Scheduler) AddJob(jobConfig *JobConfiguration) error {
 		return err
 	}
 
-	err = s.Store.StoreObject(server.JOB_CONFIGS_INDEX, jobConfig.ID, jobConfig) // store it for the future
+	err = s.Store.StoreObject(server.JobConfigIndex, jobConfig.ID, jobConfig) // store it for the future
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (s *Scheduler) DeleteJob(jobID string) error {
 // works, it will not return nil when not found, but an empty jobConfig object.
 func (s *Scheduler) LoadJob(jobID string) (*JobConfiguration, error) {
 	jobConfig := &JobConfiguration{}
-	err := s.Store.GetObject(server.JOB_CONFIGS_INDEX, jobID, jobConfig)
+	err := s.Store.GetObject(server.JobConfigIndex, jobID, jobConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +325,7 @@ func (s *Scheduler) GetRunningJob(jobid string) *JobStatus {
 // Each job stores its Start and End time, together with the last error if any.
 func (s *Scheduler) GetJobHistory() []*jobResult {
 	results := make([]*jobResult, 0)
-	_ = s.Store.IterateObjectsRaw(server.JOB_RESULT_INDEX_BYTES, func(jsonData []byte) error {
+	_ = s.Store.IterateObjectsRaw(server.JobResultIndexBytes, func(jsonData []byte) error {
 		jobResult := &jobResult{}
 		err := json.Unmarshal(jsonData, jobResult)
 		if err != nil {
@@ -369,7 +369,7 @@ func (s *Scheduler) ResetJob(jobid string, since string) error {
 	s.Logger.Infof("Resetting since token for job with id '%s' (%s)", jobid, jobTitle)
 
 	syncJobState := &SyncJobState{}
-	err := s.Store.GetObject(server.JOB_DATA_INDEX, jobid, syncJobState)
+	err := s.Store.GetObject(server.JobDataIndex, jobid, syncJobState)
 	if err != nil {
 		return err
 	}
@@ -379,7 +379,7 @@ func (s *Scheduler) ResetJob(jobid string, since string) error {
 	}
 
 	syncJobState.ContinuationToken = since
-	err = s.Store.StoreObject(server.JOB_DATA_INDEX, jobid, syncJobState)
+	err = s.Store.StoreObject(server.JobDataIndex, jobid, syncJobState)
 	if err != nil {
 		return err
 	}
@@ -440,7 +440,7 @@ func (s *Scheduler) changeStatus(jobid string, pause bool) error {
 func (s *Scheduler) loadConfigurations() []*JobConfiguration {
 	jobConfigs := []*JobConfiguration{}
 
-	_ = s.Store.IterateObjectsRaw(server.JOB_CONFIGS_INDEX_BYTES, func(jsonData []byte) error {
+	_ = s.Store.IterateObjectsRaw(server.JobConfigsIndexBytes, func(jsonData []byte) error {
 		jobConfig := &JobConfiguration{}
 		err := json.Unmarshal(jsonData, jobConfig)
 		if err != nil {

--- a/internal/jobs/scheduler_test.go
+++ b/internal/jobs/scheduler_test.go
@@ -88,7 +88,7 @@ func TestScheduler(t *testing.T) {
 			err = scheduler.AddJob(sj)
 			g.Assert(err).IsNil("Could add job to scheduler")
 
-			_, ok := runner.scheduledJobs[sj.Id]
+			_, ok := runner.scheduledJobs[sj.ID]
 			g.Assert(ok).IsFalse("Does not have job id, because it is paused")
 
 			//register callback to get notified when job is done
@@ -100,14 +100,14 @@ func TestScheduler(t *testing.T) {
 				}
 			}
 
-			id, err := scheduler.RunJob(sj.Id, JobTypeIncremental)
+			id, err := scheduler.RunJob(sj.ID, JobTypeIncremental)
 			g.Assert(err).IsNil("RunJob returns no error")
-			g.Assert(id).Eql(sj.Id, "Correct job id is returned from RunJob")
+			g.Assert(id).Eql(sj.ID, "Correct job id is returned from RunJob")
 
 			wg.Wait()
 			history := scheduler.GetJobHistory()
 			g.Assert(len(history)).IsNotZero("We found something in the job history")
-			g.Assert(history[0].Id).Eql(sj.Id, "History contains only our job in first place")
+			g.Assert(history[0].ID).Eql(sj.ID, "History contains only our job in first place")
 		})
 
 		g.It("Should reset a job when asked to", func() {
@@ -164,18 +164,18 @@ func TestScheduler(t *testing.T) {
 				}
 			}
 
-			_, err = scheduler.RunJob(sj.Id, JobTypeIncremental)
+			_, err = scheduler.RunJob(sj.ID, JobTypeIncremental)
 			g.Assert(err).IsNil()
 
 			startWg.Wait()
 
-			g.Assert(scheduler.GetRunningJob(sj.Id)).IsNotNil("Our job is running now")
+			g.Assert(scheduler.GetRunningJob(sj.ID)).IsNotNil("Our job is running now")
 
-			scheduler.KillJob(sj.Id)
+			scheduler.KillJob(sj.ID)
 
 			//wait until our job is not running anymore
 			doneWg.Wait()
-			g.Assert(scheduler.GetRunningJob(sj.Id)).IsNil("Our job is killed now")
+			g.Assert(scheduler.GetRunningJob(sj.ID)).IsNil("Our job is killed now")
 		})
 
 		g.It("Should pause a job when asked to", func() {
@@ -195,13 +195,13 @@ func TestScheduler(t *testing.T) {
 			err = scheduler.AddJob(sj)
 			g.Assert(err).IsNil("Could add job to scheduler")
 
-			_, ok := runner.scheduledJobs[sj.Id]
+			_, ok := runner.scheduledJobs[sj.ID]
 			g.Assert(ok).IsTrue("Our job is registered as schedule")
 
-			err = scheduler.PauseJob(sj.Id)
+			err = scheduler.PauseJob(sj.ID)
 			g.Assert(err).IsNil("we could call PauseJob without error")
 
-			_, ok = runner.scheduledJobs[sj.Id]
+			_, ok = runner.scheduledJobs[sj.ID]
 			g.Assert(ok).IsFalse("Our job is no longer registered as schedule")
 		})
 
@@ -223,13 +223,13 @@ func TestScheduler(t *testing.T) {
 			err = scheduler.AddJob(sj)
 			g.Assert(err).IsNil("Could add job to scheduler")
 
-			_, ok := runner.scheduledJobs[sj.Id]
+			_, ok := runner.scheduledJobs[sj.ID]
 			g.Assert(ok).IsFalse("Our job is not registered as schedule (paused in json)")
 
-			err = scheduler.UnpauseJob(sj.Id)
+			err = scheduler.UnpauseJob(sj.ID)
 			g.Assert(err).IsNil("we could call UnpauseJob without error")
 
-			_, ok = runner.scheduledJobs[sj.Id]
+			_, ok = runner.scheduledJobs[sj.ID]
 			g.Assert(ok).IsTrue("Our job is registered as schedule now")
 		})
 		g.It("Should immediately run a job when asked to", func() {
@@ -251,7 +251,7 @@ func TestScheduler(t *testing.T) {
 			err = scheduler.AddJob(sj)
 			g.Assert(err).IsNil("Could add job to scheduler")
 
-			_, ok := runner.scheduledJobs[sj.Id]
+			_, ok := runner.scheduledJobs[sj.ID]
 			g.Assert(ok).IsFalse("Our job is not registered as schedule (paused in json)")
 
 			_, _ = dsm.CreateDataset("People", nil)
@@ -265,9 +265,9 @@ func TestScheduler(t *testing.T) {
 				}
 			}
 
-			id, err := scheduler.RunJob(sj.Id, JobTypeIncremental)
+			id, err := scheduler.RunJob(sj.ID, JobTypeIncremental)
 			g.Assert(err).IsNil("We could invoke RunJob without error")
-			g.Assert(id).Eql(sj.Id, "RunJob returned the correct job id")
+			g.Assert(id).Eql(sj.ID, "RunJob returned the correct job id")
 
 			wg.Wait()
 
@@ -295,21 +295,21 @@ func TestScheduler(t *testing.T) {
 			err = scheduler.AddJob(sj)
 			g.Assert(err).IsNil("Could add job to scheduler")
 
-			job, err := scheduler.LoadJob(sj.Id)
+			job, err := scheduler.LoadJob(sj.ID)
 			g.Assert(err).IsNil()
 			g.Assert(job).IsNotNil()
-			g.Assert(job.Id).Eql("sync-samplesource-to-datasetsink", "We could read back the job")
-			_, ok := runner.scheduledJobs[job.Id]
+			g.Assert(job.ID).Eql("sync-samplesource-to-datasetsink", "We could read back the job")
+			_, ok := runner.scheduledJobs[job.ID]
 			g.Assert(ok).IsTrue("our job is registered as schedule")
 
-			err = scheduler.DeleteJob(job.Id)
+			err = scheduler.DeleteJob(job.ID)
 			g.Assert(err).IsNil("Could invoke DeleteJob without error")
 
-			job, err = scheduler.LoadJob(sj.Id)
+			job, err = scheduler.LoadJob(sj.ID)
 			g.Assert(err).IsNil()
 			g.Assert(job).IsNotNil() // not ideal detail - we get an empty object back if not found
 			g.Assert(*job).IsZero("We get an empty configuration back, confirming deletion")
-			_, ok = runner.scheduledJobs[job.Id]
+			_, ok = runner.scheduledJobs[job.ID]
 			g.Assert(ok).IsFalse("our job is no longer registered as schedule")
 		})
 
@@ -330,7 +330,7 @@ func TestScheduler(t *testing.T) {
 			} }`)))
 			g.Assert(err).IsNil("Error free parsing of jobConfiguration json")
 			g.Assert(sj).IsNotNil("Could parse jobConfiguration json")
-			g.Assert(sj.Id).Eql("sync-customer-from-adventure-works-to-datahub",
+			g.Assert(sj.ID).Eql("sync-customer-from-adventure-works-to-datahub",
 				"The produced configuration object is not empty")
 			g.Assert(len(sj.Triggers)).Eql(2)
 		})
@@ -351,7 +351,7 @@ func TestScheduler(t *testing.T) {
 			g.Assert(err).IsNil("Error free parsing of jobConfiguration json")
 			err = scheduler.AddJob(sj)
 			g.Assert(err).IsNil("Could add job to scheduler")
-			g.Assert(runner.scheduledJobs[sj.Id]).Eql([]cron.EntryID{cron.EntryID(1)}, "Our job has received internal id 1")
+			g.Assert(runner.scheduledJobs[sj.ID]).Eql([]cron.EntryID{cron.EntryID(1)}, "Our job has received internal id 1")
 
 			// close
 			runner.Stop()
@@ -360,7 +360,7 @@ func TestScheduler(t *testing.T) {
 
 			// reopen
 			scheduler, store, runner, dsm, statsdClient = setupScheduler(storeLocation, t)
-			g.Assert(runner.scheduledJobs[sj.Id]).Eql([]cron.EntryID{cron.EntryID(1)}, "Our job has received internal id 1")
+			g.Assert(runner.scheduledJobs[sj.ID]).Eql([]cron.EntryID{cron.EntryID(1)}, "Our job has received internal id 1")
 		})
 
 		g.It("Should marshal entities back and forth without data loss", func() {
@@ -383,7 +383,7 @@ func TestScheduler(t *testing.T) {
 		g.Describe("Should handle concurrent run requests", func() {
 			g.It("Should ignore RunJob (return an error message), if job is running", func() {
 				config := &JobConfiguration{
-					Id:     "j1",
+					ID:     "j1",
 					Title:  "j1",
 					Sink:   map[string]interface{}{"Type": "DevNullSink"},
 					Source: map[string]interface{}{"Type": "SlowSource", "Sleep": "300ms"},
@@ -429,7 +429,7 @@ func TestScheduler(t *testing.T) {
 
 			g.It("Should skip a scheduled run, while a RunJob is active", func() {
 				config := &JobConfiguration{
-					Id:     "j1",
+					ID:     "j1",
 					Title:  "j1",
 					Sink:   map[string]interface{}{"Type": "DevNullSink"},
 					Source: map[string]interface{}{"Type": "SlowSource", "Sleep": "100ms"},
@@ -482,7 +482,7 @@ func TestScheduler(t *testing.T) {
 			})
 			g.It("Should update the syncState and history of an incremental job after RunJob", func() {
 				config := &JobConfiguration{
-					Id:     "j1",
+					ID:     "j1",
 					Title:  "j1",
 					Sink:   map[string]interface{}{"Type": "DevNullSink"},
 					Source: map[string]interface{}{"Type": "SampleSource"},
@@ -518,7 +518,7 @@ func TestScheduler(t *testing.T) {
 			})
 			g.It("Should let a fullsync  RunJob fail, while a scheduled run is active (user can try again soon)", func() {
 				config := &JobConfiguration{
-					Id:     "j1",
+					ID:     "j1",
 					Title:  "j1",
 					Sink:   map[string]interface{}{"Type": "DevNullSink"},
 					Source: map[string]interface{}{"Type": "SlowSource", "Sleep": "300ms"},
@@ -565,7 +565,7 @@ func TestScheduler(t *testing.T) {
 			g.It("Should start a scheduled fullsync after a RunJob if the schedule triggers during RunJob", func() {
 				_ = os.Setenv("JOB_FULLSYNC_RETRY_INTERVAL", "100ms")
 				config := &JobConfiguration{
-					Id:     "j1",
+					ID:     "j1",
 					Title:  "j1",
 					Sink:   map[string]interface{}{"Type": "DevNullSink"},
 					Source: map[string]interface{}{"Type": "SlowSource", "Sleep": "200ms"},
@@ -665,7 +665,7 @@ func TestScheduler(t *testing.T) {
 				//also set it larger than runtime of complete testsuite to avoid that it kicks in while other tests run
 				_ = os.Setenv("JOB_FULLSYNC_RETRY_INTERVAL", "5m")
 				config := &JobConfiguration{
-					Id:     "j1",
+					ID:     "j1",
 					Title:  "j1",
 					Sink:   map[string]interface{}{"Type": "DevNullSink"},
 					Source: map[string]interface{}{"Type": "SlowSource", "Sleep": "200ms"},
@@ -704,18 +704,18 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if title is missing", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x"})
+				err := scheduler.AddJob(&JobConfiguration{ID: "x"})
 				g.Assert(err).Eql(errors.New("job configuration needs a title"))
 			})
 
 			g.It("Should fail if source is missing", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x"})
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x"})
 				g.Assert(err).Eql(errors.New("you must configure a source"))
 			})
 
 			g.It("Should fail if sink is missing", func() {
 				err := scheduler.AddJob(&JobConfiguration{
-					Id:     "x",
+					ID:     "x",
 					Title:  "x",
 					Source: validSource,
 				})
@@ -724,7 +724,7 @@ func TestScheduler(t *testing.T) {
 
 			g.It("Should fail if TriggerType is missing", func() {
 				err := scheduler.AddJob(&JobConfiguration{
-					Id:       "x",
+					ID:       "x",
 					Title:    "x",
 					Triggers: []JobTrigger{{}},
 					Source:   validSource,
@@ -734,7 +734,7 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if JobType is missing", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x", Source: validSource, Sink: validSink,
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x", Source: validSource, Sink: validSink,
 					Triggers: []JobTrigger{
 						{TriggerType: TriggerTypeCron},
 					},
@@ -743,7 +743,7 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if trigger type is unknown", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x", Source: validSource, Sink: validSink,
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x", Source: validSource, Sink: validSink,
 					Triggers: []JobTrigger{
 						{TriggerType: "foo"},
 					},
@@ -751,7 +751,7 @@ func TestScheduler(t *testing.T) {
 				g.Assert(err).Eql(errors.New("need to set 'triggerType'. must be one of: cron, onchange"))
 			})
 			g.It("Should fail if sync type is unknown", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x", Source: validSource, Sink: validSink,
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x", Source: validSource, Sink: validSink,
 					Triggers: []JobTrigger{
 						{TriggerType: TriggerTypeCron, JobType: "foo"},
 					},
@@ -760,7 +760,7 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if schedule is missing", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x", Source: validSource, Sink: validSink,
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x", Source: validSource, Sink: validSink,
 					Triggers: []JobTrigger{
 						{TriggerType: TriggerTypeCron, JobType: JobTypeIncremental},
 					},
@@ -770,7 +770,7 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if source is unknown type", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x",
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x",
 					Source: map[string]interface{}{"Type": "foo"},
 					Sink:   validSink,
 					Triggers: []JobTrigger{
@@ -781,7 +781,7 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if sink is unknown type", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x", Source: validSource,
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x", Source: validSource,
 					Sink: map[string]interface{}{"Type": "foo"},
 					Triggers: []JobTrigger{
 						{TriggerType: TriggerTypeCron, JobType: JobTypeIncremental, Schedule: "@midnight"},
@@ -791,7 +791,7 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if transform is unknown type", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x", Source: validSource, Sink: validSink,
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x", Source: validSource, Sink: validSink,
 					Triggers: []JobTrigger{
 						{TriggerType: TriggerTypeOnChange, JobType: JobTypeIncremental, MonitoredDataset: "foo"},
 					},
@@ -801,7 +801,7 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if job type is 'event', but schedule is set", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x", Source: validSource, Sink: validSink,
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x", Source: validSource, Sink: validSink,
 					Triggers: []JobTrigger{
 						{TriggerType: TriggerTypeOnChange, JobType: JobTypeIncremental, Schedule: "@midnight"},
 					},
@@ -810,7 +810,7 @@ func TestScheduler(t *testing.T) {
 			})
 
 			g.It("Should fail if schedule is not parsable", func() {
-				err := scheduler.AddJob(&JobConfiguration{Id: "x", Title: "x", Source: validSource, Sink: validSink,
+				err := scheduler.AddJob(&JobConfiguration{ID: "x", Title: "x", Source: validSource, Sink: validSink,
 					Triggers: []JobTrigger{
 						{TriggerType: TriggerTypeCron, JobType: JobTypeIncremental, Schedule: "midnight"},
 					},

--- a/internal/jobs/scheduler_test.go
+++ b/internal/jobs/scheduler_test.go
@@ -28,20 +28,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/security"
-
-	"github.com/bamzi/jobrunner"
-	"github.com/robfig/cron/v3"
-
-	"github.com/franela/goblin"
-	"github.com/mimiro-io/datahub/internal/conf"
-	"go.uber.org/fx/fxtest"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/bamzi/jobrunner"
+	"github.com/franela/goblin"
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/server"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/security"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 var logger = zap.NewNop().Sugar()

--- a/internal/jobs/scheduler_test.go
+++ b/internal/jobs/scheduler_test.go
@@ -116,14 +116,14 @@ func TestScheduler(t *testing.T) {
 				ID:                "job-1",
 				ContinuationToken: "cont-token-123",
 			}
-			err := store.StoreObject(server.JOB_DATA_INDEX, "job-1", syncJobState)
+			err := store.StoreObject(server.JobDataIndex, "job-1", syncJobState)
 			g.Assert(err).IsNil("We could store a syncJobState")
 
 			err = scheduler.ResetJob("job-1", "hello-world")
 			g.Assert(err).IsNil("We called ResetJob without error")
 
 			s2 := &SyncJobState{}
-			err = store.GetObject(server.JOB_DATA_INDEX, "job-1", s2)
+			err = store.GetObject(server.JobDataIndex, "job-1", s2)
 			g.Assert(err).IsNil("We could load the syncJobState back")
 			g.Assert(s2.ContinuationToken).Eql("hello-world",
 				"We find the continuation token that was injected with ResetJob in the syncState")
@@ -518,7 +518,7 @@ func TestScheduler(t *testing.T) {
 				hist := scheduler.GetJobHistory()
 				g.Assert(len(hist)).Eql(1, "our RunJob is in history")
 				syncJobState := &SyncJobState{}
-				err = runner.store.GetObject(server.JOB_DATA_INDEX, j.id, syncJobState)
+				err = runner.store.GetObject(server.JobDataIndex, j.id, syncJobState)
 				g.Assert(err).IsNil()
 				g.Assert(syncJobState).Eql(&SyncJobState{ID: j.id, ContinuationToken: "0"})
 			})

--- a/internal/jobs/sink.go
+++ b/internal/jobs/sink.go
@@ -55,7 +55,7 @@ func (s *Scheduler) parseSink(jobConfig *JobConfiguration) (Sink, error) {
 					sink := &httpDatasetSink{}
 					sink.Store = s.Store
 					sink.logger = s.Logger.Named("sink")
-					sink.Endpoint, _ = server.UrlJoin(dataset.ProxyConfig.RemoteUrl, "/entities")
+					sink.Endpoint, _ = server.URLJoin(dataset.ProxyConfig.RemoteURL, "/entities")
 
 					if dataset.ProxyConfig.AuthProviderName != "" {
 						sink.TokenProvider = dataset.ProxyConfig.AuthProviderName

--- a/internal/jobs/sink.go
+++ b/internal/jobs/sink.go
@@ -25,10 +25,9 @@ import (
 	"strings"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/gojektech/heimdall/v6/httpclient"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 
 	"github.com/mimiro-io/datahub/internal/server"
 )

--- a/internal/jobs/sink.go
+++ b/internal/jobs/sink.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gojektech/heimdall/v6/httpclient"
 	"github.com/google/uuid"
+
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
@@ -46,7 +47,8 @@ func (s *Scheduler) parseSink(jobConfig *JobConfiguration) (Sink, error) {
 	if sinkConfig != nil {
 		sinkTypeName := sinkConfig["Type"]
 		if sinkTypeName != nil {
-			if sinkTypeName == "DatasetSink" {
+			switch sinkTypeName {
+			case "DatasetSink":
 				dsname := (sinkConfig["Name"]).(string)
 				dataset := s.DatasetManager.GetDataset(dsname)
 				if dataset != nil && dataset.IsProxy() {
@@ -65,10 +67,10 @@ func (s *Scheduler) parseSink(jobConfig *JobConfiguration) (Sink, error) {
 				sink.Store = s.Store
 				sink.DatasetManager = s.DatasetManager
 				return sink, nil
-			} else if sinkTypeName == "DevNullSink" {
+			case "DevNullSink":
 				sink := &devNullSink{}
 				return sink, nil
-			} else if sinkTypeName == "ConsoleSink" {
+			case "ConsoleSink":
 				sink := &consoleSink{}
 				v, ok := sinkConfig["Prefix"]
 				if ok {
@@ -80,7 +82,7 @@ func (s *Scheduler) parseSink(jobConfig *JobConfiguration) (Sink, error) {
 				}
 
 				return sink, nil
-			} else if sinkTypeName == "HttpDatasetSink" {
+			case "HttpDatasetSink":
 				sink := &httpDatasetSink{}
 				sink.Store = s.Store
 				sink.logger = s.Logger.Named("sink")
@@ -94,14 +96,13 @@ func (s *Scheduler) parseSink(jobConfig *JobConfiguration) (Sink, error) {
 					sink.TokenProvider = tokenProvider.(string)
 				}
 				return sink, nil
-			} else {
+			default:
 				return nil, errors.New("unknown sink type: " + sinkTypeName.(string))
 			}
 		}
 		return nil, errors.New("missing sink type")
 	}
 	return nil, errors.New("missing or wrong sink type")
-
 }
 
 type devNullSink struct{}
@@ -181,7 +182,6 @@ func (httpDatasetSink *httpDatasetSink) startFullSync(runner *Runner) error {
 }
 
 func (httpDatasetSink *httpDatasetSink) endFullSync(runner *Runner) error {
-
 	// send empty batch to server with end
 	timeout := 60 * time.Minute
 	client := httpclient.NewClient(httpclient.WithHTTPTimeout(timeout))
@@ -190,7 +190,7 @@ func (httpDatasetSink *httpDatasetSink) endFullSync(runner *Runner) error {
 	url := httpDatasetSink.Endpoint
 
 	allObjects := make([]interface{}, 1)
-	//TODO: https://mimiro.atlassian.net/browse/MIM-693
+	// TODO: https://mimiro.atlassian.net/browse/MIM-693
 	allObjects[0] = runner.store.GetGlobalContext()
 
 	jsonEntities, err := json.Marshal(allObjects)
@@ -220,7 +220,7 @@ func (httpDatasetSink *httpDatasetSink) endFullSync(runner *Runner) error {
 	}
 
 	if res.StatusCode != 200 {
-		return handleHttpError(res)
+		return handleHTTPError(res)
 	}
 
 	// reset full sync state
@@ -232,7 +232,6 @@ func (httpDatasetSink *httpDatasetSink) endFullSync(runner *Runner) error {
 }
 
 func (httpDatasetSink *httpDatasetSink) processEntities(runner *Runner, entities []*server.Entity) error {
-
 	timeout := 60 * time.Minute
 	client := httpclient.NewClient(httpclient.WithHTTPTimeout(timeout))
 
@@ -240,7 +239,7 @@ func (httpDatasetSink *httpDatasetSink) processEntities(runner *Runner, entities
 	url := httpDatasetSink.Endpoint
 
 	allObjects := make([]interface{}, len(entities)+1)
-	//TODO: https://mimiro.atlassian.net/browse/MIM-693
+	// TODO: https://mimiro.atlassian.net/browse/MIM-693
 	allObjects[0] = runner.store.GetGlobalContext()
 	for i := 0; i < len(entities); i++ {
 		allObjects[i+1] = entities[i]
@@ -285,7 +284,7 @@ func (httpDatasetSink *httpDatasetSink) processEntities(runner *Runner, entities
 	}
 
 	if res.StatusCode != 200 {
-		return handleHttpError(res)
+		return handleHTTPError(res)
 	}
 
 	return nil
@@ -347,10 +346,11 @@ func (datasetSink *datasetSink) GetConfig() map[string]interface{} {
 	config["Name"] = datasetSink.DatasetName
 	return config
 }
-func handleHttpError(response *http.Response) error {
+
+func handleHTTPError(response *http.Response) error {
 	bodyBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Received http sink error (%d). Unable to read error body", response.StatusCode))
+		return fmt.Errorf("received http sink error (%d). Unable to read error body", response.StatusCode)
 	}
-	return errors.New(fmt.Sprintf("Received http sink error (%d): %s", response.StatusCode, string(bodyBytes)))
+	return fmt.Errorf("received http sink error (%d): %s", response.StatusCode, string(bodyBytes))
 }

--- a/internal/jobs/source/dataset_source.go
+++ b/internal/jobs/source/dataset_source.go
@@ -40,8 +40,11 @@ func (datasetSource *DatasetSource) EndFullSync() {
 	datasetSource.isFullSync = false
 }
 
-func (datasetSource *DatasetSource) ReadEntities(since DatasetContinuation, batchSize int,
-	processEntities func([]*server.Entity, DatasetContinuation) error) error {
+func (datasetSource *DatasetSource) ReadEntities(
+	since DatasetContinuation,
+	batchSize int,
+	processEntities func([]*server.Entity, DatasetContinuation) error,
+) error {
 	exists := datasetSource.DatasetManager.IsDataset(datasetSource.DatasetName)
 	if !exists {
 		return fmt.Errorf("dataset does not exist: %v", datasetSource.DatasetName)
@@ -49,7 +52,6 @@ func (datasetSource *DatasetSource) ReadEntities(since DatasetContinuation, batc
 	dataset := datasetSource.DatasetManager.GetDataset(datasetSource.DatasetName)
 
 	entities := make([]*server.Entity, 0)
-	var err error
 	var cont *StringDatasetContinuation
 	if datasetSource.isFullSync {
 		if dataset.IsProxy() {
@@ -107,7 +109,7 @@ func (datasetSource *DatasetSource) ReadEntities(since DatasetContinuation, batc
 		}
 	}
 
-	err = processEntities(entities, cont)
+	err := processEntities(entities, cont)
 	if err != nil {
 		return err
 	}

--- a/internal/jobs/source/dataset_source_test.go
+++ b/internal/jobs/source/dataset_source_test.go
@@ -17,6 +17,9 @@ package source_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal"
@@ -25,8 +28,6 @@ import (
 	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func TestDatasetSource(t *testing.T) {
@@ -37,7 +38,6 @@ func TestDatasetSource(t *testing.T) {
 		var store *server.Store
 		var storeLocation string
 		g.BeforeEach(func() {
-
 			testCnt += 1
 			storeLocation = fmt.Sprintf("./test_dataset_source_%v", testCnt)
 			err := os.RemoveAll(storeLocation)
@@ -57,7 +57,6 @@ func TestDatasetSource(t *testing.T) {
 				fmt.Println(err.Error())
 				t.FailNow()
 			}
-
 		})
 		g.AfterEach(func() {
 			_ = store.Close()
@@ -73,19 +72,23 @@ func TestDatasetSource(t *testing.T) {
 			var tokens []source.DatasetContinuation
 			var recordedEntities []server.Entity
 			token := &source.StringDatasetContinuation{}
-			//testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			// testSource.StartFullSync()
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 			g.Assert(len(recordedEntities)).Eql(4, "two entities with 2 changes each expected")
 
-			//now, modify alice and verify that we get alice emitted in next read
+			// now, modify alice and verify that we get alice emitted in next read
 			err = people.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    peoplePrefix + ":Alice",
@@ -93,16 +96,21 @@ func TestDatasetSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 			since := tokens[len(tokens)-1]
 			tokens = []source.DatasetContinuation{}
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				since,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
@@ -118,13 +126,17 @@ func TestDatasetSource(t *testing.T) {
 			var recordedEntities []server.Entity
 			token := &source.StringDatasetContinuation{}
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 			g.Assert(len(recordedEntities)).Eql(2, "two entities")
@@ -147,13 +159,17 @@ func TestDatasetSource(t *testing.T) {
 			tokens = []source.DatasetContinuation{}
 			recordedEntities = []server.Entity{}
 			testSource.StartFullSync()
-			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				since,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 			g.Assert(len(recordedEntities)).Eql(1)
@@ -166,23 +182,30 @@ func TestDatasetSource(t *testing.T) {
 			// add one change to each entity -> 4 changes
 			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
 
-			testSource := source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm,
-				LatestOnly: true}
+			testSource := source.DatasetSource{
+				DatasetName: "people", Store: store, DatasetManager: dsm,
+				LatestOnly: true,
+			}
 			var tokens []source.DatasetContinuation
 			var recordedEntities []server.Entity
 			token := &source.StringDatasetContinuation{}
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).Eql(2, "There are 4 changes present, we expect only 2 (latest) changes emitted")
+			g.Assert(len(recordedEntities)).
+				Eql(2, "There are 4 changes present, we expect only 2 (latest) changes emitted")
 
-			//now, modify alice and verify that we get alice emitted in next read
+			// now, modify alice and verify that we get alice emitted in next read
 			err = people.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    peoplePrefix + ":Alice",
@@ -190,20 +213,24 @@ func TestDatasetSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 			since := tokens[len(tokens)-1]
 			tokens = []source.DatasetContinuation{}
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				since,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
 		})
-
 	})
 }

--- a/internal/jobs/source/dataset_source_test.go
+++ b/internal/jobs/source/dataset_source_test.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"github.com/mimiro-io/datahub/internal/server"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 func TestDatasetSource(t *testing.T) {

--- a/internal/jobs/source/multi_source.go
+++ b/internal/jobs/source/multi_source.go
@@ -204,9 +204,9 @@ func (multiSource *MultiSource) processDependency(dep Dependency, d *MultiDatase
 				// 1. build a RelatedFrom query input
 				searchBuffer := make([]byte, 10)
 				if join.Inverse {
-					binary.BigEndian.PutUint16(searchBuffer, server.INCOMING_REF_INDEX)
+					binary.BigEndian.PutUint16(searchBuffer, server.IncomingRefIndex)
 				} else {
-					binary.BigEndian.PutUint16(searchBuffer, server.OUTGOING_REF_INDEX)
+					binary.BigEndian.PutUint16(searchBuffer, server.OutgoingRefIndex)
 				}
 				binary.BigEndian.PutUint64(searchBuffer[2:], rid)
 

--- a/internal/jobs/source/multi_source.go
+++ b/internal/jobs/source/multi_source.go
@@ -253,9 +253,9 @@ func (multiSource *MultiSource) processDependency(dep Dependency, d *MultiDatase
 						prevRelatedFrom.At = timestamp
 					repeatPrevQuery:
 						// same query paging logic as lines 213-227, just different point in time. duplicates may be put onto channel here
-						prevRelatedEntities, cont, err := multiSource.Store.GetRelatedAtTime(prevRelatedFrom, batchSize)
-						if err != nil {
-							errChan <- fmt.Errorf("previous GetRelatedAtTime failed for Join %+v at timestamp %v, %w", join, timestamp, err)
+						prevRelatedEntities, cont, err2 := multiSource.Store.GetRelatedAtTime(prevRelatedFrom, batchSize)
+						if err2 != nil {
+							errChan <- fmt.Errorf("previous GetRelatedAtTime failed for Join %+v at timestamp %v, %w", join, timestamp, err2)
 						}
 						for _, r := range prevRelatedEntities {
 							joinLvlChan <- r.EntityID

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -1359,7 +1359,7 @@ func TestMultiSource(t *testing.T) {
 				// create main dataset as proxy dataset
 				_, err := dsm.CreateDataset("people", &server.CreateDatasetConfig{
 					ProxyDatasetConfig: &server.ProxyDatasetConfig{
-						RemoteUrl: "http://localhost:7777/datasets/people",
+						RemoteURL: "http://localhost:7777/datasets/people",
 					},
 				})
 				g.Assert(err).IsNil()
@@ -1388,7 +1388,7 @@ func TestMultiSource(t *testing.T) {
 				// create dependency dataset as proxy dataset
 				_, err := dsm.CreateDataset("address", &server.CreateDatasetConfig{
 					ProxyDatasetConfig: &server.ProxyDatasetConfig{
-						RemoteUrl: "http://localhost:7777/datasets/address",
+						RemoteURL: "http://localhost:7777/datasets/address",
 					},
 				})
 				g.Assert(err).IsNil()

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -23,12 +23,13 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"github.com/mimiro-io/datahub/internal/server"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 func TestMultiSource(t *testing.T) {

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal"
@@ -26,8 +29,6 @@ import (
 	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func TestMultiSource(t *testing.T) {
@@ -73,18 +74,22 @@ func TestMultiSource(t *testing.T) {
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 			g.Assert(len(recordedEntities)).Eql(4, "two entities with 2 changes each expected")
 
-			//now, modify alice and verify that we get alice emitted in next read
+			// now, modify alice and verify that we get alice emitted in next read
 			err = people.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    peoplePrefix + ":Alice",
@@ -92,16 +97,21 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 			since := tokens[len(tokens)-1]
 			tokens = []source.DatasetContinuation{}
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				since,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
@@ -113,24 +123,31 @@ func TestMultiSource(t *testing.T) {
 			// add one change to each entity -> 4 changes
 			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm,
-				LatestOnly: true}
+			testSource := source.MultiSource{
+				DatasetName: "people", Store: store, DatasetManager: dsm,
+				LatestOnly: true,
+			}
 			var tokens []source.DatasetContinuation
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).Eql(2, "There are 4 changes present, we expect only 2 (latest) changes emitted")
+			g.Assert(len(recordedEntities)).
+				Eql(2, "There are 4 changes present, we expect only 2 (latest) changes emitted")
 
-			//now, modify alice and verify that we get alice emitted in next read
+			// now, modify alice and verify that we get alice emitted in next read
 			err = people.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    peoplePrefix + ":Alice",
@@ -138,16 +155,21 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 			since := tokens[len(tokens)-1]
 			tokens = []source.DatasetContinuation{}
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(since, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				tokens = append(tokens, token)
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				since,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					tokens = append(tokens, token)
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
@@ -176,31 +198,46 @@ func TestMultiSource(t *testing.T) {
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err = testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
-			//test that we do not get anything emitted without further changes. verifying that watermarks are stored in lastToken
+			// test that we do not get anything emitted without further changes. verifying that watermarks are stored in lastToken
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(0)
 		})
 
 		g.It("should emit main entity if direct dependency was changed after fullsync", func() {
-			addresses, addressPrefix := createTestDataset("address", []string{"Mainstreet", "Sidealley"}, nil, dsm, g, store)
+			addresses, addressPrefix := createTestDataset(
+				"address",
+				[]string{"Mainstreet", "Sidealley"},
+				nil,
+				dsm,
+				g,
+				store,
+			)
 			peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
 			createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
 				"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
@@ -218,22 +255,26 @@ func TestMultiSource(t *testing.T) {
 			err = testSource.ParseDependencies(srcConfig["Dependencies"])
 			g.Assert(err).IsNil()
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err = testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
-			//now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
+			// now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
 			err = addresses.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    addressPrefix + ":Mainstreet",
@@ -241,24 +282,35 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
-			//Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
-
 		})
 
-		//initial incremental will be much slower, as it traverses all main entities and processes all dependency changes without watermarks
+		// initial incremental will be much slower, as it traverses all main entities and processes all dependency changes without watermarks
 		g.It("should emit main entity if direct dependency was changed after initial incremental run", func() {
-			addresses, addressPrefix := createTestDataset("address", []string{"Mainstreet", "Sidealley"}, nil, dsm, g, store)
+			addresses, addressPrefix := createTestDataset(
+				"address",
+				[]string{"Mainstreet", "Sidealley"},
+				nil,
+				dsm,
+				g,
+				store,
+			)
 			peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
 			createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
 				"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
@@ -276,21 +328,25 @@ func TestMultiSource(t *testing.T) {
 			err = testSource.ParseDependencies(srcConfig["Dependencies"])
 			g.Assert(err).IsNil()
 
-			//initial incremental run.
-			//Since the fullsync flag is not set, the run will traverse all dependencies in addition to all main entities
+			// initial incremental run.
+			// Since the fullsync flag is not set, the run will traverse all dependencies in addition to all main entities
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
-			err = testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 
-			//now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
+			// now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
 			err = addresses.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    addressPrefix + ":Mainstreet",
@@ -298,17 +354,22 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
-			//Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
 		})
 
@@ -318,7 +379,9 @@ func TestMultiSource(t *testing.T) {
 				[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
 					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
 					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale":        {peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"}},
+					"YardSale": {
+						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+					},
 				}, dsm, g, store)
 
 			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
@@ -330,22 +393,26 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
-			//now, modify MediumCorp employment and verify that we get Bob emitted in next read (MediumCorp is inverse dependency to bob)
+			// now, modify MediumCorp employment and verify that we get Bob emitted in next read (MediumCorp is inverse dependency to bob)
 			err = employments.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    employmentPrefix + ":MediumCorp",
@@ -353,39 +420,51 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{peoplePrefix + ":employment": peoplePrefix + ":Bob"},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
-			//Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
 
-			//also, modify YardSale employment and verify that both Bob and Alice emitted in next read
+			// also, modify YardSale employment and verify that both Bob and Alice emitted in next read
 			err = employments.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    employmentPrefix + ":YardSale",
 					"props": map[string]interface{}{"name": "YardSale-changed"},
-					"refs":  map[string]interface{}{peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"}},
+					"refs": map[string]interface{}{
+						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+					},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
-			//expect both referred-to people to be emitted
+			// expect both referred-to people to be emitted
 			g.Assert(len(recordedEntities)).Eql(2)
 		})
 
@@ -417,22 +496,26 @@ func TestMultiSource(t *testing.T) {
 			err = testSource.ParseDependencies(srcConfig["Dependencies"])
 			g.Assert(err).IsNil()
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err = testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
-			//modify Mainstreet address and verify that nothing changed (address is not a dependency, just a join)
+			// modify Mainstreet address and verify that nothing changed (address is not a dependency, just a join)
 			err = addresses.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    addressPrefix + ":Mainstreet",
@@ -440,18 +523,23 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{addressPrefix + ":city": cityPrefix + ":Oslo"},
 				}),
 			})
+			g.Assert(err).IsNil()
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(0)
 
-			//now, modify Oslo city and verify that bob is found via Mainstreet address
+			// now, modify Oslo city and verify that bob is found via Mainstreet address
 			err = cities.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    cityPrefix + ":Oslo",
@@ -459,14 +547,19 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
 		})
@@ -478,12 +571,19 @@ func TestMultiSource(t *testing.T) {
 				[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
 					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
 					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale":        {peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"}},
+					"YardSale": {
+						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+					},
 				}, dsm, g, store)
 			incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
 				[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
 					"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
-					"Low":  {employmentPrefix + ":employment": []string{employmentPrefix + ":MediumCorp", employmentPrefix + "YardSale"}},
+					"Low": {
+						employmentPrefix + ":employment": []string{
+							employmentPrefix + ":MediumCorp",
+							employmentPrefix + "YardSale",
+						},
+					},
 				}, dsm, g, store)
 
 			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
@@ -497,22 +597,26 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
-			//now, modify High incomeRange and verify that we get Bob emitted in next read (MediumCorp is inverse dependency to bob via employment MediumCorp)
+			// now, modify High incomeRange and verify that we get Bob emitted in next read (MediumCorp is inverse dependency to bob via employment MediumCorp)
 			err = incomeRanges.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    incomeRangePrefix + ":High",
@@ -520,18 +624,23 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
-			//Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
 		})
 
@@ -541,7 +650,9 @@ func TestMultiSource(t *testing.T) {
 				[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
 					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
 					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale":        {peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"}},
+					"YardSale": {
+						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+					},
 				}, dsm, g, store)
 
 			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
@@ -553,22 +664,26 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
-			//now, remove all refs  from MediumCorp.  this should emit bob because the dependency was changed
+			// now, remove all refs  from MediumCorp.  this should emit bob because the dependency was changed
 			err = employments.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    employmentPrefix + ":MediumCorp",
@@ -576,18 +691,23 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(1)
-			//Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
 		})
 		g.It("should support empty dependency dastasets", func() {
@@ -603,18 +723,22 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
@@ -622,13 +746,17 @@ func TestMultiSource(t *testing.T) {
 
 			// run inc
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(0)
 		})
@@ -641,12 +769,19 @@ func TestMultiSource(t *testing.T) {
 					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
 					"BigCorp":         {peoplePrefix + ":employment": peoplePrefix + ":Hank"},
 					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale":        {peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"}},
+					"YardSale": {
+						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+					},
 				}, dsm, g, store)
 			incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
 				[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
 					"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
-					"Low":  {employmentPrefix + ":employment": []string{employmentPrefix + ":MediumCorp", employmentPrefix + "YardSale"}},
+					"Low": {
+						employmentPrefix + ":employment": []string{
+							employmentPrefix + ":MediumCorp",
+							employmentPrefix + "YardSale",
+						},
+					},
 				}, dsm, g, store)
 
 			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
@@ -660,23 +795,27 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
-			//now, point High incomeRange from MediumCorp to BigCorp.
-			//Hank and Bob should be emitted (Hank, because he gained High incomeRange. Bob, because he lost it).
+			// now, point High incomeRange from MediumCorp to BigCorp.
+			// Hank and Bob should be emitted (Hank, because he gained High incomeRange. Bob, because he lost it).
 			err = incomeRanges.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    incomeRangePrefix + ":High",
@@ -684,17 +823,22 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":BigCorp"},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
 			batchCnt := 0
-			err = testSource.ReadEntities(lastToken, 1, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				batchCnt++
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					batchCnt++
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(batchCnt).Eql(3, "2 batches of 1, and final main dataset batch is empty")
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(2)
@@ -705,7 +849,6 @@ func TestMultiSource(t *testing.T) {
 			}
 			g.Assert(seenBob).IsTrue("expected to find Bob in emitted entities")
 			g.Assert(seenHank).IsTrue("expected to find Hank in emitted entities")
-
 		})
 
 		g.It("should support same dataset as dependency multiple times", func() {
@@ -717,12 +860,19 @@ func TestMultiSource(t *testing.T) {
 					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
 					"BigCorp":         {peoplePrefix + ":employment": peoplePrefix + ":Hank"},
 					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale":        {peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"}},
+					"YardSale": {
+						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+					},
 				}, dsm, g, store)
 			incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
 				[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
 					"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
-					"Low":  {employmentPrefix + ":employment": []string{employmentPrefix + ":MediumCorp", employmentPrefix + "YardSale"}},
+					"Low": {
+						employmentPrefix + ":employment": []string{
+							employmentPrefix + ":MediumCorp",
+							employmentPrefix + "YardSale",
+						},
+					},
 				}, dsm, g, store)
 			_, _ = createTestDataset("demographic", []string{"young", "middle-aged", "senior"},
 				map[string]map[string]interface{}{
@@ -749,18 +899,22 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
@@ -773,15 +927,20 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(2)
 			var seenBob, seenAlice bool
@@ -791,17 +950,27 @@ func TestMultiSource(t *testing.T) {
 			}
 			g.Assert(seenBob).IsTrue("expected to find Bob in emitted entities via 1st dep")
 			g.Assert(seenAlice).IsTrue("expected to find Alice in emitted entities via 2nd dep")
-
 		})
 
 		g.It("should support multiple link predicates per join", func() {
 			// people <- band -> people
-			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Rob", "Mary", "Alice", "Hank", "Lisa"}, nil, dsm, g, store)
+			people, peoplePrefix := createTestDataset(
+				"people",
+				[]string{"Bob", "Rob", "Mary", "Alice", "Hank", "Lisa"},
+				nil,
+				dsm,
+				g,
+				store,
+			)
 
 			_, _ = createTestDataset("band", []string{"Rockbuds", "SideshowBand"},
 				map[string]map[string]interface{}{
 					"Rockbuds": {
-						peoplePrefix + ":singer":  []string{peoplePrefix + ":Rob", peoplePrefix + ":Mary", peoplePrefix + ":Lisa"},
+						peoplePrefix + ":singer": []string{
+							peoplePrefix + ":Rob",
+							peoplePrefix + ":Mary",
+							peoplePrefix + ":Lisa",
+						},
 						peoplePrefix + ":drummer": []string{peoplePrefix + ":Alice"},
 					},
 					"SideshowBand": {
@@ -833,18 +1002,22 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
@@ -856,15 +1029,20 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(2)
 			var seenBob, seenHank bool
@@ -884,15 +1062,20 @@ func TestMultiSource(t *testing.T) {
 					"refs":  map[string]interface{}{},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(5)
 			var lisaSeen, robSeen, marySeen, aliceSeen bool
@@ -923,12 +1106,20 @@ func TestMultiSource(t *testing.T) {
 			_, _ = createTestDataset("team", []string{"product", "development"},
 				map[string]map[string]interface{}{
 					"product": {
-						teamPrefix + ":lead":   peoplePrefix + ":Bob",
-						teamPrefix + ":member": []string{peoplePrefix + ":Bob", peoplePrefix + ":Rob", peoplePrefix + ":Mary"},
+						teamPrefix + ":lead": peoplePrefix + ":Bob",
+						teamPrefix + ":member": []string{
+							peoplePrefix + ":Bob",
+							peoplePrefix + ":Rob",
+							peoplePrefix + ":Mary",
+						},
 					},
 					"development": {
-						teamPrefix + ":lead":   peoplePrefix + ":Alice",
-						teamPrefix + ":member": []string{peoplePrefix + ":Alice", peoplePrefix + ":Hank", peoplePrefix + ":Lisa"},
+						teamPrefix + ":lead": peoplePrefix + ":Alice",
+						teamPrefix + ":member": []string{
+							peoplePrefix + ":Alice",
+							peoplePrefix + ":Hank",
+							peoplePrefix + ":Lisa",
+						},
 					},
 				}, dsm, g, store)
 
@@ -964,18 +1155,22 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
@@ -991,13 +1186,17 @@ func TestMultiSource(t *testing.T) {
 			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 
 			g.Assert(err).IsNil()
 			g.Assert(len(recordedEntities)).Eql(3)
@@ -1039,42 +1238,55 @@ func TestMultiSource(t *testing.T) {
 			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			//fullsync
+			// fullsync
 			var recordedEntities []server.Entity
 			token := &source.MultiDatasetContinuation{}
 			var lastToken source.DatasetContinuation
 			testSource.StartFullSync()
-			err := testSource.ReadEntities(token, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err := testSource.ReadEntities(
+				token,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
 			testSource.EndFullSync()
 
-			//now, add new Employment with refs to Bob (exists) and Franz (non-exists)
+			// now, add new Employment with refs to Bob (exists) and Franz (non-exists)
 			err = employmentDs.StoreEntities([]*server.Entity{
 				server.NewEntityFromMap(map[string]interface{}{
 					"id":    employmentPrefix + ":YardSale",
 					"props": map[string]interface{}{"name": "YardSale"},
-					"refs":  map[string]interface{}{peoplePrefix + ":employment": []string{peoplePrefix + ":Franz", peoplePrefix + ":Bob"}},
+					"refs": map[string]interface{}{
+						peoplePrefix + ":employment": []string{peoplePrefix + ":Franz", peoplePrefix + ":Bob"},
+					},
 				}),
 			})
+			g.Assert(err).IsNil()
 
 			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(lastToken, 1000, func(entities []*server.Entity, token source.DatasetContinuation) error {
-				lastToken = token
-				for _, e := range entities {
-					recordedEntities = append(recordedEntities, *e)
-				}
-				return nil
-			})
+			err = testSource.ReadEntities(
+				lastToken,
+				1000,
+				func(entities []*server.Entity, token source.DatasetContinuation) error {
+					lastToken = token
+					for _, e := range entities {
+						recordedEntities = append(recordedEntities, *e)
+					}
+					return nil
+				},
+			)
 			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1, "YardSale change points to non-existing entity 'Franz' in people, therefore only Bob should be emitted")
+			g.Assert(len(recordedEntities)).
+				Eql(1, "YardSale change points to non-existing entity 'Franz' in people, therefore only Bob should be emitted")
 			g.Assert(recordedEntities[0].ID).Eql(peoplePrefix + ":Bob")
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob", "Bob exists in two datasets. making sure we dont get a merged result")
+			g.Assert(recordedEntities[0].Properties["name"]).
+				Eql("Bob", "Bob exists in two datasets. making sure we dont get a merged result")
 		})
 
 		g.Describe("parseDependencies", func() {
@@ -1148,7 +1360,8 @@ func TestMultiSource(t *testing.T) {
 				_, err := dsm.CreateDataset("people", &server.CreateDatasetConfig{
 					ProxyDatasetConfig: &server.ProxyDatasetConfig{
 						RemoteUrl: "http://localhost:7777/datasets/people",
-					}})
+					},
+				})
 				g.Assert(err).IsNil()
 
 				// now instantiate (simulating job start)
@@ -1168,7 +1381,7 @@ func TestMultiSource(t *testing.T) {
 				srcConfig := map[string]interface{}{}
 				_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 				err = testSource.ParseDependencies(srcConfig["Dependencies"])
-				//t.Log(err)
+				// t.Log(err)
 				g.Assert(err).IsNotNil()
 			})
 			g.It("Should fail if a dependency is a proxy dataset", func() {
@@ -1176,7 +1389,8 @@ func TestMultiSource(t *testing.T) {
 				_, err := dsm.CreateDataset("address", &server.CreateDatasetConfig{
 					ProxyDatasetConfig: &server.ProxyDatasetConfig{
 						RemoteUrl: "http://localhost:7777/datasets/address",
-					}})
+					},
+				})
 				g.Assert(err).IsNil()
 
 				// now instantiate (simulating job start)
@@ -1196,7 +1410,7 @@ func TestMultiSource(t *testing.T) {
 				srcConfig := map[string]interface{}{}
 				_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
 				err = testSource.ParseDependencies(srcConfig["Dependencies"])
-				//t.Log(err)
+				// t.Log(err)
 				g.Assert(err).IsNotNil()
 			})
 		})
@@ -1204,7 +1418,8 @@ func TestMultiSource(t *testing.T) {
 }
 
 func createTestDataset(dsName string, entityNames []string, refMap map[string]map[string]interface{},
-	dsm *server.DsManager, g *goblin.G, store *server.Store) (*server.Dataset, string) {
+	dsm *server.DsManager, g *goblin.G, store *server.Store,
+) (*server.Dataset, string) {
 	dataset, err := dsm.CreateDataset(dsName, nil)
 	g.Assert(err).IsNil()
 	peoplePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion("http://" + dsName + "/")
@@ -1225,7 +1440,12 @@ func createTestDataset(dsName string, entityNames []string, refMap map[string]ma
 	return dataset, peoplePrefix
 }
 
-func addChanges(dsName string, entityNames []string, dsm *server.DsManager, store *server.Store) (*server.Dataset, string) {
+func addChanges(
+	dsName string,
+	entityNames []string,
+	dsm *server.DsManager,
+	store *server.Store,
+) (*server.Dataset, string) {
 	dataset := dsm.GetDataset(dsName)
 	peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://" + dsName + "/")
 	var entities []*server.Entity

--- a/internal/jobs/source/sample_source.go
+++ b/internal/jobs/source/sample_source.go
@@ -41,8 +41,11 @@ func (source *SampleSource) GetConfig() map[string]interface{} {
 	return config
 }
 
-func (source *SampleSource) ReadEntities(since DatasetContinuation, batchSize int, processEntities func([]*server.Entity, DatasetContinuation) error) error {
-
+func (source *SampleSource) ReadEntities(
+	since DatasetContinuation,
+	batchSize int,
+	processEntities func([]*server.Entity, DatasetContinuation) error,
+) error {
 	var err error
 	sinceOffset := int(since.AsIncrToken())
 	if source.NumberOfEntities < batchSize {

--- a/internal/jobs/source/slow_source.go
+++ b/internal/jobs/source/slow_source.go
@@ -43,7 +43,11 @@ func (source *SlowSource) GetConfig() map[string]interface{} {
 	return config
 }
 
-func (source *SlowSource) ReadEntities(since DatasetContinuation, batchSize int, processEntities func([]*server.Entity, DatasetContinuation) error) error {
+func (source *SlowSource) ReadEntities(
+	since DatasetContinuation,
+	batchSize int,
+	processEntities func([]*server.Entity, DatasetContinuation) error,
+) error {
 	// assert sample source namespace
 
 	entities := make([]*server.Entity, source.BatchSize)

--- a/internal/jobs/source/source.go
+++ b/internal/jobs/source/source.go
@@ -24,7 +24,11 @@ import (
 // Source interface for pulling data
 type Source interface {
 	GetConfig() map[string]interface{}
-	ReadEntities(since DatasetContinuation, batchSize int, processEntities func([]*server.Entity, DatasetContinuation) error) error
+	ReadEntities(
+		since DatasetContinuation,
+		batchSize int,
+		processEntities func([]*server.Entity, DatasetContinuation) error,
+	) error
 	StartFullSync()
 	EndFullSync()
 }
@@ -42,6 +46,7 @@ type StringDatasetContinuation struct {
 func (c *StringDatasetContinuation) GetToken() string {
 	return c.Token
 }
+
 func (c *StringDatasetContinuation) AsIncrToken() uint64 {
 	if c.Token != "" {
 		i, err := strconv.Atoi(c.Token)
@@ -52,6 +57,7 @@ func (c *StringDatasetContinuation) AsIncrToken() uint64 {
 	}
 	return 0
 }
+
 func (c *StringDatasetContinuation) Encode() (string, error) {
 	return c.GetToken(), nil
 }

--- a/internal/jobs/source/union_source_test.go
+++ b/internal/jobs/source/union_source_test.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"github.com/mimiro-io/datahub/internal/server"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 func TestUnionDatasetSource(t *testing.T) {

--- a/internal/jobs/transform.go
+++ b/internal/jobs/transform.go
@@ -26,9 +26,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/gofrs/uuid"
-
 	"github.com/dop251/goja"
+	"github.com/gofrs/uuid"
 	"github.com/gojektech/heimdall/v6/httpclient"
 	"go.uber.org/zap"
 

--- a/internal/jobs/transform_test.go
+++ b/internal/jobs/transform_test.go
@@ -16,12 +16,13 @@ package jobs
 
 import (
 	"encoding/base64"
+	"strings"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/zap"
-	"strings"
-	"testing"
 )
 
 func TestTransform(t *testing.T) {
@@ -122,7 +123,7 @@ func TestTransform(t *testing.T) {
 
 			r, _ := transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
 			g.Assert(len(r)).Eql(1)
-			//t.Logf("%+v", r[0])
+			// t.Logf("%+v", r[0])
 			g.Assert(r[0].Properties["b:output"].(*server.Entity).
 				Properties["b:num"]).Eql(entities[0].Properties["a:input"])
 		})
@@ -151,7 +152,7 @@ func TestTransform(t *testing.T) {
 			r, err := transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
 			g.Assert(err).IsNil()
 			g.Assert(len(r)).Eql(1)
-			//t.Logf("%+v", r[0])
+			// t.Logf("%+v", r[0])
 			g.Assert(r[0].Properties["b:output"]).Eql([]interface{}{
 				entities[0].Properties["a:input"],
 				entities[0].Properties["a:input"],
@@ -192,7 +193,6 @@ func TestJavascriptTransform_ToString(t *testing.T) {
 
 			ret := transform.ToString(lemap)
 			g.Assert(ret).Equal("map[field1:1 field2:2]")
-
 		})
 		g.It("an entity should be formatted correctly", func() {
 			transform := &JavascriptTransform{}
@@ -215,14 +215,24 @@ func TestHttpTransformConfig(t *testing.T) {
 	g := goblin.Goblin(t)
 	g.Describe("Test that httpTransform picks up timeout from config", func() {
 		g.It("Should return correct httpTransform", func() {
-			c := &JobConfiguration{Id: "oes3fjudqn", Title: "my-test-title", Description: "my-description", Source: map[string]interface{}{"Type": "DatasetSource", "Name": "test-dataset"}, Sink: map[string]interface{}{"Type": "DatasetSink", "Name": "test-transformed"}, Transform: map[string]interface{}{"TimeOut": 70.00, "Type": "HttpTransform", "Url": "https://very-external"}}
-			transform := &HttpTransform{TimeOut: 70.00, Url: "https://very-external"}
+			c := &JobConfiguration{
+				ID:          "oes3fjudqn",
+				Title:       "my-test-title",
+				Description: "my-description",
+				Source:      map[string]interface{}{"Type": "DatasetSource", "Name": "test-dataset"},
+				Sink:        map[string]interface{}{"Type": "DatasetSink", "Name": "test-transformed"},
+				Transform: map[string]interface{}{
+					"TimeOut": 70.00,
+					"Type":    "HttpTransform",
+					"Url":     "https://very-external",
+				},
+			}
+			transform := &HTTPTransform{TimeOut: 70.00, URL: "https://very-external"}
 			scheduler := Scheduler{}
 			test, err := scheduler.parseTransform(c)
 			g.Assert(err).IsNil("should not error here")
 
 			g.Assert(transform).Equal(test, "Bare minimum transform")
-
 		})
 	})
 }

--- a/internal/jobs/transform_test.go
+++ b/internal/jobs/transform_test.go
@@ -21,8 +21,9 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
-	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 func TestTransform(t *testing.T) {

--- a/internal/security/claims.go
+++ b/internal/security/claims.go
@@ -15,8 +15,9 @@
 package security
 
 import (
-	"github.com/golang-jwt/jwt/v4"
 	"strings"
+
+	"github.com/golang-jwt/jwt/v4"
 )
 
 type CustomClaims struct {
@@ -25,7 +26,7 @@ type CustomClaims struct {
 	Gty      string   `json:"gty"`
 	Adm      bool     `json:"adm"`
 	Roles    []string `json:"roles"`
-	ClientId string   `json:"client_id"`
+	ClientID string   `json:"client_id"`
 	jwt.RegisteredClaims
 }
 

--- a/internal/security/dljwt.go
+++ b/internal/security/dljwt.go
@@ -27,7 +27,7 @@ import (
 
 // JwtBearerProvider contains the auth0 configuration
 type JwtBearerProvider struct {
-	ClientId     string `json:"client_id"`
+	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	Audience     string `json:"audience"`
 	GrantType    string `json:"grant_type"`
@@ -51,7 +51,7 @@ type auth0Response struct {
 // NewDlJwtConfig creates a new JwtBearerProvider struct, populated with the values from Viper.
 func NewDlJwtConfig(logger *zap.SugaredLogger, conf ProviderConfig, pm *ProviderManager) *JwtBearerProvider {
 	config := &JwtBearerProvider{
-		ClientId:     pm.LoadValue(conf.ClientId),
+		ClientID:     pm.LoadValue(conf.ClientID),
 		ClientSecret: pm.LoadValue(conf.ClientSecret),
 		Audience:     pm.LoadValue(conf.Audience),
 		GrantType:    pm.LoadValue(conf.GrantType),
@@ -68,7 +68,6 @@ func (auth0 *JwtBearerProvider) Authorize(req *http.Request) {
 	} else {
 		req.Header.Add("Authorization", bearer)
 	}
-
 }
 
 // Token returns a valid token, or an error caused when getting one
@@ -110,7 +109,7 @@ func (auth0 *JwtBearerProvider) callRemote() (*auth0Response, error) {
 	client := httpclient.NewClient(httpclient.WithHTTPTimeout(timeout))
 
 	requestBody, err := json.Marshal(map[string]string{
-		"client_id":     auth0.ClientId,
+		"client_id":     auth0.ClientID,
 		"client_secret": auth0.ClientSecret,
 		"audience":      auth0.Audience,
 		"grant_type":    auth0.GrantType,

--- a/internal/security/dljwt_test.go
+++ b/internal/security/dljwt_test.go
@@ -32,7 +32,7 @@ func TestDlJwt(t *testing.T) {
 			provider := ProviderConfig{
 				Name: "jwt",
 				Type: "bearer",
-				ClientId: &ValueReader{
+				ClientID: &ValueReader{
 					Type:  "text",
 					Value: "id1",
 				},
@@ -55,7 +55,7 @@ func TestDlJwt(t *testing.T) {
 			}
 
 			config := NewDlJwtConfig(zap.NewNop().Sugar(), provider, &ProviderManager{})
-			g.Assert(config.ClientId).Eql("id1")
+			g.Assert(config.ClientID).Eql("id1")
 			g.Assert(config.ClientSecret).Eql("some-secret")
 		})
 
@@ -63,7 +63,7 @@ func TestDlJwt(t *testing.T) {
 			srv := serverMock()
 
 			config := JwtBearerProvider{
-				ClientId:     "123",
+				ClientID:     "123",
 				ClientSecret: "456",
 				Audience:     "",
 				GrantType:    "",
@@ -82,7 +82,7 @@ func TestDlJwt(t *testing.T) {
 			srv := serverMock()
 
 			config := JwtBearerProvider{
-				ClientId:     "123",
+				ClientID:     "123",
 				ClientSecret: "456",
 				Audience:     "",
 				GrantType:    "",
@@ -97,7 +97,7 @@ func TestDlJwt(t *testing.T) {
 
 			// cache is set and time is in the future, so it should return the cached version
 			config = JwtBearerProvider{
-				ClientId:     "123",
+				ClientID:     "123",
 				ClientSecret: "456",
 				Audience:     "",
 				GrantType:    "",
@@ -115,7 +115,7 @@ func TestDlJwt(t *testing.T) {
 
 			// cache is set but time is in the past, so it should return a new token
 			config = JwtBearerProvider{
-				ClientId:     "123",
+				ClientID:     "123",
 				ClientSecret: "456",
 				Audience:     "",
 				GrantType:    "",

--- a/internal/security/login_provider.go
+++ b/internal/security/login_provider.go
@@ -18,19 +18,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"os"
+
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/conf/secrets"
 	"github.com/mimiro-io/datahub/internal/server"
 	"github.com/spf13/viper"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"net/http"
-	"os"
 )
 
-var (
-	ErrLoginProviderNotFound = errors.New("login provider not found")
-)
+var ErrLoginProviderNotFound = errors.New("login provider not found")
 
 type Provider interface {
 	Authorize(req *http.Request)
@@ -62,7 +61,7 @@ func NewProviderManager(lc fx.Lifecycle, env *conf.Env, store *server.Store, log
 // addComp makes sure we still support the old version by adding the
 // jwt configuration from the env if present.
 func (pm *ProviderManager) addComp() error {
-	if pm.env.DlJwtConfig != nil && pm.env.DlJwtConfig.ClientId != "" {
+	if pm.env.DlJwtConfig != nil && pm.env.DlJwtConfig.ClientID != "" {
 		provider := ProviderConfig{
 			Name: "jwttokenprovider",
 			Type: "bearer",

--- a/internal/security/login_provider.go
+++ b/internal/security/login_provider.go
@@ -113,7 +113,7 @@ func (pm *ProviderManager) LoadValue(vp *ValueReader) string {
 
 func (pm *ProviderManager) ListProviders() ([]ProviderConfig, error) {
 	providers := make([]ProviderConfig, 0)
-	err := pm.store.IterateObjectsRaw(server.LOGIN_PROVIDER_INDEX_BYTES, func(bytes []byte) error {
+	err := pm.store.IterateObjectsRaw(server.LoginProviderIndexBytes, func(bytes []byte) error {
 		provider := ProviderConfig{}
 		if err := json.Unmarshal(bytes, &provider); err != nil {
 			return err
@@ -125,7 +125,7 @@ func (pm *ProviderManager) ListProviders() ([]ProviderConfig, error) {
 }
 
 func (pm *ProviderManager) AddProvider(providerConfig ProviderConfig) error {
-	err := pm.store.StoreObject(server.LOGIN_PROVIDER_INDEX, providerConfig.Name, providerConfig)
+	err := pm.store.StoreObject(server.LoginProviderIndex, providerConfig.Name, providerConfig)
 	if err != nil {
 		return err
 	}
@@ -133,12 +133,12 @@ func (pm *ProviderManager) AddProvider(providerConfig ProviderConfig) error {
 }
 
 func (pm *ProviderManager) DeleteProvider(name string) error {
-	return pm.store.DeleteObject(server.LOGIN_PROVIDER_INDEX, name)
+	return pm.store.DeleteObject(server.LoginProviderIndex, name)
 }
 
 func (pm *ProviderManager) FindByName(name string) (*ProviderConfig, error) {
 	config := &ProviderConfig{}
-	if err := pm.store.GetObject(server.LOGIN_PROVIDER_INDEX, name, config); err != nil {
+	if err := pm.store.GetObject(server.LoginProviderIndex, name, config); err != nil {
 		return nil, err
 	} else {
 		if config.Name == "" { // does not exist

--- a/internal/security/login_provider.go
+++ b/internal/security/login_provider.go
@@ -21,12 +21,13 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/mimiro-io/datahub/internal/conf"
-	"github.com/mimiro-io/datahub/internal/conf/secrets"
-	"github.com/mimiro-io/datahub/internal/server"
 	"github.com/spf13/viper"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/conf/secrets"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 var ErrLoginProviderNotFound = errors.New("login provider not found")

--- a/internal/security/login_provider.go
+++ b/internal/security/login_provider.go
@@ -65,7 +65,7 @@ func (pm *ProviderManager) addComp() error {
 		provider := ProviderConfig{
 			Name: "jwttokenprovider",
 			Type: "bearer",
-			ClientId: &ValueReader{
+			ClientID: &ValueReader{
 				Type:  "env",
 				Value: "DL_JWT_CLIENT_ID",
 			},
@@ -153,7 +153,7 @@ type ProviderConfig struct {
 	Type         string       `json:"type"`
 	User         *ValueReader `json:"user,omitempty"`
 	Password     *ValueReader `json:"password,omitempty"`
-	ClientId     *ValueReader `json:"key,omitempty"`
+	ClientID     *ValueReader `json:"key,omitempty"`
 	ClientSecret *ValueReader `json:"secret,omitempty"`
 	Audience     *ValueReader `json:"audience,omitempty"`
 	GrantType    *ValueReader `json:"grantType,omitempty"`

--- a/internal/security/login_provider_test.go
+++ b/internal/security/login_provider_test.go
@@ -21,11 +21,12 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/server"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 func TestCrud(t *testing.T) {

--- a/internal/security/login_provider_test.go
+++ b/internal/security/login_provider_test.go
@@ -15,6 +15,10 @@
 package security
 
 import (
+	"os"
+	"strconv"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal"
@@ -22,16 +26,12 @@ import (
 	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
-	"strconv"
-	"testing"
 )
 
 func TestCrud(t *testing.T) {
 	g := goblin.Goblin(t)
 
 	g.Describe("Login Provider Crud operations", func() {
-
 		var store *server.Store
 		var e *conf.Env
 		var pm *ProviderManager
@@ -91,7 +91,6 @@ func TestCrud(t *testing.T) {
 
 			_, err = pm.FindByName("test-jwt-4")
 			g.Assert(err).Eql(ErrLoginProviderNotFound)
-
 		})
 		g.It("should be able to delete a config", func() {
 			p := createConfig("test-jwt-5")
@@ -118,7 +117,6 @@ func TestCrud(t *testing.T) {
 			items, err := pm.ListProviders()
 			g.Assert(err).IsNil()
 			g.Assert(len(items)).Equal(2)
-
 		})
 	})
 }
@@ -127,7 +125,7 @@ func createConfig(name string) ProviderConfig {
 	return ProviderConfig{
 		Name: name,
 		Type: "bearer",
-		ClientId: &ValueReader{
+		ClientID: &ValueReader{
 			Type:  "text",
 			Value: "id1",
 		},

--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
+
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/server"
 )

--- a/internal/security/manager_test.go
+++ b/internal/security/manager_test.go
@@ -15,6 +15,10 @@
 package security
 
 import (
+	"os"
+	"strconv"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal"
@@ -22,16 +26,12 @@ import (
 	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
-	"strconv"
-	"testing"
 )
 
 func TestManager(t *testing.T) {
 	g := goblin.Goblin(t)
 
 	g.Describe("Security Manager", func() {
-
 		var store *server.Store
 		var e *conf.Env
 		var pm *ProviderManager

--- a/internal/security/manager_test.go
+++ b/internal/security/manager_test.go
@@ -21,11 +21,12 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/server"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 func TestManager(t *testing.T) {

--- a/internal/security/token.go
+++ b/internal/security/token.go
@@ -16,9 +16,10 @@ package security
 
 import (
 	"context"
+	"strings"
+
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"strings"
 )
 
 type TokenProviders struct {
@@ -49,9 +50,14 @@ func (providers *TokenProviders) Add(providerConfig ProviderConfig) error {
 
 // NewTokenProviders provides a map of token providers, keyed on the
 // name of the token provider struct as lower_case.
-func NewTokenProviders(lc fx.Lifecycle, logger *zap.SugaredLogger, providerManager *ProviderManager, serviceCore *ServiceCore) *TokenProviders {
+func NewTokenProviders(
+	lc fx.Lifecycle,
+	logger *zap.SugaredLogger,
+	providerManager *ProviderManager,
+	serviceCore *ServiceCore,
+) *TokenProviders {
 	log := logger.Named("security")
-	var providers = make(map[string]Provider)
+	providers := make(map[string]Provider)
 
 	tp := &TokenProviders{
 		log:         log,
@@ -61,7 +67,7 @@ func NewTokenProviders(lc fx.Lifecycle, logger *zap.SugaredLogger, providerManag
 	}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			if providerList, err := providerManager.ListProviders(); err != nil {
 				log.Warn(err)
 			} else {

--- a/internal/server/backup.go
+++ b/internal/server/backup.go
@@ -23,10 +23,11 @@ import (
 	"path/filepath"
 
 	"github.com/bamzi/jobrunner"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 const StorageIDFileName = "DATAHUB_BACKUPID"

--- a/internal/server/backup.go
+++ b/internal/server/backup.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const StorageIdFileName = "DATAHUB_BACKUPID"
+const StorageIDFileName = "DATAHUB_BACKUPID"
 
 type BackupManager struct {
 	backupLocation       string
@@ -43,7 +43,6 @@ type BackupManager struct {
 }
 
 func NewBackupManager(lc fx.Lifecycle, store *Store, env *conf.Env) (*BackupManager, error) {
-
 	if env.BackupLocation == "" {
 		return nil, nil
 	}
@@ -65,14 +64,14 @@ func NewBackupManager(lc fx.Lifecycle, store *Store, env *conf.Env) (*BackupMana
 	backup.logger = env.Logger.Named("backup")
 
 	// load last id
-	lastID, err := backup.LoadLastId()
+	lastID, err := backup.LoadLastID()
 	if err != nil {
 		return nil, err
 	}
 	backup.lastID = lastID
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			backup.logger.Info("init backup via hook")
 			schedule, err := cron.ParseStandard(backup.schedule)
 			if err != nil {
@@ -114,14 +113,14 @@ func (backupManager *BackupManager) Run() {
 			}
 		}
 	} else {
-		backupManager.logger.Panicf("invalid backup location. %v out of sync", StorageIdFileName)
+		backupManager.logger.Panicf("invalid backup location. %v out of sync", StorageIDFileName)
 	}
 
 	backupManager.isRunning = false
 }
 
 func (backupManager *BackupManager) DoRsyncBackup() error {
-	err := os.MkdirAll(backupManager.backupLocation, 0700)
+	err := os.MkdirAll(backupManager.backupLocation, 0o700)
 	if err != nil {
 		return err
 	}
@@ -132,7 +131,7 @@ func (backupManager *BackupManager) DoRsyncBackup() error {
 }
 
 func (backupManager *BackupManager) DoNativeBackup() error {
-	err := os.MkdirAll(backupManager.backupLocation, 0700)
+	err := os.MkdirAll(backupManager.backupLocation, 0o700)
 	if err != nil {
 		return err
 	}
@@ -148,10 +147,10 @@ func (backupManager *BackupManager) DoNativeBackup() error {
 	backupManager.lastID = since
 
 	// store last id
-	return backupManager.StoreLastId()
+	return backupManager.StoreLastID()
 }
 
-func (backupManager *BackupManager) StoreLastId() error {
+func (backupManager *BackupManager) StoreLastID() error {
 	lastIDFilename := backupManager.backupLocation + string(os.PathSeparator) + "datahub-backup.lastseen"
 	file, _ := os.Create(lastIDFilename)
 	defer file.Close()
@@ -162,7 +161,7 @@ func (backupManager *BackupManager) StoreLastId() error {
 	return err
 }
 
-func (backupManager *BackupManager) LoadLastId() (uint64, error) {
+func (backupManager *BackupManager) LoadLastID() (uint64, error) {
 	lastIDFilename := backupManager.backupLocation + string(os.PathSeparator) + "datahub-backupManager.lastseen"
 	file, err := os.Open(lastIDFilename)
 	if err != nil {
@@ -172,6 +171,9 @@ func (backupManager *BackupManager) LoadLastId() (uint64, error) {
 
 	data := make([]byte, 8)
 	_, err = file.Read(data)
+	if err != nil {
+		return 0, err
+	}
 	lastID := binary.LittleEndian.Uint64(data)
 	return lastID, nil
 }
@@ -185,45 +187,42 @@ func (backupManager *BackupManager) fileExists(filename string) bool {
 }
 
 func (backupManager *BackupManager) validLocation() bool {
-	dhIdFile := filepath.Join(backupManager.store.storeLocation, StorageIdFileName)
-	b, err := os.ReadFile(dhIdFile)
+	dhIDFile := filepath.Join(backupManager.store.storeLocation, StorageIDFileName)
+	b, err := os.ReadFile(dhIDFile)
 	if err != nil {
 		backupManager.logger.Warnf("could not read DATAHUB_BACKUPID file")
 		return false
 	}
-	dhId := string(b)
-	backedUpDhIdFile := filepath.Join(backupManager.backupLocation, StorageIdFileName)
-	b, err = os.ReadFile(backedUpDhIdFile)
+	dhID := string(b)
+	backedUpDhIDFile := filepath.Join(backupManager.backupLocation, StorageIDFileName)
+	b, err = os.ReadFile(backedUpDhIDFile)
 	if err != nil {
 		backupManager.logger.Infof("could not read DATAHUB_BACKUPID file at backup location. copying now")
-		source, err := os.Open(dhIdFile)
+		source, err := os.Open(dhIDFile)
 		if err != nil {
-			backupManager.logger.Errorf("Could not open backup id file at %v.", dhIdFile)
+			backupManager.logger.Errorf("Could not open backup id file at %v.", dhIDFile)
 			return false
 		}
 		defer source.Close()
 
-		err = os.MkdirAll(backupManager.backupLocation, 0700)
+		err = os.MkdirAll(backupManager.backupLocation, 0o700)
 		if err != nil {
 			backupManager.logger.Errorf("Could create backup dir at %v. (%w)", backupManager.backupLocation, err)
 			return false
 		}
-		destination, err := os.Create(backedUpDhIdFile)
+		destination, err := os.Create(backedUpDhIDFile)
 		if err != nil {
-			backupManager.logger.Errorf("Could not open backed up id file at %v. (%w)", backedUpDhIdFile, err)
+			backupManager.logger.Errorf("Could not open backed up id file at %v. (%w)", backedUpDhIDFile, err)
 			return false
 		}
 		defer destination.Close()
 		_, err = io.Copy(destination, source)
 		if err != nil {
-			backupManager.logger.Errorf("Could not copý %v to %v.", dhIdFile, backedUpDhIdFile)
-			return false
-		}
-		if err != nil {
+			backupManager.logger.Errorf("Could not copý %v to %v.", dhIDFile, backedUpDhIDFile)
 			return false
 		}
 		return true
 	}
-	buDhId := string(b)
-	return dhId == buDhId
+	buDhID := string(b)
+	return dhID == buDhID
 }

--- a/internal/server/backup_test.go
+++ b/internal/server/backup_test.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 func TestBackup(t *testing.T) {

--- a/internal/server/badger_access.go
+++ b/internal/server/badger_access.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"fmt"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/mimiro-io/datahub/internal/service/types"
 )
@@ -41,8 +42,8 @@ func (b BadgerAccess) LookupDatasetName(internalDatasetID types.InternalDatasetI
 	return result, result != ""
 }
 
-func (b BadgerAccess) IsDatasetDeleted(datasetId types.InternalDatasetID) bool {
-	return b.dsm.store.deletedDatasets[uint32(datasetId)]
+func (b BadgerAccess) IsDatasetDeleted(datasetID types.InternalDatasetID) bool {
+	return b.dsm.store.deletedDatasets[uint32(datasetID)]
 }
 
 func (b BadgerAccess) LookupExpansionPrefix(namespaceURI types.URI) (types.Prefix, error) {

--- a/internal/server/badger_access.go
+++ b/internal/server/badger_access.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/dgraph-io/badger/v3"
+
 	"github.com/mimiro-io/datahub/internal/service/types"
 )
 

--- a/internal/server/constants.go
+++ b/internal/server/constants.go
@@ -19,33 +19,33 @@ import "encoding/binary"
 type CollectionIndex uint16
 
 const (
-	URI_TO_ID_INDEX_ID         uint16 = 0
-	ENTITY_ID_TO_JSON_INDEX_ID uint16 = 1
-	INCOMING_REF_INDEX         uint16 = 2
-	OUTGOING_REF_INDEX         uint16 = 3
-	DATASET_ENTITY_CHANGE_LOG  uint16 = 4
-	SYS_DATASETS_ID            uint16 = 5
-	SYS_JOBS_ID                uint16 = 6
-	SYS_DATASETS_SEQUENCES     uint16 = 7
-	DATASET_LATEST_ENTITIES    uint16 = 8
-	ID_TO_URI_INDEX_ID         uint16 = 9
+	URIToIDIndexID         uint16 = 0
+	EntityIDToJSONIndexID  uint16 = 1
+	IncomingRefIndex       uint16 = 2
+	OutgoingRefIndex       uint16 = 3
+	DatasetEntityChangeLog uint16 = 4
+	SysDatasetsID          uint16 = 5
+	SysJobsID              uint16 = 6
+	SysDatasetsSequences   uint16 = 7
+	DatasetLatestEntities  uint16 = 8
+	IDToURIIndexID         uint16 = 9
 
-	STORE_META_INDEX      CollectionIndex = 10
-	NAMESPACES_INDEX      CollectionIndex = 11
-	JOB_RESULT_INDEX      CollectionIndex = 12
-	JOB_DATA_INDEX        CollectionIndex = 13
-	JOB_CONFIGS_INDEX     CollectionIndex = 14
-	CONTENT_INDEX         CollectionIndex = 15
-	STORE_NEXT_DATASET_ID CollectionIndex = 16
-	LOGIN_PROVIDER_INDEX  CollectionIndex = 17
+	StoreMetaIndex     CollectionIndex = 10
+	NamespacesIndex    CollectionIndex = 11
+	JobResultIndex     CollectionIndex = 12
+	JobDataIndex       CollectionIndex = 13
+	JobConfigIndex     CollectionIndex = 14
+	ContentIndex       CollectionIndex = 15
+	StoreNextDatasetID CollectionIndex = 16
+	LoginProviderIndex CollectionIndex = 17
 )
 
 var (
-	JOB_RESULT_INDEX_BYTES      = uint16ToBytes(JOB_RESULT_INDEX)
-	JOB_CONFIGS_INDEX_BYTES     = uint16ToBytes(JOB_CONFIGS_INDEX)
-	CONTENT_INDEX_BYTES         = uint16ToBytes(CONTENT_INDEX)
-	STORE_NEXT_DATASET_ID_BYTES = uint16ToBytes(STORE_NEXT_DATASET_ID)
-	LOGIN_PROVIDER_INDEX_BYTES  = uint16ToBytes(LOGIN_PROVIDER_INDEX)
+	JobResultIndexBytes     = uint16ToBytes(JobResultIndex)
+	JobConfigsIndexBytes    = uint16ToBytes(JobConfigIndex)
+	ContentIndexBytes       = uint16ToBytes(ContentIndex)
+	StoreNextDatasetIDBytes = uint16ToBytes(StoreNextDatasetID)
+	LoginProviderIndexBytes = uint16ToBytes(LoginProviderIndex)
 )
 
 func uint16ToBytes(i CollectionIndex) []byte {

--- a/internal/server/dataset_benchmark_test.go
+++ b/internal/server/dataset_benchmark_test.go
@@ -15,12 +15,13 @@
 package server
 
 import (
-	"github.com/DataDog/datadog-go/v5/statsd"
-	"go.uber.org/zap"
 	"os"
 	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"go.uber.org/zap"
 )
 
 func BenchmarkDatasetStoreEntities(b *testing.B) {
@@ -50,7 +51,7 @@ func BenchmarkDatasetStoreEntities(b *testing.B) {
 			b.Fail()
 		}
 		b.StopTimer()
-		persons = persons[:0] // clear out slice
+		// persons = persons[:0] // clear out slice
 	}
 	ds.store.Close()
 	os.RemoveAll(storeLocation)

--- a/internal/server/dataset_test.go
+++ b/internal/server/dataset_test.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 type testEnv struct {

--- a/internal/server/dataset_test.go
+++ b/internal/server/dataset_test.go
@@ -60,15 +60,15 @@ func TestDataset(t *testing.T) {
 			g.Assert(err).IsNil()
 
 			// namespaces
-			peopleNamespacePrefix, err := s.NamespaceManager.AssertPrefixMappingForExpansion(
+			peopleNamespacePrefix, _ := s.NamespaceManager.AssertPrefixMappingForExpansion(
 				"http://data.mimiro.io/people/",
 			)
-			companyNamespacePrefix, err := s.NamespaceManager.AssertPrefixMappingForExpansion(
+			companyNamespacePrefix, _ := s.NamespaceManager.AssertPrefixMappingForExpansion(
 				"http://data.mimiro.io/company/",
 			)
 
 			// create dataset
-			peopleDataset, err := dsm.CreateDataset("people", nil)
+			peopleDataset, _ := dsm.CreateDataset("people", nil)
 			env = &testEnv{
 				s,
 				peopleNamespacePrefix,
@@ -100,14 +100,14 @@ func TestDataset(t *testing.T) {
 
 			var company2Seen, company1Seen bool
 			for _, r := range result {
-				refEntityId := r[2].(*Entity).ID
+				refEntityID := r[2].(*Entity).ID
 				relation := r[1].(string)
 				if strings.Contains(relation, "worksfor") {
-					g.Assert(refEntityId == "ns4:company-3").IsTrue("worksfor should be company-3")
+					g.Assert(refEntityID == "ns4:company-3").IsTrue("worksfor should be company-3")
 				}
 				if strings.Contains(relation, "workedfor") {
-					company1Seen = company1Seen || strings.Contains(refEntityId, "company-1")
-					company2Seen = company2Seen || strings.Contains(refEntityId, "company-2")
+					company1Seen = company1Seen || strings.Contains(refEntityID, "company-1")
+					company2Seen = company2Seen || strings.Contains(refEntityID, "company-2")
 				}
 			}
 			g.Assert(company1Seen).IsTrue("company-1 was not observed in relations")
@@ -134,15 +134,15 @@ func TestDataset(t *testing.T) {
 			company2Seen = false
 			company1Seen = false
 			for _, r := range result {
-				refEntityId := r[2].(*Entity).ID
+				refEntityID := r[2].(*Entity).ID
 				relation := r[1].(string)
 				if strings.Contains(relation, "worksfor") {
-					g.Assert(refEntityId == "ns4:company-4").IsTrue("worksfor should be company-4")
+					g.Assert(refEntityID == "ns4:company-4").IsTrue("worksfor should be company-4")
 				}
 				if strings.Contains(relation, "workedfor") {
-					company1Seen = company1Seen || strings.Contains(refEntityId, "company-1")
-					company2Seen = company2Seen || strings.Contains(refEntityId, "company-2")
-					company3Seen = company3Seen || strings.Contains(refEntityId, "company-3")
+					company1Seen = company1Seen || strings.Contains(refEntityID, "company-1")
+					company2Seen = company2Seen || strings.Contains(refEntityID, "company-2")
+					company3Seen = company3Seen || strings.Contains(refEntityID, "company-3")
 				}
 			}
 			g.Assert(company1Seen).IsTrue("company-1 was not observed in relations")

--- a/internal/server/dsmanager_test.go
+++ b/internal/server/dsmanager_test.go
@@ -18,17 +18,19 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/mimiro-io/datahub/internal"
 	"math"
 	"os"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/mimiro-io/datahub/internal"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
 
 	"github.com/franela/goblin"
 )
@@ -82,11 +84,11 @@ func TestDatasetManager(t *testing.T) {
 			err = ds.StoreEntities([]*Entity{{ID: "hei"}})
 			g.Assert(err).IsNil()
 
-			details, found, err = dsm.GetDatasetDetails("people")
+			details, _, _ = dsm.GetDatasetDetails("people")
 			g.Assert(details.Properties).Eql(map[string]interface{}{"ns0:items": 0, "ns0:name": "people"},
 				"people dataset was not unchanged")
 
-			details, found, err = dsm.GetDatasetDetails("more.people")
+			details, _, _ = dsm.GetDatasetDetails("more.people")
 			g.Assert(details.Properties).Eql(map[string]interface{}{"ns0:items": 1, "ns0:name": "more.people"})
 		})
 
@@ -107,7 +109,6 @@ func TestDatasetManager(t *testing.T) {
 			g.Assert(len(store.deletedDatasets)).Eql(1, "Deleted datasets should have surviced restart of store")
 			_, ok := store.deletedDatasets[ds.InternalID]
 			g.Assert(ok).IsTrue("our ds should still be deleted")
-
 		})
 
 		g.It("Should assign a new internal id to re-created datasets", func() {
@@ -119,7 +120,8 @@ func TestDatasetManager(t *testing.T) {
 			ds1, _ := dsm.CreateDataset("people", nil)
 			g.Assert(ds1).IsNotZero()
 
-			g.Assert(ds1.InternalID == ds.InternalID).IsFalse("re-creating the same dataset after deletin should result in new internal id")
+			g.Assert(ds1.InternalID == ds.InternalID).
+				IsFalse("re-creating the same dataset after deletin should result in new internal id")
 			g.Assert(ds1.ID).Eql(ds.ID, "the re-created dataset's ID should be equal to previously deleted ID")
 		})
 
@@ -138,7 +140,6 @@ func TestDatasetManager(t *testing.T) {
 			ds2, _ := dsm.CreateDataset("animals", nil)
 			g.Assert(ds2).IsNotZero()
 			g.Assert(ds2.InternalID).Eql(uint32(3))
-
 		})
 
 		g.It("Should store and overwrite and restore datasets at same pace", func() {
@@ -156,12 +157,12 @@ func TestDatasetManager(t *testing.T) {
 			//  - third iteration after a dataset delete + dataset create, no GC
 			// all three write processes should be in the same performance range
 			for deletes := 0; deletes < 3; deletes++ {
-				//t.Log("restored dataset times: ", deletes)
+				// t.Log("restored dataset times: ", deletes)
 				var times []time.Duration
 				for rewrites := 0; rewrites < 2; rewrites++ {
 					prefix := "http://data.mimiro.io/people/p1-"
 					idcounter := uint64(0)
-					//write 5 batches
+					// write 5 batches
 					for j := 0; j < iterationSize; j++ {
 						entities := make([]*Entity, batchSize)
 						// of 10000 entities each
@@ -187,8 +188,8 @@ func TestDatasetManager(t *testing.T) {
 						ts := time.Now()
 						totalcnt += len(entities)
 						_ = ds.StoreEntities(entities)
-						//t.Log("StoreEntities of batch took ", time.Now().Sub(ts))
-						times = append(times, time.Now().Sub(ts))
+						// t.Log("StoreEntities of batch took ", time.Now().Sub(ts))
+						times = append(times, time.Since(ts))
 					}
 				}
 				totalDur := time.Duration(0)
@@ -223,7 +224,7 @@ func TestDatasetManager(t *testing.T) {
 			g.It("should replace entry in system collection", func() {
 				_, _ = dsm.CreateDataset("people0", nil)
 				prefix := make([]byte, 2)
-				binary.BigEndian.PutUint16(prefix, SYS_DATASETS_ID)
+				binary.BigEndian.PutUint16(prefix, SysDatasetsID)
 				storedDatasets := map[string]*Dataset{}
 				dsm.store.iterateObjects(prefix, reflect.TypeOf(Dataset{}), func(i interface{}) error {
 					ds := i.(*Dataset)
@@ -251,7 +252,6 @@ func TestDatasetManager(t *testing.T) {
 				g.Assert(storedDatasets["people1"].SubjectIdentifier).Eql("http://data.mimiro.io/datasets/people1")
 			})
 			g.It("should replace entry in cached dataset list", func() {
-
 				_, _ = dsm.CreateDataset("people0", nil)
 				g.Assert(len(dsm.GetDatasetNames())).Eql(2)
 				seen := false

--- a/internal/server/dsmanager_test.go
+++ b/internal/server/dsmanager_test.go
@@ -24,15 +24,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mimiro-io/datahub/internal"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/franela/goblin"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
+	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
-
-	"github.com/franela/goblin"
 )
 
 func TestDatasetManager(t *testing.T) {

--- a/internal/server/entity.go
+++ b/internal/server/entity.go
@@ -96,7 +96,7 @@ func (e *Entity) ExpandIdentifiers(store *Store) error {
 
 // GetName returns a human readable Name
 func (e *Entity) GetName() string {
-	name := e.GetStringProperty(RdfsLabelUri)
+	name := e.GetStringProperty(RdfsLabelURI)
 
 	if name == "" {
 		index := strings.LastIndex(e.ID, "/")
@@ -133,9 +133,9 @@ func (e *Entity) GetStringProperty(propName string) string {
 // GetProperty returns the value of the named property as an interface
 func (e *Entity) GetProperty(propName string) interface{} {
 	prop := e.Properties[propName]
-	switch prop.(type) {
+	switch p := prop.(type) {
 	case map[string]interface{}:
-		return NewEntityFromMap(prop.(map[string]interface{}))
+		return NewEntityFromMap(p)
 	default:
 		return prop
 	}

--- a/internal/server/error.go
+++ b/internal/server/error.go
@@ -40,16 +40,16 @@ func (e *StorageError) Error() string {
 var (
 	AttemptStoreEntitiesErr = func(detail error) error { return fmt.Errorf("failed when attempting to store entities: %w", detail) }
 	SinceParseErr           = func(detail error) error { return fmt.Errorf("since should be an integer number: %w", detail) }
-	HttpBodyMissingErr      = func(detail error) error { return fmt.Errorf("body is missing or could not read: %w", detail) }
-	HttpJobParsingErr       = func(detail error) error { return fmt.Errorf("failed at parsing the job definition: %w", detail) }
-	HttpJobSchedulingErr    = func(detail error) error { return fmt.Errorf("failed at scheduling the job definition: %w", detail) }
-	HttpJsonParsingErr      = func(detail error) error { return fmt.Errorf("failed parsing the json body: %w", detail) }
-	HttpContentStoreErr     = func(detail error) error { return fmt.Errorf("failed updating the content: %w", detail) }
-	HttpQueryParamErr       = func(detail error) error {
+	HTTPBodyMissingErr      = func(detail error) error { return fmt.Errorf("body is missing or could not read: %w", detail) }
+	HTTPJobParsingErr       = func(detail error) error { return fmt.Errorf("failed at parsing the job definition: %w", detail) }
+	HTTPJobSchedulingErr    = func(detail error) error { return fmt.Errorf("failed at scheduling the job definition: %w", detail) }
+	HTTPJsonParsingErr      = func(detail error) error { return fmt.Errorf("failed parsing the json body: %w", detail) }
+	HTTPContentStoreErr     = func(detail error) error { return fmt.Errorf("failed updating the content: %w", detail) }
+	HTTPQueryParamErr       = func(detail error) error {
 		return fmt.Errorf("one or more of the query parameters failed its validation: %w", detail)
 	}
-	HttpGenericErr  = func(detail error) error { return fmt.Errorf("internal failure: %w", detail) }
-	HttpFullsyncErr = func(detail error) error {
+	HTTPGenericErr  = func(detail error) error { return fmt.Errorf("internal failure: %w", detail) }
+	HTTPFullsyncErr = func(detail error) error {
 		return fmt.Errorf("an error occured trying to start or update a full sync: %w", detail)
 	}
 )

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -43,8 +43,7 @@ type MEventBus struct {
 	logger *zap.SugaredLogger
 }
 
-type NoOp struct {
-}
+type NoOp struct{}
 
 func NewBus(env *conf.Env) (EventBus, error) {
 	// configure id generator (it doesn't have to be monoton)

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -22,11 +22,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mustafaturan/bus"
 	"github.com/mustafaturan/monoton"
 	"github.com/mustafaturan/monoton/sequencer"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 type EventBus interface {

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -28,14 +28,15 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"github.com/labstack/echo/v4"
+	"github.com/mustafaturan/bus"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/jobs"
 	"github.com/mimiro-io/datahub/internal/server"
 	"github.com/mimiro-io/datahub/internal/web"
-	"github.com/mustafaturan/bus"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 func TestEvents(t *testing.T) {

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -25,24 +25,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mimiro-io/datahub/internal"
-
-	"github.com/labstack/echo/v4"
-
-	"github.com/mimiro-io/datahub/internal/web"
-
-	"github.com/mimiro-io/datahub/internal/server"
-
-	"github.com/mimiro-io/datahub/internal/jobs"
-
-	"github.com/mustafaturan/bus"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/franela/goblin"
+	"github.com/labstack/echo/v4"
+	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/jobs"
+	"github.com/mimiro-io/datahub/internal/server"
+	"github.com/mimiro-io/datahub/internal/web"
+	"github.com/mustafaturan/bus"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-
-	"github.com/franela/goblin"
 )
 
 func TestEvents(t *testing.T) {

--- a/internal/server/garbagecollector.go
+++ b/internal/server/garbagecollector.go
@@ -21,9 +21,10 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v3"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 type GarbageCollector struct {

--- a/internal/server/garbagecollector.go
+++ b/internal/server/garbagecollector.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"time"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"time"
 )
 
 type GarbageCollector struct {
@@ -39,7 +40,7 @@ func NewGarbageCollector(lc fx.Lifecycle, store *Store, env *conf.Env) *GarbageC
 	}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			if env.GcOnStartup {
 				gc.logger.Info("Starting inital GC in background")
 				go func() {
@@ -67,7 +68,7 @@ func NewGarbageCollector(lc fx.Lifecycle, store *Store, env *conf.Env) *GarbageC
 			}
 			return nil
 		},
-		OnStop: func(ctx context.Context) error {
+		OnStop: func(_ context.Context) error {
 			go func() { gc.quit <- true }()
 			return nil
 		},
@@ -97,12 +98,11 @@ func (garbageCollector *GarbageCollector) Cleandeleted() error {
 	binary.BigEndian.PutUint16(entityIdBuffer[22:], uint16(jsonLength))
 	*/
 	index := make([]byte, 2)
-	binary.BigEndian.PutUint16(index, ENTITY_ID_TO_JSON_INDEX_ID)
+	binary.BigEndian.PutUint16(index, EntityIDToJSONIndexID)
 	err := garbageCollector.deleteByPrefixAndSelectorFunction(index, func(key []byte) bool {
 		dsInternalID := binary.BigEndian.Uint32(key[10:])
 		return garbageCollector.store.deletedDatasets[dsInternalID]
 	})
-
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (garbageCollector *GarbageCollector) Cleandeleted() error {
 			binary.BigEndian.PutUint64(entityIdChangeTimeBuffer[14:], rid)
 		*/
 		index = make([]byte, 6)
-		binary.BigEndian.PutUint16(index, DATASET_ENTITY_CHANGE_LOG)
+		binary.BigEndian.PutUint16(index, DatasetEntityChangeLog)
 		binary.BigEndian.PutUint32(index[2:], deletedDsID)
 		err = garbageCollector.deleteByPrefixAndSelectorFunction(index, func(key []byte) bool {
 			return true
@@ -133,7 +133,7 @@ func (garbageCollector *GarbageCollector) Cleandeleted() error {
 		binary.BigEndian.PutUint32(datasetEntitiesLatestVersionKey[2:], ds.InternalID)
 		binary.BigEndian.PutUint64(datasetEntitiesLatestVersionKey[6:], rid) */
 		index = make([]byte, 6)
-		binary.BigEndian.PutUint16(index, DATASET_LATEST_ENTITIES)
+		binary.BigEndian.PutUint16(index, DatasetLatestEntities)
 		binary.BigEndian.PutUint32(index[2:], deletedDsID)
 		err = garbageCollector.deleteByPrefixAndSelectorFunction(index, func(key []byte) bool {
 			return true
@@ -155,7 +155,7 @@ func (garbageCollector *GarbageCollector) Cleandeleted() error {
 		binary.BigEndian.PutUint32(outgoingBuffer[36:], ds.InternalID)
 	*/
 	index = make([]byte, 2)
-	binary.BigEndian.PutUint16(index, OUTGOING_REF_INDEX)
+	binary.BigEndian.PutUint16(index, OutgoingRefIndex)
 	err = garbageCollector.deleteByPrefixAndSelectorFunction(index, func(key []byte) bool {
 		dsInternalID := binary.BigEndian.Uint32(key[36:])
 		return garbageCollector.store.deletedDatasets[dsInternalID]
@@ -176,7 +176,7 @@ func (garbageCollector *GarbageCollector) Cleandeleted() error {
 		binary.BigEndian.PutUint32(incomingBuffer[36:], ds.InternalID)
 	*/
 	index = make([]byte, 2)
-	binary.BigEndian.PutUint16(index, INCOMING_REF_INDEX)
+	binary.BigEndian.PutUint16(index, IncomingRefIndex)
 	err = garbageCollector.deleteByPrefixAndSelectorFunction(index, func(key []byte) bool {
 		dsInternalID := binary.BigEndian.Uint32(key[36:])
 		return garbageCollector.store.deletedDatasets[dsInternalID]
@@ -189,7 +189,10 @@ func (garbageCollector *GarbageCollector) Cleandeleted() error {
 	return nil
 }
 
-func (garbageCollector *GarbageCollector) deleteByPrefixAndSelectorFunction(prefix []byte, selector func(key []byte) bool) error {
+func (garbageCollector *GarbageCollector) deleteByPrefixAndSelectorFunction(
+	prefix []byte,
+	selector func(key []byte) bool,
+) error {
 	deleteKeys := func(keysForDelete [][]byte) error {
 		return garbageCollector.store.database.Update(func(txn *badger.Txn) error {
 			for _, key := range keysForDelete {

--- a/internal/server/garbagecollector_test.go
+++ b/internal/server/garbagecollector_test.go
@@ -22,10 +22,11 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 func TestGC(t *testing.T) {

--- a/internal/server/garbagecollector_test.go
+++ b/internal/server/garbagecollector_test.go
@@ -17,14 +17,15 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func TestGC(t *testing.T) {
@@ -108,7 +109,9 @@ func TestGC(t *testing.T) {
 
 		g.It("Should delete the correct incoming and outgoing references", func() {
 			b := store.database
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/people/")
+			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+				"http://data.mimiro.io/people/",
+			)
 			workPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/work/")
 			g.Assert(count(b)).Eql(16)
 
@@ -122,23 +125,39 @@ func TestGC(t *testing.T) {
 				NewEntityFromMap(map[string]interface{}{
 					"id":    peopleNamespacePrefix + ":person-1",
 					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"}}),
+					"refs": map[string]interface{}{
+						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
+					},
+				}),
 				NewEntityFromMap(map[string]interface{}{
 					"id":    peopleNamespacePrefix + ":person-2",
 					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Bob"},
-					"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1"}}),
+					"refs": map[string]interface{}{
+						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
+					},
+				}),
 			})
 			g.Assert(count(b)).Eql(55)
 
 			// check that we can query outgoing
-			result, err := store.GetManyRelatedEntities([]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", false, nil)
+			result, err := store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"},
+				peopleNamespacePrefix+":Friend",
+				false,
+				nil,
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(result)).Eql(1)
 			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
 			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
 
 			// check that we can query incoming
-			result, err = store.GetManyRelatedEntities([]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", true, nil)
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"},
+				peopleNamespacePrefix+":Friend",
+				true,
+				nil,
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(result)).Eql(1)
 			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
@@ -148,22 +167,34 @@ func TestGC(t *testing.T) {
 				NewEntityFromMap(map[string]interface{}{
 					"id":    peopleNamespacePrefix + ":person-1",
 					"props": map[string]interface{}{workPrefix + ":Wage": "110"},
-					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-2"}}),
+					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-2"},
+				}),
 				NewEntityFromMap(map[string]interface{}{
 					"id":    peopleNamespacePrefix + ":person-2",
 					"props": map[string]interface{}{workPrefix + ":Wage": "100"},
-					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-3"}}),
+					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-3"},
+				}),
 			})
 			g.Assert(count(b)).Eql(72)
 
 			// check that we can still query outgoing
-			result, err = store.GetManyRelatedEntities([]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", false, nil)
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"},
+				peopleNamespacePrefix+":Friend",
+				false,
+				nil,
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(result)).Eql(1, "Expected still to find person-3 as a friend")
 			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
 
 			// and incoming
-			result, err = store.GetManyRelatedEntities([]string{"http://data.mimiro.io/people/person-1"}, peopleNamespacePrefix+":Friend", true, nil)
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"},
+				peopleNamespacePrefix+":Friend",
+				true,
+				nil,
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(result)).Eql(1, "Expected still to find person-2 as reverse friend")
 			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
@@ -176,13 +207,23 @@ func TestGC(t *testing.T) {
 			g.Assert(count(b)).Eql(66, "two entities with 5 keys each should be removed now")
 
 			// make sure we still can query
-			result, err = store.GetManyRelatedEntities([]string{"http://data.mimiro.io/people/person-1"}, "*", false, nil)
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-1"},
+				"*",
+				false,
+				nil,
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(result)).Eql(1)
 			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
 			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
 
-			result, err = store.GetManyRelatedEntities([]string{"http://data.mimiro.io/people/person-2"}, "*", false, nil)
+			result, err = store.GetManyRelatedEntities(
+				[]string{"http://data.mimiro.io/people/person-2"},
+				"*",
+				false,
+				nil,
+			)
 			g.Assert(err).IsNil()
 			g.Assert(len(result)).Eql(1)
 			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")

--- a/internal/server/get_related_test.go
+++ b/internal/server/get_related_test.go
@@ -3,12 +3,13 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"

--- a/internal/server/get_related_test.go
+++ b/internal/server/get_related_test.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
-
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
 )
 
 func TestGetRelated(test *testing.T) {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -32,10 +32,9 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/dgraph-io/badger/v3"
+	"github.com/mimiro-io/datahub/internal/conf"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-
-	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 type qresult struct {

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -24,18 +24,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mimiro-io/datahub/internal"
-
-	"github.com/dgraph-io/badger/v3"
-
-	"github.com/franela/goblin"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/dgraph-io/badger/v3"
+	"github.com/franela/goblin"
 	"go.uber.org/fx/fxtest"
-
-	"github.com/mimiro-io/datahub/internal/conf"
-
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 func TestStoreRelations(test *testing.T) {

--- a/internal/server/streamparser_test.go
+++ b/internal/server/streamparser_test.go
@@ -17,10 +17,11 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/mimiro-io/datahub/internal"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/mimiro-io/datahub/internal"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/zap"
@@ -96,7 +97,6 @@ func TestStreamParser(t *testing.T) {
 
 			people := txn.DatasetEntities["people"]
 			g.Assert(people).IsNotNil("people dataset updates missing")
-
 		})
 
 		g.It("Should process transaction with dataset with empty array of entities", func() {

--- a/internal/server/streamparser_test.go
+++ b/internal/server/streamparser_test.go
@@ -21,15 +21,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mimiro-io/datahub/internal"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
-	"github.com/franela/goblin"
-
+	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
-	"go.uber.org/fx/fxtest"
 )
 
 func TestJsonOmitOnEntity(m *testing.T) {

--- a/internal/server/uriconstants.go
+++ b/internal/server/uriconstants.go
@@ -14,10 +14,12 @@
 
 package server
 
-const RdfNamespaceExpansion = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+const (
+	RdfNamespaceExpansion = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 
-// rdf and rdfs core uris
-const RdfTypeUri string = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+	// rdf and rdfs core uris
+	RdfTypeURI string = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 
-const RdfsClassUri string = "http://www.w3.org/2000/01/rdf-schema#Class"
-const RdfsLabelUri string = "http://www.w3.org/2000/01/rdf-schema#label"
+	RdfsClassURI string = "http://www.w3.org/2000/01/rdf-schema#Class"
+	RdfsLabelURI string = "http://www.w3.org/2000/01/rdf-schema#label"
+)

--- a/internal/service/dataset/iterator.go
+++ b/internal/service/dataset/iterator.go
@@ -19,11 +19,10 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/mimiro-io/datahub/internal/service/types"
-
 	"github.com/dgraph-io/badger/v3"
 
 	"github.com/mimiro-io/datahub/internal/service/store"
+	"github.com/mimiro-io/datahub/internal/service/types"
 )
 
 type IterableDataset interface {

--- a/internal/service/dataset/iterator.go
+++ b/internal/service/dataset/iterator.go
@@ -17,8 +17,9 @@ package dataset
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/mimiro-io/datahub/internal/service/types"
 	"io"
+
+	"github.com/mimiro-io/datahub/internal/service/types"
 
 	"github.com/dgraph-io/badger/v3"
 

--- a/internal/service/dataset/iterator_benchmark_test.go
+++ b/internal/service/dataset/iterator_benchmark_test.go
@@ -21,12 +21,13 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/server"
 	ds "github.com/mimiro-io/datahub/internal/service/dataset"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 func BenchmarkChangesIterator(b *testing.B) {

--- a/internal/service/dataset/iterator_benchmark_test.go
+++ b/internal/service/dataset/iterator_benchmark_test.go
@@ -16,6 +16,10 @@ package dataset_test
 
 import (
 	"context"
+	"os"
+	"strconv"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
@@ -23,9 +27,6 @@ import (
 	ds "github.com/mimiro-io/datahub/internal/service/dataset"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
-	"strconv"
-	"testing"
 )
 
 func BenchmarkChangesIterator(b *testing.B) {
@@ -37,16 +38,17 @@ func BenchmarkChangesIterator(b *testing.B) {
 	b.ResetTimer()
 	for no := 0; no < b.N; no++ {
 		c := 0
-		//b.Log("run")
+		// b.Log("run")
 		it, _ := ds.At(0)
 		for it.Next() {
 			c += len(it.Item())
 		}
 		it.Close()
-		//b.Log(c)
-		//b.Logf("found %v", raw)
+		// b.Log(c)
+		// b.Logf("found %v", raw)
 	}
 }
+
 func BenchmarkGetChanges(b *testing.B) {
 	storeLocation := "./test_store_iterator_bench_1"
 	dataset, _, _, after := setup(storeLocation, b)
@@ -54,7 +56,7 @@ func BenchmarkGetChanges(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for no := 0; no < b.N; no++ {
-		//b.Log("run")
+		// b.Log("run")
 		c := 0
 		_, err := dataset.ProcessChangesRaw(0, 10000, false, func(jsonData []byte) error {
 			c += len(jsonData)
@@ -63,8 +65,8 @@ func BenchmarkGetChanges(b *testing.B) {
 		if err != nil {
 			panic(err)
 		}
-		//b.Logf("found %v", raw)
-		//b.Log(c)
+		// b.Logf("found %v", raw)
+		// b.Log(c)
 	}
 }
 

--- a/internal/service/dataset/iterator_test.go
+++ b/internal/service/dataset/iterator_test.go
@@ -17,6 +17,9 @@ package dataset_test
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"testing"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
 	"github.com/mimiro-io/datahub/internal"
@@ -26,8 +29,6 @@ import (
 	"github.com/mimiro-io/datahub/internal/service/types"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func TestDatasetIterator(t *testing.T) {
@@ -76,7 +77,6 @@ func TestDatasetIterator(t *testing.T) {
 		g.After(func() {
 			lc.Stop(context.Background())
 			os.RemoveAll(storeLocation)
-
 		})
 		g.It("should be able to create a 0 offset", func() {
 			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
@@ -131,8 +131,8 @@ func TestDatasetIterator(t *testing.T) {
 			for it.Next() {
 				jsonData := it.Item()
 				e := server.Entity{}
-				err := json.Unmarshal(jsonData, &e)
-				g.Assert(err).IsNil()
+				err2 := json.Unmarshal(jsonData, &e)
+				g.Assert(err2).IsNil()
 				foundIds = append(foundIds, e.ID)
 				continuationToken = it.NextOffset()
 				if len(foundIds) == 2 {
@@ -145,6 +145,7 @@ func TestDatasetIterator(t *testing.T) {
 			g.Assert(continuationToken).Equal(types.DatasetOffset(2))
 
 			it, err = dataset.At(continuationToken)
+			g.Assert(err).IsNil()
 			foundIds = []string{}
 			for it.Next() {
 				jsonData := it.Item()
@@ -213,8 +214,8 @@ func TestDatasetIterator(t *testing.T) {
 			for it.Next() {
 				jsonData := it.Item()
 				e := server.Entity{}
-				err := json.Unmarshal(jsonData, &e)
-				g.Assert(err).IsNil()
+				err2 := json.Unmarshal(jsonData, &e)
+				g.Assert(err2).IsNil()
 				foundIds = append(foundIds, e.ID)
 				continuationToken = it.NextOffset()
 				if len(foundIds) == 2 {
@@ -227,6 +228,7 @@ func TestDatasetIterator(t *testing.T) {
 			g.Assert(continuationToken).Equal(types.DatasetOffset(2))
 
 			it, err = dataset.At(continuationToken)
+			g.Assert(err).IsNil()
 			it = it.Inverse()
 			foundIds = []string{}
 			for it.Next() {
@@ -242,6 +244,5 @@ func TestDatasetIterator(t *testing.T) {
 			g.Assert(foundIds).Equal([]string{"II", "I"})
 			g.Assert(continuationToken).Equal(types.DatasetOffset(0))
 		})
-
 	})
 }

--- a/internal/service/dataset/iterator_test.go
+++ b/internal/service/dataset/iterator_test.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/franela/goblin"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/server"
 	ds "github.com/mimiro-io/datahub/internal/service/dataset"
 	"github.com/mimiro-io/datahub/internal/service/types"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
 )
 
 func TestDatasetIterator(t *testing.T) {

--- a/internal/service/entity/details.go
+++ b/internal/service/entity/details.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/mimiro-io/datahub/internal/service/namespace"
 	"github.com/mimiro-io/datahub/internal/service/store"
@@ -48,23 +49,27 @@ func (l Lookup) Details(id string, datasetNames []string) (map[string]interface{
 
 	rtxn := b.NewTransaction(false)
 	defer rtxn.Discard()
-	internalId, err := l.internalIdForCURIE(rtxn, curie)
+	internalID, err := l.internalIDForCURIE(rtxn, curie)
 	if err != nil {
 		return nil, err
 	}
 
 	scope := l.badger.LookupDatasetIDs(datasetNames)
-	details, err := l.loadDetails(rtxn, internalId, scope)
+	details, err := l.loadDetails(rtxn, internalID, scope)
 	if err != nil {
 		return nil, err
 	}
 	return details, nil
 }
 
-func (l Lookup) loadDetails(rtxn *badger.Txn, internalEntityId types.InternalID, scope []types.InternalDatasetID) (map[string]interface{}, error) {
+func (l Lookup) loadDetails(
+	rtxn *badger.Txn,
+	internalEntityID types.InternalID,
+	scope []types.InternalDatasetID,
+) (map[string]interface{}, error) {
 	result := map[string]interface{}{}
 
-	entityLocatorPrefixBuffer := store.SeekEntity(internalEntityId)
+	entityLocatorPrefixBuffer := store.SeekEntity(internalEntityID)
 	opts1 := badger.DefaultIteratorOptions
 	opts1.PrefetchValues = false
 	opts1.Prefix = entityLocatorPrefixBuffer
@@ -72,21 +77,21 @@ func (l Lookup) loadDetails(rtxn *badger.Txn, internalEntityId types.InternalID,
 	defer entityLocatorIterator.Close()
 
 	var prevValueBytes []byte
-	var previousDatasetId types.InternalDatasetID = 0
-	var currentDatasetId types.InternalDatasetID = 0
+	var previousDatasetID types.InternalDatasetID = 0
+	var currentDatasetID types.InternalDatasetID = 0
 	partials := map[types.InternalDatasetID][]byte{}
 	for entityLocatorIterator.Seek(entityLocatorPrefixBuffer); entityLocatorIterator.ValidForPrefix(entityLocatorPrefixBuffer); entityLocatorIterator.Next() {
 		item := entityLocatorIterator.Item()
 		key := item.Key()
 
-		currentDatasetId = types.InternalDatasetID(binary.BigEndian.Uint32(key[10:]))
+		currentDatasetID = types.InternalDatasetID(binary.BigEndian.Uint32(key[10:]))
 
 		// check if dataset has been deleted, or must be excluded
-		datasetDeleted := l.badger.IsDatasetDeleted(currentDatasetId)
+		datasetDeleted := l.badger.IsDatasetDeleted(currentDatasetID)
 		datasetIncluded := len(scope) == 0 // no specified datasets means no restriction - all datasets are allowed
 		if !datasetIncluded {
 			for _, id := range scope {
-				if id == currentDatasetId {
+				if id == currentDatasetID {
 					datasetIncluded = true
 					break
 				}
@@ -96,38 +101,41 @@ func (l Lookup) loadDetails(rtxn *badger.Txn, internalEntityId types.InternalID,
 			continue
 		}
 
-		if previousDatasetId != 0 {
-			if currentDatasetId != previousDatasetId {
-				partials[previousDatasetId] = prevValueBytes
+		if previousDatasetID != 0 {
+			if currentDatasetID != previousDatasetID {
+				partials[previousDatasetID] = prevValueBytes
 			}
 		}
 
-		previousDatasetId = currentDatasetId
+		previousDatasetID = currentDatasetID
 
 		// fixme: pre alloc big ish buffer once and use value size
 		prevValueBytes, _ = item.ValueCopy(nil)
 	}
 
-	if previousDatasetId != 0 {
-		partials[previousDatasetId] = prevValueBytes
+	if previousDatasetID != 0 {
+		partials[previousDatasetID] = prevValueBytes
 	}
 
-	for internalDatasetId, entityBytes := range partials {
-		n, ok := l.badger.LookupDatasetName(internalDatasetId)
+	for internalDatasetID, entityBytes := range partials {
+		n, ok := l.badger.LookupDatasetName(internalDatasetID)
 		if !ok {
-			result[fmt.Sprintf("%v", internalDatasetId)] = "UNEXPECTED: dataset name not found"
+			result[fmt.Sprintf("%v", internalDatasetID)] = "UNEXPECTED: dataset name not found"
 		} else {
 			result[n] = map[string]interface{}{
 				"latest":  string(entityBytes),
-				"changes": l.loadChanges(rtxn, internalEntityId, internalDatasetId),
+				"changes": l.loadChanges(rtxn, internalEntityID, internalDatasetID),
 			}
 		}
 	}
 	return result, nil
-
 }
 
-func (l Lookup) loadChanges(rtxn *badger.Txn, internalEntityID types.InternalID, internalDatasetID types.InternalDatasetID) []string {
+func (l Lookup) loadChanges(
+	rtxn *badger.Txn,
+	internalEntityID types.InternalID,
+	internalDatasetID types.InternalDatasetID,
+) []string {
 	seekPrefix := store.SeekEntityChanges(internalDatasetID, internalEntityID)
 	iteratorOptions := badger.DefaultIteratorOptions
 	iteratorOptions.PrefetchValues = true

--- a/internal/service/entity/details.go
+++ b/internal/service/entity/details.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/dgraph-io/badger/v3"
+
 	"github.com/mimiro-io/datahub/internal/service/namespace"
 	"github.com/mimiro-io/datahub/internal/service/store"
 	"github.com/mimiro-io/datahub/internal/service/types"

--- a/internal/service/entity/ids.go
+++ b/internal/service/entity/ids.go
@@ -3,15 +3,15 @@ package entity
 import (
 	"encoding/binary"
 	"fmt"
+	"strings"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/mimiro-io/datahub/internal/service/store"
 	"github.com/mimiro-io/datahub/internal/service/types"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 func (l Lookup) asCURIE(id string) (types.CURIE, error) {
-
 	if prefix, ok := l.namespaces.ExtractPrefix(id); ok && !strings.HasPrefix(id, "http") {
 		if _, err := l.namespaces.ExpandPrefix(prefix); err == nil {
 			return types.CURIE(id), nil
@@ -19,8 +19,8 @@ func (l Lookup) asCURIE(id string) (types.CURIE, error) {
 			return "", err
 		}
 	}
-	if nsUri, localValue, ok := l.namespaces.ExtractNamespaceURI(id); ok {
-		if prefix, err := l.namespaces.GetNamespacePrefix(nsUri); err == nil {
+	if nsURI, localValue, ok := l.namespaces.ExtractNamespaceURI(id); ok {
+		if prefix, err := l.namespaces.GetNamespacePrefix(nsURI); err == nil {
 			return types.CURIE(fmt.Sprintf("%v:%v", prefix, localValue)), nil
 		} else {
 			return "", err
@@ -29,7 +29,7 @@ func (l Lookup) asCURIE(id string) (types.CURIE, error) {
 	return "", fmt.Errorf("input %v is neither in CURIE format (prefix:value) nor a URI", id)
 }
 
-func (l Lookup) internalIdForCURIE(txn *badger.Txn, curie types.CURIE) (types.InternalID, error) {
+func (l Lookup) internalIDForCURIE(txn *badger.Txn, curie types.CURIE) (types.InternalID, error) {
 	var rid uint64
 
 	// check if it exists already uri => id
@@ -41,7 +41,6 @@ func (l Lookup) internalIdForCURIE(txn *badger.Txn, curie types.CURIE) (types.In
 			rid = binary.BigEndian.Uint64(val)
 			return nil
 		})
-
 		if err != nil {
 			return 0, errors.WithMessagef(err, "could not process found interalId for curie: %v", curie)
 		}

--- a/internal/service/entity/ids.go
+++ b/internal/service/entity/ids.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/dgraph-io/badger/v3"
+	"github.com/pkg/errors"
+
 	"github.com/mimiro-io/datahub/internal/service/store"
 	"github.com/mimiro-io/datahub/internal/service/types"
-	"github.com/pkg/errors"
 )
 
 func (l Lookup) asCURIE(id string) (types.CURIE, error) {

--- a/internal/service/entity/ids_test.go
+++ b/internal/service/entity/ids_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/franela/goblin"
+
 	"github.com/mimiro-io/datahub/internal/service/namespace"
 	"github.com/mimiro-io/datahub/internal/service/types"
 )

--- a/internal/service/entity/ids_test.go
+++ b/internal/service/entity/ids_test.go
@@ -12,7 +12,7 @@ import (
 type nsMock struct{}
 
 func (n nsMock) LookupNamespaceExpansion(prefix types.Prefix) (types.URI, error) {
-	if "foo" == prefix {
+	if prefix == "foo" {
 		return "http://foo", nil
 	}
 	return "", errors.New("unknown prefix")

--- a/internal/service/namespace/manager.go
+++ b/internal/service/namespace/manager.go
@@ -1,9 +1,10 @@
 package namespace
 
 import (
+	"strings"
+
 	"github.com/mimiro-io/datahub/internal/service/store"
 	"github.com/mimiro-io/datahub/internal/service/types"
-	"strings"
 )
 
 type (

--- a/internal/service/namespace/manager.go
+++ b/internal/service/namespace/manager.go
@@ -38,12 +38,13 @@ func (m BadgerManager) ExpandPrefix(input types.Prefix) (types.URI, error) {
 	return m.store.LookupNamespaceExpansion(input)
 }
 
-//ExtractNamespaceURI split given URI into namespace and value
-//  returns (
-//    namespaceURI with trailing slash,
-//    value (last path element),
-//    success flag
-//   )
+// ExtractNamespaceURI split given URI into namespace and value
+//
+//	returns (
+//	  namespaceURI with trailing slash,
+//	  value (last path element),
+//	  success flag
+//	 )
 func (m BadgerManager) ExtractNamespaceURI(input string) (types.URI, string, bool) {
 	if strings.HasPrefix(input, "http") {
 		cutPosition := strings.LastIndex(input, "/") + 1

--- a/internal/service/store/badger.go
+++ b/internal/service/store/badger.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"github.com/dgraph-io/badger/v3"
+
 	"github.com/mimiro-io/datahub/internal/service/types"
 )
 

--- a/internal/service/store/badger.go
+++ b/internal/service/store/badger.go
@@ -32,6 +32,6 @@ type BadgerStore interface {
 	LookupDatasetName(internalDatasetID types.InternalDatasetID) (string, bool)
 
 	// need access ot in-memory mapping
-	IsDatasetDeleted(datasetId types.InternalDatasetID) bool
+	IsDatasetDeleted(datasetID types.InternalDatasetID) bool
 	LegacyNamespaceAccess
 }

--- a/internal/service/store/idx_keys.go
+++ b/internal/service/store/idx_keys.go
@@ -24,7 +24,7 @@ import (
 
 func SeekChanges(datasetID types.InternalDatasetID, since types.DatasetOffset) []byte {
 	searchBuffer := make([]byte, 14)
-	binary.BigEndian.PutUint16(searchBuffer, server.DATASET_ENTITY_CHANGE_LOG)
+	binary.BigEndian.PutUint16(searchBuffer, server.DatasetEntityChangeLog)
 	binary.BigEndian.PutUint32(searchBuffer[2:], uint32(datasetID))
 	binary.BigEndian.PutUint64(searchBuffer[6:], uint64(since))
 	return searchBuffer
@@ -32,7 +32,7 @@ func SeekChanges(datasetID types.InternalDatasetID, since types.DatasetOffset) [
 
 func SeekEntityChanges(datasetID types.InternalDatasetID, entityID types.InternalID) []byte {
 	entityIDBuffer := make([]byte, 14)
-	binary.BigEndian.PutUint16(entityIDBuffer, server.ENTITY_ID_TO_JSON_INDEX_ID)
+	binary.BigEndian.PutUint16(entityIDBuffer, server.EntityIDToJSONIndexID)
 	binary.BigEndian.PutUint64(entityIDBuffer[2:], uint64(entityID))
 	binary.BigEndian.PutUint32(entityIDBuffer[10:], uint32(datasetID))
 	return entityIDBuffer
@@ -40,14 +40,14 @@ func SeekEntityChanges(datasetID types.InternalDatasetID, entityID types.Interna
 
 func SeekDataset(datasetID types.InternalDatasetID) []byte {
 	searchBuffer := make([]byte, 6)
-	binary.BigEndian.PutUint16(searchBuffer, server.DATASET_ENTITY_CHANGE_LOG)
+	binary.BigEndian.PutUint16(searchBuffer, server.DatasetEntityChangeLog)
 	binary.BigEndian.PutUint32(searchBuffer[2:], uint32(datasetID))
 	return searchBuffer
 }
 
 func SeekEntity(intenalEntityID types.InternalID) []byte {
 	entityLocatorPrefixBuffer := make([]byte, 10)
-	binary.BigEndian.PutUint16(entityLocatorPrefixBuffer, server.ENTITY_ID_TO_JSON_INDEX_ID)
+	binary.BigEndian.PutUint16(entityLocatorPrefixBuffer, server.EntityIDToJSONIndexID)
 	binary.BigEndian.PutUint64(entityLocatorPrefixBuffer[2:], uint64(intenalEntityID))
 	return entityLocatorPrefixBuffer
 }
@@ -55,7 +55,7 @@ func SeekEntity(intenalEntityID types.InternalID) []byte {
 func GetCurieKey(curie types.CURIE) []byte {
 	curieAsBytes := []byte(curie)
 	buf := make([]byte, len(curieAsBytes)+2)
-	binary.BigEndian.PutUint16(buf, server.URI_TO_ID_INDEX_ID)
+	binary.BigEndian.PutUint16(buf, server.URIToIDIndexID)
 	copy(buf[2:], curieAsBytes)
 	return buf
 }

--- a/internal/service/store/idx_keys.go
+++ b/internal/service/store/idx_keys.go
@@ -17,9 +17,8 @@ package store
 import (
 	"encoding/binary"
 
-	"github.com/mimiro-io/datahub/internal/service/types"
-
 	"github.com/mimiro-io/datahub/internal/server"
+	"github.com/mimiro-io/datahub/internal/service/types"
 )
 
 func SeekChanges(datasetID types.InternalDatasetID, since types.DatasetOffset) []byte {

--- a/internal/service/types/types.go
+++ b/internal/service/types/types.go
@@ -1,13 +1,12 @@
 package types
 
-type URI string
-type CURIE string
+type (
+	URI               string
+	CURIE             string
+	Prefix            string
+	InternalID        uint64
+	InternalDatasetID uint32
+	DatasetOffset     uint64
+)
 
-type Prefix string
-
-type InternalID uint64
-type InternalDatasetID uint32
-
-type DatasetOffset uint64
-
-//type PointInTime uint64
+// type PointInTime uint64

--- a/internal/testutil.go
+++ b/internal/testutil.go
@@ -34,6 +34,7 @@ func (l *FxLogger) Logf(f string, a ...interface{}) {
 		l.t.Logf(f, a...)
 	}
 }
+
 func FxTestLog(t testing.TB, active bool) *FxLogger {
 	return &FxLogger{t: t, active: active}
 }

--- a/internal/web/contenthandler.go
+++ b/internal/web/contenthandler.go
@@ -21,10 +21,11 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/content"
-	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/content"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 type contentHandler struct {

--- a/internal/web/contenthandler.go
+++ b/internal/web/contenthandler.go
@@ -31,14 +31,20 @@ type contentHandler struct {
 	content *content.Config
 }
 
-func NewContentHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger, mw *Middleware, content *content.Config) {
+func NewContentHandler(
+	lc fx.Lifecycle,
+	e *echo.Echo,
+	logger *zap.SugaredLogger,
+	mw *Middleware,
+	content *content.Config,
+) {
 	log := logger.Named("web")
 	handler := &contentHandler{
 		content: content,
 	}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			// datas
 			e.GET("/content", handler.contentList, mw.authorizer(log, datahubRead))
 			e.POST("/content", handler.contentAdd, mw.authorizer(log, datahubWrite))
@@ -73,7 +79,7 @@ func (handler *contentHandler) contentAdd(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
 	}
 
-	err = handler.content.AddContent(content.Id, content)
+	err = handler.content.AddContent(content.ID, content)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
 	}
@@ -82,8 +88,8 @@ func (handler *contentHandler) contentAdd(c echo.Context) error {
 }
 
 func (handler *contentHandler) contentShow(c echo.Context) error {
-	contentId := c.Param("contentId")
-	res, err := handler.content.GetContentById(contentId)
+	contentID := c.Param("contentId")
+	res, err := handler.content.GetContentByID(contentID)
 	if err != nil {
 		return c.NoContent(http.StatusNotFound)
 	}
@@ -99,14 +105,14 @@ func (handler *contentHandler) contentUpdate(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
 	}
-	contentId := c.Param("contentId")
+	contentID := c.Param("contentId")
 	payload := &content.Content{}
 	err = json.Unmarshal(body, payload)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
 	}
 
-	err = handler.content.UpdateContent(contentId, payload)
+	err = handler.content.UpdateContent(contentID, payload)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
 	}
@@ -115,13 +121,13 @@ func (handler *contentHandler) contentUpdate(c echo.Context) error {
 }
 
 func (handler *contentHandler) contentDelete(c echo.Context) error {
-	contentId := c.Param("contentId")
-	_, err := handler.content.GetContentById(contentId)
+	contentID := c.Param("contentId")
+	_, err := handler.content.GetContentByID(contentID)
 	if err != nil {
 		return c.NoContent(http.StatusNotFound)
 	}
 
-	err = handler.content.DeleteContent(contentId)
+	err = handler.content.DeleteContent(contentID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
 	}

--- a/internal/web/contenthandler.go
+++ b/internal/web/contenthandler.go
@@ -60,7 +60,7 @@ func NewContentHandler(
 func (handler *contentHandler) contentList(c echo.Context) error {
 	res, err := handler.content.ListContents()
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, server.HTTPGenericErr(err).Error())
 	}
 
 	return c.JSON(http.StatusOK, res)
@@ -70,18 +70,18 @@ func (handler *contentHandler) contentAdd(c echo.Context) error {
 	// read json
 	body, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPBodyMissingErr(err).Error())
 	}
 
 	content := &content.Content{}
 	err = json.Unmarshal(body, content)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPJsonParsingErr(err).Error())
 	}
 
 	err = handler.content.AddContent(content.ID, content)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPContentStoreErr(err).Error())
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -103,18 +103,18 @@ func (handler *contentHandler) contentShow(c echo.Context) error {
 func (handler *contentHandler) contentUpdate(c echo.Context) error {
 	body, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPBodyMissingErr(err).Error())
 	}
 	contentID := c.Param("contentId")
 	payload := &content.Content{}
 	err = json.Unmarshal(body, payload)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPJsonParsingErr(err).Error())
 	}
 
 	err = handler.content.UpdateContent(contentID, payload)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPContentStoreErr(err).Error())
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -129,7 +129,7 @@ func (handler *contentHandler) contentDelete(c echo.Context) error {
 
 	err = handler.content.DeleteContent(contentID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpContentStoreErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPContentStoreErr(err).Error())
 	}
 
 	return c.NoContent(http.StatusOK)

--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -27,16 +27,14 @@ import (
 	"strings"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/mimiro-io/datahub/internal/security"
-	"github.com/mimiro-io/datahub/internal/service/types"
-
+	"github.com/labstack/echo/v4"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
-	"github.com/labstack/echo/v4"
-
+	"github.com/mimiro-io/datahub/internal/security"
 	"github.com/mimiro-io/datahub/internal/server"
 	ds "github.com/mimiro-io/datahub/internal/service/dataset"
+	"github.com/mimiro-io/datahub/internal/service/types"
 )
 
 type datasetHandler struct {

--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -156,7 +156,7 @@ func (handler *datasetHandler) datasetCreate(c echo.Context) error {
 	}
 	if isProxy == "true" {
 		if createDatasetConfig.ProxyDatasetConfig == nil ||
-			createDatasetConfig.ProxyDatasetConfig.RemoteUrl == "" {
+			createDatasetConfig.ProxyDatasetConfig.RemoteURL == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "invalid proxy configuration provided")
 		}
 		_, err = handler.datasetManager.CreateDataset(datasetName, createDatasetConfig)
@@ -253,7 +253,7 @@ func (handler *datasetHandler) getEntitiesHandler(c echo.Context) error {
 	if limit != "" {
 		f, err2 := strconv.ParseInt(limit, 10, 64)
 		if err2 != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, server.HttpQueryParamErr(err2).Error())
+			return echo.NewHTTPError(http.StatusBadRequest, server.HTTPQueryParamErr(err2).Error())
 		}
 		l = int(f)
 	}
@@ -359,7 +359,7 @@ func (handler *datasetHandler) getChangesHandler(c echo.Context) error {
 	if limit != "" {
 		f, err := strconv.ParseInt(limit, 10, 64)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, server.HttpQueryParamErr(err).Error())
+			return echo.NewHTTPError(http.StatusBadRequest, server.HTTPQueryParamErr(err).Error())
 		}
 		l = int(f)
 	}
@@ -488,12 +488,12 @@ func (handler *datasetHandler) processEntities(
 	if fullSyncStart {
 		err2 := dataset.StartFullSyncWithLease(fullSyncID)
 		if err2 != nil {
-			return echo.NewHTTPError(http.StatusConflict, server.HttpFullsyncErr(err2).Error())
+			return echo.NewHTTPError(http.StatusConflict, server.HTTPFullsyncErr(err2).Error())
 		}
 	} else if dataset.FullSyncStarted() {
 		err = dataset.RefreshFullSyncLease(fullSyncID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusConflict, server.HttpFullsyncErr(err).Error())
+			return echo.NewHTTPError(http.StatusConflict, server.HTTPFullsyncErr(err).Error())
 		}
 	}
 
@@ -529,10 +529,10 @@ func (handler *datasetHandler) processEntities(
 
 	if fullSyncEnd {
 		if err := dataset.ReleaseFullSyncLease(fullSyncID); err != nil {
-			return echo.NewHTTPError(http.StatusGone, server.HttpGenericErr(err).Error())
+			return echo.NewHTTPError(http.StatusGone, server.HTTPGenericErr(err).Error())
 		}
 		if err := dataset.CompleteFullSync(); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, server.HttpGenericErr(err).Error())
+			return echo.NewHTTPError(http.StatusInternalServerError, server.HTTPGenericErr(err).Error())
 		}
 	}
 	// we have to emit the dataset, so that subscribers can react to the event

--- a/internal/web/joboperationhandler.go
+++ b/internal/web/joboperationhandler.go
@@ -19,9 +19,10 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/jobs"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/jobs"
 )
 
 type jobOperationHandler struct {

--- a/internal/web/joboperationhandler.go
+++ b/internal/web/joboperationhandler.go
@@ -28,14 +28,20 @@ type jobOperationHandler struct {
 	jobScheduler *jobs.Scheduler
 }
 
-func NewJobOperationHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger, mw *Middleware, js *jobs.Scheduler) {
+func NewJobOperationHandler(
+	lc fx.Lifecycle,
+	e *echo.Echo,
+	logger *zap.SugaredLogger,
+	mw *Middleware,
+	js *jobs.Scheduler,
+) {
 	log := logger.Named("web")
 	handler := &jobOperationHandler{
 		jobScheduler: js,
 	}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			e.PUT("/job/:jobid/pause", handler.jobsPause, mw.authorizer(log, datahubWrite))
 			e.PUT("/job/:jobid/resume", handler.jobsUnpause, mw.authorizer(log, datahubWrite))
 			e.PUT("/job/:jobid/kill", handler.jobsKill, mw.authorizer(log, datahubWrite))
@@ -49,61 +55,61 @@ func NewJobOperationHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLo
 }
 
 func (handler *jobOperationHandler) jobsPause(c echo.Context) error {
-	jobId := c.Param("jobid")
-	err := handler.jobScheduler.PauseJob(jobId)
+	jobID := c.Param("jobid")
+	err := handler.jobScheduler.PauseJob(jobID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, "could not pause job")
 	}
-	return c.JSON(http.StatusOK, &JobResponse{JobId: jobId})
+	return c.JSON(http.StatusOK, &JobResponse{JobID: jobID})
 }
 
 func (handler *jobOperationHandler) jobsKill(c echo.Context) error {
-	jobId := c.Param("jobid")
-	handler.jobScheduler.KillJob(jobId)
-	return c.JSON(http.StatusOK, &JobResponse{JobId: jobId})
+	jobID := c.Param("jobid")
+	handler.jobScheduler.KillJob(jobID)
+	return c.JSON(http.StatusOK, &JobResponse{JobID: jobID})
 }
 
 func (handler *jobOperationHandler) jobsUnpause(c echo.Context) error {
-	jobId := c.Param("jobid")
-	err := handler.jobScheduler.UnpauseJob(jobId)
+	jobID := c.Param("jobid")
+	err := handler.jobScheduler.UnpauseJob(jobID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, "could not un-pause job")
 	}
-	return c.JSON(http.StatusOK, &JobResponse{JobId: jobId})
+	return c.JSON(http.StatusOK, &JobResponse{JobID: jobID})
 }
 
 func (handler *jobOperationHandler) jobsRun(c echo.Context) error {
-	jobId := c.Param("jobid")
+	jobID := c.Param("jobid")
 	jobType := c.QueryParam("jobType")
 	if len(jobType) == 0 {
 		jobType = jobs.JobTypeIncremental
 	}
-	tempId, err := handler.jobScheduler.RunJob(jobId, jobType)
+	tempID, err := handler.jobScheduler.RunJob(jobID, jobType)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, "could not un-pause job")
 	}
-	if tempId == "" {
+	if tempID == "" {
 		return c.NoContent(http.StatusNotFound)
 	}
 
-	return c.JSON(http.StatusOK, &JobResponse{JobId: tempId})
+	return c.JSON(http.StatusOK, &JobResponse{JobID: tempID})
 }
 
 func (handler *jobOperationHandler) jobsReset(c echo.Context) error {
-	jobId := c.Param("jobid")
+	jobID := c.Param("jobid")
 	since := c.QueryParam("since")
 
-	err := handler.jobScheduler.ResetJob(jobId, since)
+	err := handler.jobScheduler.ResetJob(jobID, since)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, "internal error")
 	}
-	return c.JSON(http.StatusOK, &JobResponse{JobId: jobId})
+	return c.JSON(http.StatusOK, &JobResponse{JobID: jobID})
 }
 
 func (handler *jobOperationHandler) jobsGetStatus(c echo.Context) error {
-	jobId := c.Param("jobid")
+	jobID := c.Param("jobid")
 
-	status := handler.jobScheduler.GetRunningJob(jobId)
+	status := handler.jobScheduler.GetRunningJob(jobID)
 	if status == nil {
 		return c.JSON(http.StatusOK, []*jobs.JobStatus{})
 	}

--- a/internal/web/jobshandler.go
+++ b/internal/web/jobshandler.go
@@ -76,12 +76,12 @@ func (handler *jobsHandler) jobsAdd(c echo.Context) error {
 	// read json
 	body, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPBodyMissingErr(err).Error())
 	}
 
 	config, err := handler.jobScheduler.Parse(body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJobParsingErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPJobParsingErr(err).Error())
 	}
 
 	err = handler.jobScheduler.AddJob(config)

--- a/internal/web/jobshandler.go
+++ b/internal/web/jobshandler.go
@@ -21,10 +21,11 @@ import (
 	"net/url"
 
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/jobs"
-	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/jobs"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 // This is used to give the web handler a type, instead of just a map

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -16,8 +16,9 @@ package web
 
 import (
 	"context"
-	"github.com/mimiro-io/datahub/internal/security"
 	"strings"
+
+	"github.com/mimiro-io/datahub/internal/security"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -37,7 +38,14 @@ type Middleware struct {
 	env        *conf.Env
 }
 
-func NewMiddleware(lc fx.Lifecycle, env *conf.Env, handler *WebHandler, e *echo.Echo, auth *AuthorizerConfig, core *security.ServiceCore) *Middleware {
+func NewMiddleware(
+	lc fx.Lifecycle,
+	env *conf.Env,
+	handler *WebHandler,
+	e *echo.Echo,
+	auth *AuthorizerConfig,
+	core *security.ServiceCore,
+) *Middleware {
 	skipper := func(c echo.Context) bool {
 		// don't secure health endpoints
 		if strings.HasPrefix(c.Request().URL.Path, "/health") {
@@ -72,7 +80,7 @@ func NewMiddleware(lc fx.Lifecycle, env *conf.Env, handler *WebHandler, e *echo.
 	}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			mw.configure(e)
 			return nil
 		},
@@ -128,13 +136,14 @@ func setupJWT(env *conf.Env, core *security.ServiceCore, skipper func(c echo.Con
 		Skipper:   skipper,
 		Audience:  env.Auth.Audience,
 		Issuer:    env.Auth.Issuer,
-		Wellknown: env.Auth.WellKnown}
+		Wellknown: env.Auth.WellKnown,
+	}
 
 	// if node security is enabled
 	if env.Auth.Middleware == "local" {
 		config.NodePublicKey = core.NodeInfo.KeyPairs[0].PublicKey
-		config.Issuer = []string{"node:" + core.NodeInfo.NodeId}
-		config.Audience = []string{"node:" + core.NodeInfo.NodeId}
+		config.Issuer = []string{"node:" + core.NodeInfo.NodeID}
+		config.Audience = []string{"node:" + core.NodeInfo.NodeID}
 	}
 
 	return middlewares.JWTHandler(config)

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -18,14 +18,14 @@ import (
 	"context"
 	"strings"
 
-	"github.com/mimiro-io/datahub/internal/security"
-
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/mimiro-io/datahub/internal/conf"
-	"github.com/mimiro-io/datahub/internal/web/middlewares"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/security"
+	"github.com/mimiro-io/datahub/internal/web/middlewares"
 )
 
 type Middleware struct {

--- a/internal/web/middlewares/authentication.go
+++ b/internal/web/middlewares/authentication.go
@@ -24,6 +24,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+
 	"github.com/mimiro-io/datahub/internal/security"
 )
 

--- a/internal/web/middlewares/authentication.go
+++ b/internal/web/middlewares/authentication.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"crypto/rsa"
 	"errors"
+	"net/http"
+
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/mimiro-io/datahub/internal/security"
-	"net/http"
 )
 
 type (
@@ -145,7 +146,6 @@ func (config *JwtConfig) ValidateToken(auth string) (*jwt.Token, error) {
 			}
 		}
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/web/middlewares/authorization.go
+++ b/internal/web/middlewares/authorization.go
@@ -18,12 +18,12 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mimiro-io/datahub/internal/security"
-
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/juliangruber/go-intersect"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/security"
 )
 
 func JwtAuthorizer(logger *zap.SugaredLogger, scopes ...string) echo.MiddlewareFunc {

--- a/internal/web/middlewares/authorization.go
+++ b/internal/web/middlewares/authorization.go
@@ -15,9 +15,10 @@
 package middlewares
 
 import (
-	"github.com/mimiro-io/datahub/internal/security"
 	"net/http"
 	"strings"
+
+	"github.com/mimiro-io/datahub/internal/security"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/juliangruber/go-intersect"
@@ -26,7 +27,6 @@ import (
 )
 
 func JwtAuthorizer(logger *zap.SugaredLogger, scopes ...string) echo.MiddlewareFunc {
-
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			if c.Get("user") == nil { // user never got set, oops
@@ -36,7 +36,7 @@ func JwtAuthorizer(logger *zap.SugaredLogger, scopes ...string) echo.MiddlewareF
 
 			claims := token.Claims.(*security.CustomClaims)
 			if claims.Gty == "client-credentials" ||
-				claims.Subject == claims.ClientId { // this is a machine or an application token
+				claims.Subject == claims.ClientID { // this is a machine or an application token
 				var claimScopes []string
 				if len(claims.Scopes()) > 0 {
 					claimScopes = strings.Split(claims.Scopes()[0], " ")
@@ -57,7 +57,7 @@ func JwtAuthorizer(logger *zap.SugaredLogger, scopes ...string) echo.MiddlewareF
 					subject := claims.Subject
 					// it needs the subject in the url
 					uri := c.Request().RequestURI
-					if strings.Index(uri, subject) == -1 { // not present, so forbidden
+					if !strings.Contains(uri, subject) { // not present, so forbidden
 						return echo.NewHTTPError(http.StatusForbidden, "user has no access to path")
 					}
 				}

--- a/internal/web/middlewares/loggerfilter.go
+++ b/internal/web/middlewares/loggerfilter.go
@@ -38,7 +38,6 @@ type LoggerConfig struct {
 }
 
 func LoggerFilter(config LoggerConfig) echo.MiddlewareFunc {
-
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			if config.Skipper(c) {
@@ -63,7 +62,13 @@ func LoggerFilter(config LoggerConfig) echo.MiddlewareFunc {
 			timed := time.Since(start)
 
 			err := config.StatsdClient.Incr("http.count", tags, 1)
+			if err != nil {
+				config.Logger.Warn("Error with statsd", zap.String("error", fmt.Sprintf("%s", err)))
+			}
 			err = config.StatsdClient.Timing("http.time", timed, tags, 1)
+			if err != nil {
+				config.Logger.Warn("Error with statsd", zap.String("error", fmt.Sprintf("%s", err)))
+			}
 			err = config.StatsdClient.Gauge("http.size", float64(res.Size), tags, 1)
 			if err != nil {
 				config.Logger.Warn("Error with statsd", zap.String("error", fmt.Sprintf("%s", err)))

--- a/internal/web/middlewares/opa.go
+++ b/internal/web/middlewares/opa.go
@@ -45,12 +45,11 @@ type opaDatasets struct {
 	Result []string `json:"result"`
 }
 
-func OpaAuthorizer(logger *zap.SugaredLogger, scopes ...string) echo.MiddlewareFunc {
+func OpaAuthorizer(_ *zap.SugaredLogger, scopes ...string) echo.MiddlewareFunc {
 	opaEndpoint := viper.GetString("OPA_ENDPOINT")
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-
 			token := c.Get("user").(*jwt.Token)
 
 			input := opaRequest{
@@ -83,6 +82,9 @@ func OpaAuthorizer(logger *zap.SugaredLogger, scopes ...string) echo.MiddlewareF
 			}
 			resp := opaDatasets{}
 			err = json.Unmarshal(body, &resp)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusForbidden, err.Error())
+			}
 			datasets := pluckDatasets(resp)
 			c.Set("datasets", datasets)
 
@@ -129,10 +131,7 @@ func pluckDatasets(resp opaDatasets) []string {
 	datasets := make([]string, 0)
 
 	if len(resp.Result) > 0 {
-		for _, item := range resp.Result {
-			datasets = append(datasets, item)
-		}
+		datasets = append(datasets, resp.Result...)
 	}
 	return datasets
-
 }

--- a/internal/web/middlewares/recover.go
+++ b/internal/web/middlewares/recover.go
@@ -23,16 +23,14 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	// DefaultRecoverConfig is the default Recover middleware config.
-	DefaultRecoverConfig = middleware.RecoverConfig{
-		Skipper:           middleware.DefaultSkipper,
-		StackSize:         4 << 10, // 4 KB
-		DisableStackAll:   false,
-		DisablePrintStack: false,
-		LogLevel:          0,
-	}
-)
+// DefaultRecoverConfig is the default Recover middleware config.
+var DefaultRecoverConfig = middleware.RecoverConfig{
+	Skipper:           middleware.DefaultSkipper,
+	StackSize:         4 << 10, // 4 KB
+	DisableStackAll:   false,
+	DisablePrintStack: false,
+	LogLevel:          0,
+}
 
 func RecoverWithConfig(config middleware.RecoverConfig, logger *zap.SugaredLogger) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/internal/web/namespacehandler.go
+++ b/internal/web/namespacehandler.go
@@ -19,9 +19,10 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 type namespaceHandler struct {

--- a/internal/web/namespacehandler.go
+++ b/internal/web/namespacehandler.go
@@ -28,11 +28,17 @@ type namespaceHandler struct {
 	store *server.Store
 }
 
-func NewNamespaceHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger, mw *Middleware, store *server.Store) {
+func NewNamespaceHandler(
+	lc fx.Lifecycle,
+	e *echo.Echo,
+	logger *zap.SugaredLogger,
+	mw *Middleware,
+	store *server.Store,
+) {
 	handler := namespaceHandler{store: store}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			e.GET("/namespaces", handler.getNamespaces, mw.authorizer(logger.Named("web"), datahubRead))
 			return nil
 		},
@@ -43,5 +49,4 @@ func (handler *namespaceHandler) getNamespaces(c echo.Context) error {
 	v := handler.store.GetGlobalContext()
 
 	return c.JSON(http.StatusOK, v.Namespaces)
-
 }

--- a/internal/web/providerhandler.go
+++ b/internal/web/providerhandler.go
@@ -20,10 +20,11 @@ import (
 	"net/url"
 
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/security"
-	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/security"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 type providerHandler struct {

--- a/internal/web/providerhandler.go
+++ b/internal/web/providerhandler.go
@@ -58,11 +58,11 @@ func NewProviderHandler(
 func (handler *providerHandler) loginCreate(c echo.Context) error {
 	var provider security.ProviderConfig
 	if err := c.Bind(&provider); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPGenericErr(err).Error())
 	}
 
 	if err := handler.tokenProviders.Add(provider); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, server.HTTPGenericErr(err).Error())
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -71,15 +71,15 @@ func (handler *providerHandler) loginCreate(c echo.Context) error {
 func (handler *providerHandler) loginUpdate(c echo.Context) error {
 	providerName, err := url.QueryUnescape(c.Param("providerName"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPGenericErr(err).Error())
 	}
 	var provider security.ProviderConfig
 	if err := c.Bind(&provider); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPGenericErr(err).Error())
 	}
 
 	if err := handler.tokenProviders.UpdateProvider(providerName, provider); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, server.HTTPGenericErr(err).Error())
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -87,7 +87,7 @@ func (handler *providerHandler) loginUpdate(c echo.Context) error {
 
 func (handler *providerHandler) loginList(c echo.Context) error {
 	if providers, err := handler.tokenProviders.ListProviders(); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, server.HTTPGenericErr(err).Error())
 	} else {
 		return c.JSON(http.StatusOK, providers)
 	}
@@ -96,7 +96,7 @@ func (handler *providerHandler) loginList(c echo.Context) error {
 func (handler *providerHandler) loginGet(c echo.Context) error {
 	providerName, err := url.QueryUnescape(c.Param("providerName"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPGenericErr(err).Error())
 	}
 	if provider, err := handler.tokenProviders.GetProviderConfig(providerName); err != nil {
 		return c.NoContent(http.StatusNotFound)
@@ -108,7 +108,7 @@ func (handler *providerHandler) loginGet(c echo.Context) error {
 func (handler *providerHandler) loginDelete(c echo.Context) error {
 	providerName, err := url.QueryUnescape(c.Param("providerName"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpGenericErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPGenericErr(err).Error())
 	}
 	if err := handler.tokenProviders.DeleteProvider(providerName); err != nil {
 		return c.NoContent(http.StatusNotFound)

--- a/internal/web/providerhandler.go
+++ b/internal/web/providerhandler.go
@@ -16,13 +16,14 @@ package web
 
 import (
 	"context"
+	"net/http"
+	"net/url"
+
 	"github.com/labstack/echo/v4"
 	"github.com/mimiro-io/datahub/internal/security"
 	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"net/http"
-	"net/url"
 )
 
 type providerHandler struct {
@@ -30,14 +31,20 @@ type providerHandler struct {
 	tokenProviders *security.TokenProviders
 }
 
-func NewProviderHandler(lc fx.Lifecycle, e *echo.Echo, log *zap.SugaredLogger, mw *Middleware, tokenProviders *security.TokenProviders) {
+func NewProviderHandler(
+	lc fx.Lifecycle,
+	e *echo.Echo,
+	log *zap.SugaredLogger,
+	mw *Middleware,
+	tokenProviders *security.TokenProviders,
+) {
 	handler := &providerHandler{
 		log:            log.Named("web"),
 		tokenProviders: tokenProviders,
 	}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			e.POST("/provider/logins", handler.loginCreate, mw.authorizer(log, datahubWrite))
 			e.GET("/provider/logins", handler.loginList, mw.authorizer(log, datahubRead))
 			e.POST("/provider/login/:providerName", handler.loginUpdate, mw.authorizer(log, datahubWrite))

--- a/internal/web/queryhandler.go
+++ b/internal/web/queryhandler.go
@@ -154,13 +154,13 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 		body, err := io.ReadAll(c.Request().Body)
 		if err != nil {
 			handler.logger.Warn("Unable to read body")
-			return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
+			return echo.NewHTTPError(http.StatusBadRequest, server.HTTPBodyMissingErr(err).Error())
 		}
 		err = json.Unmarshal(body, &query)
 
 		if err != nil {
 			handler.logger.Warn("Unable to parse json")
-			return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
+			return echo.NewHTTPError(http.StatusBadRequest, server.HTTPJsonParsingErr(err).Error())
 		}
 
 		jsQuery, err := jobs.NewJavascriptTransform(handler.logger, query.Query, handler.store, handler.datasetManager)
@@ -190,12 +190,12 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		handler.logger.Warn("Unable to read body")
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpBodyMissingErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPBodyMissingErr(err).Error())
 	}
 	err = json.Unmarshal(body, &query)
 	if err != nil {
 		handler.logger.Warn("Unable to parse json")
-		return echo.NewHTTPError(http.StatusBadRequest, server.HttpJsonParsingErr(err).Error())
+		return echo.NewHTTPError(http.StatusBadRequest, server.HTTPJsonParsingErr(err).Error())
 	}
 	includeContinuation := true
 	// conservative default

--- a/internal/web/securityhandler.go
+++ b/internal/web/securityhandler.go
@@ -22,9 +22,10 @@ import (
 	"net/url"
 
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/security"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/security"
 )
 
 func NewSecurityHandler(

--- a/internal/web/securityhandler.go
+++ b/internal/web/securityhandler.go
@@ -17,31 +17,50 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
 	"github.com/labstack/echo/v4"
 	"github.com/mimiro-io/datahub/internal/security"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 )
 
-func NewSecurityHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger, mw *Middleware, core *security.ServiceCore) {
+func NewSecurityHandler(
+	lc fx.Lifecycle,
+	e *echo.Echo,
+	logger *zap.SugaredLogger,
+	mw *Middleware,
+	core *security.ServiceCore,
+) {
 	log := logger.Named("web")
 	handler := &SecurityHandler{}
 	handler.serviceCore = core
 	handler.logger = log
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			// query
 			e.POST("/security/token", handler.tokenRequestHandler)
 			e.POST("/security/clients", handler.clientRegistrationRequestHandler, mw.authorizer(log, datahubWrite))
 			e.GET("/security/clients", handler.getClientsRequestHandler, mw.authorizer(log, datahubWrite))
 
-			e.POST("/security/clients/:clientid/acl", handler.setClientAccessControlsRequestHandler, mw.authorizer(log, datahubWrite))
-			e.GET("/security/clients/:clientid/acl", handler.getClientAccessControlsRequestHandler, mw.authorizer(log, datahubWrite))
-			e.DELETE("/security/clients/:clientid/acl", handler.deleteClientAccessControlsRequestHandler, mw.authorizer(log, datahubWrite))
+			e.POST(
+				"/security/clients/:clientid/acl",
+				handler.setClientAccessControlsRequestHandler,
+				mw.authorizer(log, datahubWrite),
+			)
+			e.GET(
+				"/security/clients/:clientid/acl",
+				handler.getClientAccessControlsRequestHandler,
+				mw.authorizer(log, datahubWrite),
+			)
+			e.DELETE(
+				"/security/clients/:clientid/acl",
+				handler.deleteClientAccessControlsRequestHandler,
+				mw.authorizer(log, datahubWrite),
+			)
 
 			/* jwtMiddleware := MakeJWTMiddleware(core.GetActiveKeyPair().PublicKey, "node:" + core.NodeInfo.NodeId, "node:" + core.NodeInfo.NodeId)
 
@@ -73,16 +92,12 @@ func (handler *SecurityHandler) getClientsRequestHandler(c echo.Context) error {
 // oidc - oauth2 compliant token request handler
 func (handler *SecurityHandler) tokenRequestHandler(c echo.Context) error {
 	// url form encoded params
-	var grantType string
-	// var audience string
-
-	grantType = c.FormValue("grant_type")
+	grantType := c.FormValue("grant_type")
 	clientAssertionType := c.FormValue("client_assertion_type")
 
 	if grantType == "client_credentials" && clientAssertionType == "urn:ietf:params:oauth:grant-type:jwt-bearer" {
 		assertion := c.FormValue("client_assertion")
 		token, err := handler.serviceCore.ValidateClientJWTMakeJWTAccessToken(assertion)
-
 		if err != nil {
 			return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
 		}
@@ -92,10 +107,10 @@ func (handler *SecurityHandler) tokenRequestHandler(c echo.Context) error {
 		return c.JSON(http.StatusOK, response)
 
 	} else if grantType == "client_credentials" {
-		clientId := c.FormValue("client_id")
+		clientID := c.FormValue("client_id")
 		clientSecret := c.FormValue("client_secret")
 
-		token, err := handler.serviceCore.MakeAdminJWT(clientId, clientSecret)
+		token, err := handler.serviceCore.MakeAdminJWT(clientID, clientSecret)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
 		}
@@ -125,19 +140,19 @@ func (handler *SecurityHandler) clientRegistrationRequestHandler(c echo.Context)
 }
 
 func (handler *SecurityHandler) getClientAccessControlsRequestHandler(c echo.Context) error {
-	clientId, err := url.QueryUnescape(c.Param("clientid"))
+	clientID, err := url.QueryUnescape(c.Param("clientid"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "missing client id")
 	}
-	return c.JSON(http.StatusOK, handler.serviceCore.GetAccessControls(clientId))
+	return c.JSON(http.StatusOK, handler.serviceCore.GetAccessControls(clientID))
 }
 
 func (handler *SecurityHandler) deleteClientAccessControlsRequestHandler(c echo.Context) error {
-	clientId, err := url.QueryUnescape(c.Param("clientid"))
+	clientID, err := url.QueryUnescape(c.Param("clientid"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "missing client id")
 	}
-	handler.serviceCore.DeleteClientAccessControls(clientId)
+	handler.serviceCore.DeleteClientAccessControls(clientID)
 	return c.NoContent(http.StatusOK)
 }
 
@@ -147,7 +162,7 @@ func (handler *SecurityHandler) setClientAccessControlsRequestHandler(c echo.Con
 		return echo.NewHTTPError(http.StatusBadRequest, "missing body")
 	}
 
-	clientId, err := url.QueryUnescape(c.Param("clientid"))
+	clientID, err := url.QueryUnescape(c.Param("clientid"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "missing client id")
 	}
@@ -157,8 +172,7 @@ func (handler *SecurityHandler) setClientAccessControlsRequestHandler(c echo.Con
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "missing body")
 	}
-	handler.serviceCore.SetClientAccessControls(clientId, acls)
+	handler.serviceCore.SetClientAccessControls(clientID, acls)
 
 	return c.NoContent(http.StatusOK)
-
 }

--- a/internal/web/txnhandler.go
+++ b/internal/web/txnhandler.go
@@ -16,11 +16,12 @@ package web
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"net/http"
 )
 
 func NewTxnHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger, mw *Middleware, store *server.Store) {
@@ -31,7 +32,7 @@ func NewTxnHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger, mw 
 	}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			e.POST("/transactions", handler.processTransaction, mw.authorizer(log, datahubWrite))
 			return nil
 		},

--- a/internal/web/txnhandler.go
+++ b/internal/web/txnhandler.go
@@ -19,9 +19,10 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 func NewTxnHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger, mw *Middleware, store *server.Store) {

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -16,10 +16,11 @@ package web
 
 import (
 	"context"
-	"github.com/DataDog/datadog-go/v5/statsd"
 	"html/template"
 	"io"
 	"net/http"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/labstack/echo/v4"
 	"github.com/mimiro-io/datahub/internal/conf"
@@ -70,7 +71,12 @@ func (t *Template) Render(w io.Writer, name string, data interface{}, c echo.Con
 	return t.templates.ExecuteTemplate(w, name, data)
 }
 
-func NewWebServer(lc fx.Lifecycle, env *conf.Env, logger *zap.SugaredLogger, statsd statsd.ClientInterface) (*WebHandler, *echo.Echo) {
+func NewWebServer(
+	lc fx.Lifecycle,
+	env *conf.Env,
+	logger *zap.SugaredLogger,
+	statsd statsd.ClientInterface,
+) (*WebHandler, *echo.Echo) {
 	e := echo.New()
 	e.HideBanner = true
 
@@ -84,7 +90,7 @@ func NewWebServer(lc fx.Lifecycle, env *conf.Env, logger *zap.SugaredLogger, sta
 	}
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			l.Infof("Starting Http server on :%s", env.Port)
 			go func() {
 				_ = e.Start(":" + env.Port)

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -21,14 +21,13 @@ import (
 	"net/http"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-
 	"github.com/labstack/echo/v4"
-	"github.com/mimiro-io/datahub/internal/conf"
-	"github.com/mimiro-io/datahub/internal/content"
-	"github.com/mimiro-io/datahub/internal/jobs"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/content"
+	"github.com/mimiro-io/datahub/internal/jobs"
 	"github.com/mimiro-io/datahub/internal/server"
 )
 

--- a/security_integration_test.go
+++ b/security_integration_test.go
@@ -12,19 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package datahub
+package datahub_test
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/mimiro-io/datahub"
 
 	"github.com/mimiro-io/datahub/internal/security"
 
@@ -62,7 +63,7 @@ func TestNodeSecurity(t *testing.T) {
 			devNull, _ := os.Open("/dev/null")
 			os.Stdout = devNull
 			os.Stderr = devNull
-			app, _ = Start(context.Background())
+			app, _ = datahub.Start(context.Background())
 			os.Stdout = oldOut
 			os.Stderr = oldErr
 		})
@@ -481,11 +482,11 @@ func TestNodeSecurity(t *testing.T) {
 			clientInfo.ClientID = "node1"
 
 			// read the node private and public keys for use in this interaction
-			_, err = ioutil.ReadFile(securityLocation + string(os.PathSeparator) + "node_key")
+			_, err = os.ReadFile(securityLocation + string(os.PathSeparator) + "node_key")
 			g.Assert(err).IsNil()
 			// clientPrivateKey, err := security.ParseRsaPrivateKeyFromPem(content)
 
-			content, err := ioutil.ReadFile(securityLocation + string(os.PathSeparator) + "node_key.pub")
+			content, err := os.ReadFile(securityLocation + string(os.PathSeparator) + "node_key.pub")
 			g.Assert(err).IsNil()
 			publicKey, err := security.ParseRsaPublicKeyFromPem(content)
 			g.Assert(err).IsNil()
@@ -611,9 +612,9 @@ func TestNodeSecurity(t *testing.T) {
 				g.Assert(err).IsNil()
 				g.Assert(res).IsNotNil()
 				g.Assert(res.StatusCode).Eql(200)
-				body, _ := ioutil.ReadAll(res.Body)
+				body, _ := io.ReadAll(res.Body)
 				var hist []map[string]interface{}
-				json.Unmarshal(body, &hist)
+				_ = json.Unmarshal(body, &hist)
 				// t.Log(hist)
 				if len(hist) != 0 {
 					g.Assert(hist[0]["lastError"]).IsZero("no error expected")

--- a/security_integration_test.go
+++ b/security_integration_test.go
@@ -25,12 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mimiro-io/datahub"
-
-	"github.com/mimiro-io/datahub/internal/security"
-
 	"github.com/franela/goblin"
 	"go.uber.org/fx"
+
+	"github.com/mimiro-io/datahub"
+	"github.com/mimiro-io/datahub/internal/security"
 )
 
 func TestNodeSecurity(t *testing.T) {


### PR DESCRIPTION
In this Pull request we address some linting rules.

While it includes no functional change - everything should work as before - users may observe different error messages. 
In some cases the first letter of messages were updated to lowercase.

- import order
- casing of ID, HTML and JSON in variable names
- try to stay within 120 chars line length
- addressed unused parameters
- shadowed variables (typically `err`)
- use camel case for constants
- general formatting using gofumpt