### PR TITLE
Feat/ginkgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,9 @@ require (
 	github.com/dlclark/regexp2 v1.8.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gojektech/valkyrie v0.0.0-20190210220504-8f62c1e7ba45 // indirect
@@ -54,6 +56,8 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v23.3.3+incompatible // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect
@@ -67,6 +71,8 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
+	github.com/onsi/gomega v1.27.6 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,12 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
@@ -182,6 +186,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -195,6 +200,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -273,6 +280,10 @@ github.com/mustafaturan/bus v1.0.2/go.mod h1:h7gfehm8TThv4Dcaa+wDQG7r7j6p74v+7ft
 github.com/mustafaturan/monoton v0.3.1/go.mod h1:FOnE7NV3s3EWPXb8/7+/OSdiMBbdlkV0Lz8p1dc+vy8=
 github.com/mustafaturan/monoton v1.0.0 h1:8SCej+JiNn0lyps7V+Jzc1CRAkDR4EZPWrTupQ61YCQ=
 github.com/mustafaturan/monoton v1.0.0/go.mod h1:FOnE7NV3s3EWPXb8/7+/OSdiMBbdlkV0Lz8p1dc+vy8=
+github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
+github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
+github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml/v2 v2.0.7 h1:muncTPStnKRos5dpVKULv2FVd4bMOhNePj9CjgDb8Us=
 github.com/pelletier/go-toml/v2 v2.0.7/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=

--- a/internal/conf/config_test.go
+++ b/internal/conf/config_test.go
@@ -18,148 +18,139 @@ import (
 	"os"
 	"testing"
 
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/spf13/viper"
 )
 
-func TestLoadEnv(t *testing.T) {
-	g := goblin.Goblin(t)
-
-	var currentDir string
-
-	g.Describe("Loading the Environment", func() {
-		g.Before(func() {
-			_ = os.Setenv("PROFILE", "test")
-			viper.Reset()
-			d, err := os.Getwd()
-			if err != nil {
-				g.Fail(err)
-			}
-			currentDir = d + "/../../.env-test"
-		})
-		g.It("should parse the test env file", func() {
-			env, err := loadEnv(&currentDir, false)
-			if err != nil {
-				g.Fail(err)
-			}
-			g.Assert(env.Env).Equal("test")
-			g.Assert(env.Port).Equal("9999")
-		})
-
-		g.After(func() {
-			_ = os.Unsetenv("PROFILE")
-		})
-	})
+func TestConf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conf Suite")
 }
 
-func TestParseEnvFromFile(t *testing.T) {
-	g := goblin.Goblin(t)
+var _ = Describe("Loading the Environment", Ordered, func() {
+	var currentDir string
+	BeforeAll(func() {
+		_ = os.Setenv("PROFILE", "test")
+		viper.Reset()
+		d, err := os.Getwd()
+		if err != nil {
+			Fail(err.Error())
+		}
+		currentDir = d + "/../../.env-test"
+	})
+	It("should parse the test env file", func() {
+		env, err := loadEnv(&currentDir, false)
+		if err != nil {
+			Fail(err.Error())
+		}
+		Expect(env.Env).To(Equal("test"))
+		Expect(env.Port).To(Equal("9999"))
+	})
 
+	AfterAll(func() {
+		_ = os.Unsetenv("PROFILE")
+	})
+})
+
+var _ = Describe("Parsing the env file", Ordered, func() {
 	var currentDir string
 	var env *Env
-	g.Describe("Parsing the env file", func() {
-		g.Before(func() {
-			_ = os.Setenv("PROFILE", "test")
-			viper.Reset()
-			d, err := os.Getwd()
-			if err != nil {
-				g.Fail(err)
-			}
-			currentDir = d + "/../../.env-test"
-			e, err := loadEnv(&currentDir, false)
-			if err != nil {
-				g.Fail(err)
-			}
-			env = e
-		})
-		g.It("should have correct values", func() {
-			g.Assert(env.Port).Equal("9999")
-			g.Assert(env.StoreLocation).Equal("./test")
-			g.Assert(env.AgentHost).Equal("127.0.0.1:8125")
-		})
-
-		g.It("should have correct dl jwt values", func() {
-			g.Assert(env.DlJwtConfig.ClientID).Equal("id1")
-			g.Assert(env.DlJwtConfig.ClientSecret).Equal("some-secret")
-			g.Assert(env.DlJwtConfig.Audience).Equal("yes")
-			g.Assert(env.DlJwtConfig.GrantType).Equal("test")
-			g.Assert(env.DlJwtConfig.Endpoint).Equal("http://localhost")
-		})
-
-		g.It("should have correct auth values", func() {
-			g.Assert(env.Auth.WellKnown).Equal("https://example.io/jwks/.well-known/jwks.json")
-			g.Assert(env.Auth.Audience).Equal([]string{"https://example.io"})
-			g.Assert(env.Auth.Issuer).Equal([]string{"https://example.io"})
-			g.Assert(env.Auth.Middleware).Equal("noop")
-		})
-
-		g.It("should have opa configuration", func() {
-			g.Assert(viper.GetString("OPA_ENDPOINT")).Equal("http://localhost:1111")
-		})
-
-		g.It("should have correct backup values", func() {
-			g.Assert(env.BackupLocation).Equal("./backup")
-			g.Assert(env.BackupSchedule).Equal("*/15 * * * *")
-			g.Assert(env.BackupRsync).IsTrue()
-		})
-
-		g.After(func() {
-			_ = os.Unsetenv("PROFILE")
-		})
+	BeforeAll(func() {
+		_ = os.Setenv("PROFILE", "test")
+		viper.Reset()
+		d, err := os.Getwd()
+		if err != nil {
+			Fail(err.Error())
+		}
+		currentDir = d + "/../../.env-test"
+		e, err := loadEnv(&currentDir, false)
+		if err != nil {
+			Fail(err.Error())
+		}
+		env = e
 	})
-}
-
-func TestLoadEnvNoFile(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("Loading the env without a file", func() {
-		g.Before(func() {
-			_ = os.Setenv("PROFILE", "test")
-			viper.Reset()
-		})
-		g.It("should load fine", func() {
-			_, err := loadEnv(nil, false)
-			if err != nil {
-				g.Fail(err)
-			}
-		})
-
-		g.After(func() {
-			_ = os.Unsetenv("PROFILE")
-		})
+	It("should have correct values", func() {
+		Expect(env.Port).To(Equal("9999"))
+		Expect(env.StoreLocation).To(Equal("./test"))
+		Expect(env.AgentHost).To(Equal("127.0.0.1:8125"))
 	})
-}
 
-func TestLoadEnvVariables(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("Loading env from env variables only", func() {
-		var c *Env
-
-		g.Before(func() {
-			viper.Reset()
-			_ = os.Setenv("PROFILE", "test")
-			_ = os.Setenv("TOKEN_WELL_KNOWN", "https://example.io/jwks/.well-known/jwks.json")
-			_ = os.Setenv("DL_JWT_CLIENT_ID", "12345")
-			cf, err := loadEnv(nil, false)
-			if err != nil {
-				g.Fail(err)
-			}
-			c = cf
-		})
-
-		g.It("should have read some env variables", func() {
-			g.Assert(c.Auth.WellKnown).Equal("https://example.io/jwks/.well-known/jwks.json")
-			g.Assert(c.DlJwtConfig.ClientID).Equal("12345")
-		})
-
-		g.It("should have set some default values", func() {
-			g.Assert(c.BackupSchedule).Equal("*/5 * * * *")
-			g.Assert(c.BackupRsync).IsTrue()
-		})
-
-		g.After(func() {
-			_ = os.Unsetenv("PROFILE")
-			_ = os.Unsetenv("TOKEN_WELL_KNOWN")
-			_ = os.Unsetenv("DL_JWT_CLIENT_ID")
-		})
+	It("should have correct dl jwt values", func() {
+		Expect(env.DlJwtConfig.ClientID).To(Equal("id1"))
+		Expect(env.DlJwtConfig.ClientSecret).To(Equal("some-secret"))
+		Expect(env.DlJwtConfig.Audience).To(Equal("yes"))
+		Expect(env.DlJwtConfig.GrantType).To(Equal("test"))
+		Expect(env.DlJwtConfig.Endpoint).To(Equal("http://localhost"))
 	})
-}
+
+	It("should have correct auth values", func() {
+		Expect(env.Auth.WellKnown).To(Equal("https://example.io/jwks/.well-known/jwks.json"))
+		Expect(env.Auth.Audience).To(Equal([]string{"https://example.io"}))
+		Expect(env.Auth.Issuer).To(Equal([]string{"https://example.io"}))
+		Expect(env.Auth.Middleware).To(Equal("noop"))
+	})
+
+	It("should have opa configuration", func() {
+		Expect(viper.GetString("OPA_ENDPOINT")).To(Equal("http://localhost:1111"))
+	})
+
+	It("should have correct backup values", func() {
+		Expect(env.BackupLocation).To(Equal("./backup"))
+		Expect(env.BackupSchedule).To(Equal("*/15 * * * *"))
+		Expect(env.BackupRsync).To(BeTrue())
+	})
+
+	AfterAll(func() {
+		_ = os.Unsetenv("PROFILE")
+	})
+})
+
+var _ = Describe("Loading the env without a file", Ordered, func() {
+	BeforeAll(func() {
+		_ = os.Setenv("PROFILE", "test")
+		viper.Reset()
+	})
+	It("should load fine", func() {
+		_, err := loadEnv(nil, false)
+		if err != nil {
+			Fail(err.Error())
+		}
+	})
+
+	AfterAll(func() {
+		_ = os.Unsetenv("PROFILE")
+	})
+})
+
+var _ = Describe("Loading env from env variables only", Ordered, func() {
+	var c *Env
+
+	BeforeAll(func() {
+		viper.Reset()
+		_ = os.Setenv("PROFILE", "test")
+		_ = os.Setenv("TOKEN_WELL_KNOWN", "https://example.io/jwks/.well-known/jwks.json")
+		_ = os.Setenv("DL_JWT_CLIENT_ID", "12345")
+		cf, err := loadEnv(nil, false)
+		if err != nil {
+			Fail(err.Error())
+		}
+		c = cf
+	})
+
+	It("should have read some env variables", func() {
+		Expect(c.Auth.WellKnown).To(Equal("https://example.io/jwks/.well-known/jwks.json"))
+		Expect(c.DlJwtConfig.ClientID).To(Equal("12345"))
+	})
+
+	It("should have set some default values", func() {
+		Expect(c.BackupSchedule).To(Equal("*/5 * * * *"))
+		Expect(c.BackupRsync).To(BeTrue())
+	})
+
+	AfterAll(func() {
+		_ = os.Unsetenv("PROFILE")
+		_ = os.Unsetenv("TOKEN_WELL_KNOWN")
+		_ = os.Unsetenv("DL_JWT_CLIENT_ID")
+	})
+})

--- a/internal/conf/logger_test.go
+++ b/internal/conf/logger_test.go
@@ -15,35 +15,32 @@
 package conf
 
 import (
-	"testing"
-
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
 )
 
-func TestLogger(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("The Logger's Loglevel parser", func() {
-		g.It("Should accept 'debug'", func() {
-			g.Assert(getLogLevel("debug")).Eql(zapcore.DebugLevel)
-		})
-		g.It("Should accept 'info'", func() {
-			g.Assert(getLogLevel("info")).Eql(zapcore.InfoLevel)
-		})
-		g.It("Should accept 'warn'", func() {
-			g.Assert(getLogLevel("warn")).Eql(zapcore.WarnLevel)
-		})
-		g.It("Should accept 'ERRor'", func() {
-			g.Assert(getLogLevel("ERRor")).Eql(zapcore.ErrorLevel)
-		})
-		g.It("Should accept fallback to info", func() {
-			g.Assert(getLogLevel("LLSDFFSD")).Eql(zapcore.InfoLevel)
-		})
+var _ = Describe("The Logger's Loglevel parser", func() {
+	It("Should accept 'debug'", func() {
+		Expect(getLogLevel("debug")).To(Equal(zapcore.DebugLevel))
 	})
-	g.Describe("Getting a logger", func() {
-		g.It("Should get the correct logger", func() {
-			logger := GetLogger("local", zapcore.InfoLevel).Desugar()
-			g.Assert(logger.Core().Enabled(zapcore.InfoLevel)).IsTrue("Go the wrong logger")
-		})
+	It("Should accept 'info'", func() {
+		Expect(getLogLevel("info")).To(Equal(zapcore.InfoLevel))
 	})
-}
+	It("Should accept 'warn'", func() {
+		Expect(getLogLevel("warn")).To(Equal(zapcore.WarnLevel))
+	})
+	It("Should accept 'ERRor'", func() {
+		Expect(getLogLevel("ERRor")).To(Equal(zapcore.ErrorLevel))
+	})
+	It("Should accept fallback to info", func() {
+		Expect(getLogLevel("LLSDFFSD")).To(Equal(zapcore.InfoLevel))
+	})
+})
+
+var _ = Describe("Getting a logger", func() {
+	It("Should get the correct logger", func() {
+		logger := GetLogger("local", zapcore.InfoLevel).Desugar()
+		Expect(logger.Core().Enabled(zapcore.InfoLevel)).To(BeTrue(), "Go the wrong logger")
+	})
+})

--- a/internal/conf/metrics_test.go
+++ b/internal/conf/metrics_test.go
@@ -16,9 +16,9 @@ package conf
 
 import (
 	"reflect"
-	"testing"
 
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
@@ -26,30 +26,26 @@ import (
 	"github.com/mimiro-io/datahub/internal"
 )
 
-func TestStatsdClient(t *testing.T) {
-	g := goblin.Goblin(t)
-
+var _ = Describe("Start an instance", Ordered, func() {
 	var lc fx.Lifecycle
-	g.Describe("Start an instance", func() {
-		g.Before(func() {
-			lc = fxtest.NewLifecycle(internal.FxTestLog(t, false))
-		})
-		g.It("should be of noop type when no agent host", func() {
-			env := &Env{
-				AgentHost: "",
-			}
-			client, err := NewMetricsClient(lc, env, zap.NewNop().Sugar())
-			g.Assert(err).IsNil()
-			g.Assert(reflect.ValueOf(client).Type().String()).Eql("*statsd.NoOpClient")
-		})
-
-		g.It("should be statsd client when agent host set", func() {
-			env := &Env{
-				AgentHost: "127.0.0.1:8125",
-			}
-			client, err := NewMetricsClient(lc, env, zap.NewNop().Sugar())
-			g.Assert(err).IsNil()
-			g.Assert(reflect.ValueOf(client).Type().String()).Eql("*statsd.Client")
-		})
+	BeforeAll(func() {
+		lc = fxtest.NewLifecycle(internal.FxTestLog(GinkgoT(), false))
 	})
-}
+	It("should be of noop type when no agent host", func() {
+		env := &Env{
+			AgentHost: "",
+		}
+		client, err := NewMetricsClient(lc, env, zap.NewNop().Sugar())
+		Expect(err).To(BeNil())
+		Expect(reflect.ValueOf(client).Type().String()).To(Equal("*statsd.NoOpClient"))
+	})
+
+	It("should be statsd client when agent host set", func() {
+		env := &Env{
+			AgentHost: "127.0.0.1:8125",
+		}
+		client, err := NewMetricsClient(lc, env, zap.NewNop().Sugar())
+		Expect(err).To(BeNil())
+		Expect(reflect.ValueOf(client).Type().String()).To(Equal("*statsd.Client"))
+	})
+})

--- a/internal/conf/secrets/manager_test.go
+++ b/internal/conf/secrets/manager_test.go
@@ -17,10 +17,11 @@ package secrets
 import (
 	"testing"
 
-	"github.com/mimiro-io/datahub/internal/conf"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 func TestNewManager(t *testing.T) {

--- a/internal/conf/secrets/manager_test.go
+++ b/internal/conf/secrets/manager_test.go
@@ -15,34 +15,35 @@
 package secrets
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/franela/goblin"
-	"go.uber.org/zap"
-
 	"github.com/mimiro-io/datahub/internal/conf"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
 )
 
 func TestNewManager(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("Testing Secrets Creation", func() {
-		g.It("should return noop manager when given noop", func() {
-			env := &conf.Env{
-				Env:            "test",
-				SecretsManager: "noop",
-			}
-
-			mngr, err := NewManager(env, zap.NewNop().Sugar())
-			if err != nil {
-				g.Fail(err)
-			}
-			switch mngr.(type) {
-			case *NoopStore:
-				// ok
-			default:
-				g.Fail(errors.New("store is not NoopStore"))
-			}
-		})
-	})
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "conf/Secrets Suite")
 }
+
+var _ = Describe("Testing Secrets Creation", func() {
+	It("should return noop manager when given noop", func() {
+		env := &conf.Env{
+			Env:            "test",
+			SecretsManager: "noop",
+		}
+
+		mngr, err := NewManager(env, zap.NewNop().Sugar())
+		if err != nil {
+			Fail(err.Error())
+		}
+		switch mngr.(type) {
+		case *NoopStore:
+			// ok
+		default:
+			Fail("store is not NoopStore")
+		}
+	})
+})

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/conf"
-	"github.com/mimiro-io/datahub/internal/server"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/mimiro-io/datahub/internal/server"
 )
 
 func TestContent(t *testing.T) {

--- a/internal/jobs/pipeline_history_test.go
+++ b/internal/jobs/pipeline_history_test.go
@@ -22,361 +22,362 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
-func TestPipelineHistory(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("A pipeline", func() {
-		testCnt := 0
-		var dsm *server.DsManager
-		var scheduler *Scheduler
-		var store *server.Store
-		var runner *Runner
-		var storeLocation string
-		g.BeforeEach(func() {
-			// temp redirect of stdout and stderr to swallow some annoying init messages in fx and jobrunner and mockService
-			devNull, _ := os.Open("/dev/null")
-			oldErr := os.Stderr
-			oldStd := os.Stdout
-			os.Stderr = devNull
-			os.Stdout = devNull
-
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./testpipeline_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-
-			scheduler, store, runner, dsm, _ = setupScheduler(storeLocation, t)
-
-			// undo redirect of stdout and stderr after successful init of fx and jobrunner
-			os.Stderr = oldErr
-			os.Stdout = oldStd
-		})
-		g.AfterEach(func() {
-			runner.Stop()
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-		g.It("Should produce consistent output for single change", func() {
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, false)
-			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
-			//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-
-			// store first version of "homer"
-			// and first version of "mimiro"
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-
-			// run job twice, output should not change
-			job.Run()
-			job.Run()
-
-			checkEntities("homer_1", "Mimiro_1", "")
-			checkChange(0, "homer_1", "Mimiro_1", "")
-			assertChangeCount(1)
-		})
-		g.It("Should produce consistent output for changes in dependency dataset", func() {
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, false)
-			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
-			// checkChange, checkEntities, assertChangeCount, printState := setupCheckers(g, t, employees, people, companies, ns)
-
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-			// change company
-			g.Assert(mimiro("Mimiro_2")).IsNil()
-
-			// run job many times, output should not change
-			for i := 0; i < 10; i++ {
-				job.Run()
-			}
-			// printState()
-			checkEntities("homer_1", "Mimiro_2", "")
-			checkChange(0, "homer_1", "Mimiro_2", "")
-			assertChangeCount(1)
-		})
-		g.It("Should produce consistent output for changes in source dataset", func() {
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, false)
-			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			// checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
-			checkChange, checkEntities, assertChangeCount, printState := setupCheckers(
-				g, t, employees, people, companies, ns)
-
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-			// change homer
-			g.Assert(homer("homer_2")).IsNil()
-
-			// run job many times, output should not change
-			for i := 0; i < 5; i++ {
-				job.Run()
-			}
-			printState()
-			checkEntities("homer_2", "Mimiro_1", "")
-			checkChange(0, "homer_1", "Mimiro_1", "")
-			checkChange(1, "homer_2", "Mimiro_1", "")
-			checkChange(8, "homer_1", "Mimiro_1", "")
-			checkChange(9, "homer_2", "Mimiro_1", "")
-			assertChangeCount(10) //"2 changes in source, time 5 job runs"
-		})
-		g.It("Should produce consistent output for LastOnly changes in source dataset", func() {
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, true)
-			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			// checkChange, checkEntities, assertChangeCount, _ := setupCheckers(g, t, employees, people, companies, ns)
-			checkChange, checkEntities, assertChangeCount, printState := setupCheckers(
-				g, t, employees, people, companies, ns)
-
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-			// change homer
-			g.Assert(homer("homer_2")).IsNil()
-
-			// run job many times, output should not change
-			for i := 0; i < 5; i++ {
-				job.Run()
-			}
-			printState()
-			checkEntities("homer_2", "Mimiro_1", "")
-			assertChangeCount(
-				1,
-			) // only one version of homer is expected to be emitted, therefore only one resulting change version
-			checkChange(0, "homer_2", "Mimiro_1", "")
-		})
-		g.It("Should produce consistent output for 2 changes in different batches", func() {
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, false)
-			// set batchsize to 2
-			job.pipeline.(*FullSyncPipeline).batchSize = 2
-			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
-				g, t, employees, people, companies, ns)
-			//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-			g.Assert(homer("homer_2")).IsNil()
-			g.Assert(mimiro("Mimiro_2")).IsNil()
-			g.Assert(homer("homer_3")).IsNil()
-
-			// run job many times, output should not change
-			for i := 0; i < 5; i++ {
-				job.Run()
-			}
-			print()
-			checkEntities("homer_3", "Mimiro_2", "")
-			checkChange(0, "homer_1", "Mimiro_2", "")
-			checkChange(1, "homer_2", "Mimiro_2", "")
-			checkChange(2, "homer_3", "Mimiro_2", "")
-			checkChange(12, "homer_1", "Mimiro_2", "")
-			checkChange(13, "homer_2", "Mimiro_2", "")
-			checkChange(14, "homer_3", "Mimiro_2", "")
-			assertChangeCount(15) //"3 changes in source, time 5 job runs"
-		})
-		g.It("Should produce consistent output for 2 LastOnly changes in different batches", func() {
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, true)
-			// set batchsize to 2
-			job.pipeline.(*FullSyncPipeline).batchSize = 2
-			homer, _, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
-				g, t, employees, people, companies, ns)
-			//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-			g.Assert(homer("homer_2")).IsNil()
-			g.Assert(mimiro("Mimiro_2")).IsNil()
-			g.Assert(homer("homer_3")).IsNil()
-
-			// run job many times, output should not change
-			for i := 0; i < 5; i++ {
-				job.Run()
-			}
-			print()
-			checkEntities("homer_3", "Mimiro_2", "")
-			checkChange(0, "homer_3", "Mimiro_2", "")
-			assertChangeCount(1) // since only one "Latest" version of homer is emitted, we expect only one result
-		})
-		g.It("Should preserve state of composed change products also if sources change with time", func() {
-			/*
-				Here we simulate changes in two datasets over time, and verify how these changes affect the results
-				of transforms which use Query to join both datasets.
-
-				As baseline we have a person, homer, and a company, Mimiro. a transform job joins Mimiro onto homer and produces
-				an entity with data from both source entities.
-
-				With the baseline set, we add a couple of changes to both homer and Mimiro, which each should produce a new version
-				of the joined "employee" entity if we run the transform again.
-			*/
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, false)
-			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
-				g, t, employees, people, companies, ns)
-
-			// store first version of "homer"
-			// and first version of "mimiro"
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-
-			// now, first run with baseline
-			job.Run()
-
-			checkEntities("homer_1", "Mimiro_1", "")
-			assertChangeCount(1)
-			checkChange(0, "homer_1", "Mimiro_1", "")
-
-			///////////// first change: homer new name, add friend /////////////////
-			g.Assert(homerWithFriend("homer_2")).IsNil()
-			job.Run()
-
-			checkEntities("homer_2", "Mimiro_1", "barney")
-			assertChangeCount(2)
-			checkChange(0, "homer_1", "Mimiro_1", "")
-			checkChange(1, "homer_2", "Mimiro_1", "barney")
-
-			//////////// 2nd change: Mimiro new name //////////////////
-			g.Assert(mimiro("Mimiro_2")).IsNil()
-			job.Run()
-			/////////// 3rd change: homer new name again, rm friend
-			g.Assert(homer("homer_3")).IsNil()
-			job.Run()
-			/////////// 4th change: homer back to old name
-			g.Assert(homer("homer_1")).IsNil()
-			job.Run()
-			/////////// 5th change: Mimiro new name
-			g.Assert(mimiro("Mimiro_3")).IsNil()
-			job.Run()
-			/////////// 6th change: homer  final change
-			g.Assert(homer("homer_4")).IsNil()
-			job.Run()
-			/////////// 7th change: mimiro  final change
-			g.Assert(mimiro("Mimiro_4")).IsNil()
-			job.Run()
-
-			print()
-			checkEntities("homer_4", "Mimiro_4", "")
-			assertChangeCount(24)
-			checkChange(0, "homer_1", "Mimiro_1", "")
-			checkChange(1, "homer_2", "Mimiro_1", "barney")
-			checkChange(2, "homer_1", "Mimiro_2", "")
-			checkChange(3, "homer_2", "Mimiro_2", "barney")
-			checkChange(23, "homer_4", "Mimiro_4", "")
-		})
-		g.It("Should preserve state of composed LatestOnly change products also if sources change with time", func() {
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, true)
-			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
-				g, t, employees, people, companies, ns)
-
-			// store first version of "homer"
-			// and first version of "mimiro"
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-
-			// now, first run with baseline
-			job.Run()
-
-			checkEntities("homer_1", "Mimiro_1", "")
-			assertChangeCount(1)
-			checkChange(0, "homer_1", "Mimiro_1", "")
-
-			///////////// first change: homer new name, add friend /////////////////
-			g.Assert(homerWithFriend("homer_2")).IsNil()
-			job.Run()
-
-			checkEntities("homer_2", "Mimiro_1", "barney")
-			assertChangeCount(2)
-			checkChange(0, "homer_1", "Mimiro_1", "")
-			checkChange(1, "homer_2", "Mimiro_1", "barney")
-
-			//////////// 2nd change: Mimiro new name //////////////////
-			g.Assert(mimiro("Mimiro_2")).IsNil()
-			job.Run()
-			/////////// 3rd change: homer new name again, rm friend
-			g.Assert(homer("homer_3")).IsNil()
-			job.Run()
-			/////////// 4th change: homer back to old name
-			g.Assert(homer("homer_1")).IsNil()
-			job.Run()
-			/////////// 5th change: Mimiro new name
-			g.Assert(mimiro("Mimiro_3")).IsNil()
-			job.Run()
-			/////////// 6th change: homer  final change
-			g.Assert(homer("homer_4")).IsNil()
-			job.Run()
-			/////////// 7th change: mimiro  final change
-			g.Assert(mimiro("Mimiro_4")).IsNil()
-			job.Run()
-
-			print()
-			checkEntities("homer_4", "Mimiro_4", "")
-			assertChangeCount(8)
-			checkChange(0, "homer_1", "Mimiro_1", "")
-			checkChange(1, "homer_2", "Mimiro_1", "barney")
-			checkChange(2, "homer_2", "Mimiro_2", "barney")
-			checkChange(3, "homer_3", "Mimiro_2", "")
-			checkChange(4, "homer_1", "Mimiro_2", "")
-			checkChange(5, "homer_1", "Mimiro_3", "")
-			checkChange(6, "homer_4", "Mimiro_3", "")
-			checkChange(7, "homer_4", "Mimiro_4", "")
-		})
-		g.It("Should compose existing changes correctly in transform with Query", func() {
-			/*
-				  This is the same order of changes as above, except for that we only run the
-					transform job once at the end.
-			*/
-			ns, employees, people, companies := setupDatasets(store, dsm)
-			job := setupJob(scheduler, g, runner, false)
-			homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
-			checkChange, checkEntities, assertChangeCount, print := setupCheckers(
-				g, t, employees, people, companies, ns)
-
-			// store first version of "homer"
-			// and first version of "mimiro"
-			g.Assert(homer("homer_1")).IsNil()
-			g.Assert(mimiro("Mimiro_1")).IsNil()
-
-			///////////// first change: homer new name, add friend rel /////////////////
-			g.Assert(homerWithFriend("homer_2")).IsNil()
-			//////////// 2nd change: Mimiro new name //////////////////
-			g.Assert(mimiro("Mimiro_2")).IsNil()
-			/////////// 3rd change: homer new name again, remove friend
-			g.Assert(homer("homer_3")).IsNil()
-			/////////// 4th change: homer back to old name
-			g.Assert(homer("homer_1")).IsNil()
-			/////////// 5th change: Mimiro new name
-			g.Assert(mimiro("Mimiro_3")).IsNil()
-			/////////// 6th change: homer  final change
-			g.Assert(homer("homer_4")).IsNil()
-			/////////// 7th change: mimiro  final change
-			g.Assert(mimiro("Mimiro_4")).IsNil()
-			job.Run()
-
-			print()
-			checkEntities("homer_4", "Mimiro_4", "")
-			assertChangeCount(5)
-			checkChange(0, "homer_1", "Mimiro_4", "")
-			checkChange(1, "homer_2", "Mimiro_4", "barney")
-			checkChange(2, "homer_3", "Mimiro_4", "")
-			checkChange(3, "homer_1", "Mimiro_4", "")
-			checkChange(4, "homer_4", "Mimiro_4", "")
-		})
-	})
+func TestJobs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Jobs Suite")
 }
 
+var _ = Describe("A pipeline", func() {
+	testCnt := 0
+	var dsm *server.DsManager
+	var scheduler *Scheduler
+	var store *server.Store
+	var runner *Runner
+	var storeLocation string
+	BeforeEach(func() {
+		// temp redirect of stdout and stderr to swallow some annoying init messages in fx and jobrunner and mockService
+		devNull, _ := os.Open("/dev/null")
+		oldErr := os.Stderr
+		oldStd := os.Stdout
+		os.Stderr = devNull
+		os.Stdout = devNull
+
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./testpipeline_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+
+		scheduler, store, runner, dsm, _ = setupScheduler(storeLocation)
+
+		// undo redirect of stdout and stderr after successful init of fx and jobrunner
+		os.Stderr = oldErr
+		os.Stdout = oldStd
+	})
+	AfterEach(func() {
+		runner.Stop()
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+	It("Should produce consistent output for single change", func() {
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, false)
+		homer, _, mimiro := entityUpdaters(people, ns, companies)
+		checkChange, checkEntities, assertChangeCount, _ := setupCheckers(employees, people, companies, ns)
+		//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
+
+		// store first version of "homer"
+		// and first version of "mimiro"
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+
+		// run job twice, output should not change
+		job.Run()
+		job.Run()
+
+		checkEntities("homer_1", "Mimiro_1", "")
+		checkChange(0, "homer_1", "Mimiro_1", "")
+		assertChangeCount(1)
+	})
+	It("Should produce consistent output for changes in dependency dataset", func() {
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, false)
+		homer, _, mimiro := entityUpdaters(people, ns, companies)
+		checkChange, checkEntities, assertChangeCount, _ := setupCheckers(employees, people, companies, ns)
+		// checkChange, checkEntities, assertChangeCount, printState := setupCheckers(employees, people, companies, ns)
+
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+		// change company
+		Expect(mimiro("Mimiro_2")).To(BeNil())
+
+		// run job many times, output should not change
+		for i := 0; i < 10; i++ {
+			job.Run()
+		}
+		// printState()
+		checkEntities("homer_1", "Mimiro_2", "")
+		checkChange(0, "homer_1", "Mimiro_2", "")
+		assertChangeCount(1)
+	})
+	It("Should produce consistent output for changes in source dataset", func() {
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, false)
+		homer, _, mimiro := entityUpdaters(people, ns, companies)
+		// checkChange, checkEntities, assertChangeCount, _ := setupCheckers(employees, people, companies, ns)
+		checkChange, checkEntities, assertChangeCount, printState := setupCheckers(
+			employees, people, companies, ns)
+
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+		// change homer
+		Expect(homer("homer_2")).To(BeNil())
+
+		// run job many times, output should not change
+		for i := 0; i < 5; i++ {
+			job.Run()
+		}
+		printState()
+		checkEntities("homer_2", "Mimiro_1", "")
+		checkChange(0, "homer_1", "Mimiro_1", "")
+		checkChange(1, "homer_2", "Mimiro_1", "")
+		checkChange(8, "homer_1", "Mimiro_1", "")
+		checkChange(9, "homer_2", "Mimiro_1", "")
+		assertChangeCount(10) //"2 changes in source, time 5 job runs"
+	})
+	It("Should produce consistent output for LastOnly changes in source dataset", func() {
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, true)
+		homer, _, mimiro := entityUpdaters(people, ns, companies)
+		// checkChange, checkEntities, assertChangeCount, _ := setupCheckers(employees, people, companies, ns)
+		checkChange, checkEntities, assertChangeCount, printState := setupCheckers(
+			employees, people, companies, ns)
+
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+		// change homer
+		Expect(homer("homer_2")).To(BeNil())
+
+		// run job many times, output should not change
+		for i := 0; i < 5; i++ {
+			job.Run()
+		}
+		printState()
+		checkEntities("homer_2", "Mimiro_1", "")
+		assertChangeCount(
+			1,
+		) // only one version of homer is expected to be emitted, therefore only one resulting change version
+		checkChange(0, "homer_2", "Mimiro_1", "")
+	})
+	It("Should produce consistent output for 2 changes in different batches", func() {
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, false)
+		// set batchsize to 2
+		job.pipeline.(*FullSyncPipeline).batchSize = 2
+		homer, _, mimiro := entityUpdaters(people, ns, companies)
+		checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+			employees, people, companies, ns)
+		//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
+
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+		Expect(homer("homer_2")).To(BeNil())
+		Expect(mimiro("Mimiro_2")).To(BeNil())
+		Expect(homer("homer_3")).To(BeNil())
+
+		// run job many times, output should not change
+		for i := 0; i < 5; i++ {
+			job.Run()
+		}
+		print()
+		checkEntities("homer_3", "Mimiro_2", "")
+		checkChange(0, "homer_1", "Mimiro_2", "")
+		checkChange(1, "homer_2", "Mimiro_2", "")
+		checkChange(2, "homer_3", "Mimiro_2", "")
+		checkChange(12, "homer_1", "Mimiro_2", "")
+		checkChange(13, "homer_2", "Mimiro_2", "")
+		checkChange(14, "homer_3", "Mimiro_2", "")
+		assertChangeCount(15) //"3 changes in source, time 5 job runs"
+	})
+	It("Should produce consistent output for 2 LastOnly changes in different batches", func() {
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, true)
+		// set batchsize to 2
+		job.pipeline.(*FullSyncPipeline).batchSize = 2
+		homer, _, mimiro := entityUpdaters(people, ns, companies)
+		checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+			employees, people, companies, ns)
+		//	homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
+
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+		Expect(homer("homer_2")).To(BeNil())
+		Expect(mimiro("Mimiro_2")).To(BeNil())
+		Expect(homer("homer_3")).To(BeNil())
+
+		// run job many times, output should not change
+		for i := 0; i < 5; i++ {
+			job.Run()
+		}
+		print()
+		checkEntities("homer_3", "Mimiro_2", "")
+		checkChange(0, "homer_3", "Mimiro_2", "")
+		assertChangeCount(1) // since only one "Latest" version of homer is emitted, we expect only one result
+	})
+	It("Should preserve state of composed change products also if sources change with time", func() {
+		/*
+			Here we simulate changes in two datasets over time, and verify how these changes affect the results
+			of transforms which use Query to join both datasets.
+
+			As baseline we have a person, homer, and a company, Mimiro. a transform job joins Mimiro onto homer and produces
+			an entity with data from both source entities.
+
+			With the baseline set, we add a couple of changes to both homer and Mimiro, which each should produce a new version
+			of the joined "employee" entity if we run the transform again.
+		*/
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, false)
+		homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
+		checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+			employees, people, companies, ns)
+
+		// store first version of "homer"
+		// and first version of "mimiro"
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+
+		// now, first run with baseline
+		job.Run()
+
+		checkEntities("homer_1", "Mimiro_1", "")
+		assertChangeCount(1)
+		checkChange(0, "homer_1", "Mimiro_1", "")
+
+		///////////// first change: homer new name, add friend /////////////////
+		Expect(homerWithFriend("homer_2")).To(BeNil())
+		job.Run()
+
+		checkEntities("homer_2", "Mimiro_1", "barney")
+		assertChangeCount(2)
+		checkChange(0, "homer_1", "Mimiro_1", "")
+		checkChange(1, "homer_2", "Mimiro_1", "barney")
+
+		//////////// 2nd change: Mimiro new name //////////////////
+		Expect(mimiro("Mimiro_2")).To(BeNil())
+		job.Run()
+		/////////// 3rd change: homer new name again, rm friend
+		Expect(homer("homer_3")).To(BeNil())
+		job.Run()
+		/////////// 4th change: homer back to old name
+		Expect(homer("homer_1")).To(BeNil())
+		job.Run()
+		/////////// 5th change: Mimiro new name
+		Expect(mimiro("Mimiro_3")).To(BeNil())
+		job.Run()
+		/////////// 6th change: homer  final change
+		Expect(homer("homer_4")).To(BeNil())
+		job.Run()
+		/////////// 7th change: mimiro  final change
+		Expect(mimiro("Mimiro_4")).To(BeNil())
+		job.Run()
+
+		print()
+		checkEntities("homer_4", "Mimiro_4", "")
+		assertChangeCount(24)
+		checkChange(0, "homer_1", "Mimiro_1", "")
+		checkChange(1, "homer_2", "Mimiro_1", "barney")
+		checkChange(2, "homer_1", "Mimiro_2", "")
+		checkChange(3, "homer_2", "Mimiro_2", "barney")
+		checkChange(23, "homer_4", "Mimiro_4", "")
+	})
+	It("Should preserve state of composed LatestOnly change products also if sources change with time", func() {
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, true)
+		homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
+		checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+			employees, people, companies, ns)
+
+		// store first version of "homer"
+		// and first version of "mimiro"
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+
+		// now, first run with baseline
+		job.Run()
+
+		checkEntities("homer_1", "Mimiro_1", "")
+		assertChangeCount(1)
+		checkChange(0, "homer_1", "Mimiro_1", "")
+
+		///////////// first change: homer new name, add friend /////////////////
+		Expect(homerWithFriend("homer_2")).To(BeNil())
+		job.Run()
+
+		checkEntities("homer_2", "Mimiro_1", "barney")
+		assertChangeCount(2)
+		checkChange(0, "homer_1", "Mimiro_1", "")
+		checkChange(1, "homer_2", "Mimiro_1", "barney")
+
+		//////////// 2nd change: Mimiro new name //////////////////
+		Expect(mimiro("Mimiro_2")).To(BeNil())
+		job.Run()
+		/////////// 3rd change: homer new name again, rm friend
+		Expect(homer("homer_3")).To(BeNil())
+		job.Run()
+		/////////// 4th change: homer back to old name
+		Expect(homer("homer_1")).To(BeNil())
+		job.Run()
+		/////////// 5th change: Mimiro new name
+		Expect(mimiro("Mimiro_3")).To(BeNil())
+		job.Run()
+		/////////// 6th change: homer  final change
+		Expect(homer("homer_4")).To(BeNil())
+		job.Run()
+		/////////// 7th change: mimiro  final change
+		Expect(mimiro("Mimiro_4")).To(BeNil())
+		job.Run()
+
+		print()
+		checkEntities("homer_4", "Mimiro_4", "")
+		assertChangeCount(8)
+		checkChange(0, "homer_1", "Mimiro_1", "")
+		checkChange(1, "homer_2", "Mimiro_1", "barney")
+		checkChange(2, "homer_2", "Mimiro_2", "barney")
+		checkChange(3, "homer_3", "Mimiro_2", "")
+		checkChange(4, "homer_1", "Mimiro_2", "")
+		checkChange(5, "homer_1", "Mimiro_3", "")
+		checkChange(6, "homer_4", "Mimiro_3", "")
+		checkChange(7, "homer_4", "Mimiro_4", "")
+	})
+	It("Should compose existing changes correctly in transform with Query", func() {
+		/*
+			  This is the same order of changes as above, except for that we only run the
+				transform job once at the end.
+		*/
+		ns, employees, people, companies := setupDatasets(store, dsm)
+		job := setupJob(scheduler, runner, false)
+		homer, homerWithFriend, mimiro := entityUpdaters(people, ns, companies)
+		checkChange, checkEntities, assertChangeCount, print := setupCheckers(
+			employees, people, companies, ns)
+
+		// store first version of "homer"
+		// and first version of "mimiro"
+		Expect(homer("homer_1")).To(BeNil())
+		Expect(mimiro("Mimiro_1")).To(BeNil())
+
+		///////////// first change: homer new name, add friend rel /////////////////
+		Expect(homerWithFriend("homer_2")).To(BeNil())
+		//////////// 2nd change: Mimiro new name //////////////////
+		Expect(mimiro("Mimiro_2")).To(BeNil())
+		/////////// 3rd change: homer new name again, remove friend
+		Expect(homer("homer_3")).To(BeNil())
+		/////////// 4th change: homer back to old name
+		Expect(homer("homer_1")).To(BeNil())
+		/////////// 5th change: Mimiro new name
+		Expect(mimiro("Mimiro_3")).To(BeNil())
+		/////////// 6th change: homer  final change
+		Expect(homer("homer_4")).To(BeNil())
+		/////////// 7th change: mimiro  final change
+		Expect(mimiro("Mimiro_4")).To(BeNil())
+		job.Run()
+
+		print()
+		checkEntities("homer_4", "Mimiro_4", "")
+		assertChangeCount(5)
+		checkChange(0, "homer_1", "Mimiro_4", "")
+		checkChange(1, "homer_2", "Mimiro_4", "barney")
+		checkChange(2, "homer_3", "Mimiro_4", "")
+		checkChange(3, "homer_1", "Mimiro_4", "")
+		checkChange(4, "homer_4", "Mimiro_4", "")
+	})
+})
+
 func setupCheckers(
-	g *goblin.G,
-	t *testing.T,
 	employees *server.Dataset,
 	people *server.Dataset,
 	companies *server.Dataset,
@@ -386,6 +387,7 @@ func setupCheckers(
 	func(expectedHomerName string, expedtedMimiroName string, expectedHomerFriend string),
 	func(expectedCount int), func(),
 ) {
+	GinkgoHelper()
 	fv := func(homerFriend string, ns string) interface{} {
 		var friendVal interface{}
 		if homerFriend != "" {
@@ -399,32 +401,41 @@ func setupCheckers(
 	checkEntities := func(homerName, mimiroName, homerFriend string) {
 		friendVal := fv(homerFriend, ns)
 		entities, _ := employees.GetEntities("", math.MaxInt)
-		g.Assert(len(entities.Entities)).Eql(1)
-		g.Assert(entities.Entities[0].IsDeleted).IsFalse()
-		g.Assert(entities.Entities[0].Properties).Eql(map[string]interface{}{
+		Expect(len(entities.Entities)).To(Equal(1))
+		Expect(entities.Entities[0].IsDeleted).To(BeFalse())
+		Expect(entities.Entities[0].Properties).To(Equal(map[string]interface{}{
 			"companyname": mimiroName,
 			"name":        homerName,
-		})
-		g.Assert(entities.Entities[0].References[ns+":friend"]).Eql(friendVal)
+		}))
+		if friendVal != nil {
+			Expect(entities.Entities[0].References[ns+":friend"]).To(Equal(friendVal))
+		} else {
+			Expect(entities.Entities[0].References[ns+":friend"]).To(BeNil())
+		}
 	}
 
 	checkChanges := func(changeIdx int, homerName, mimiroName, homerFriend string) {
 		friendVal := fv(homerFriend, ns)
 		changes, _ := employees.GetChanges(0, math.MaxInt, false)
-		g.Assert(changes.Entities[changeIdx].IsDeleted).IsFalse()
-		g.Assert(changes.Entities[changeIdx].Properties["name"]).Eql(homerName)
-		g.Assert(changes.Entities[changeIdx].Properties["companyname"]).Eql(mimiroName)
-		g.Assert(changes.Entities[changeIdx].References[ns+":friend"]).Eql(friendVal)
+		Expect(changes.Entities[changeIdx].IsDeleted).To(BeFalse())
+		Expect(changes.Entities[changeIdx].Properties["name"]).To(Equal(homerName))
+		Expect(changes.Entities[changeIdx].Properties["companyname"]).To(Equal(mimiroName))
+		if friendVal != nil {
+			Expect(changes.Entities[changeIdx].References[ns+":friend"]).To(Equal(friendVal))
+		} else {
+			Expect(changes.Entities[changeIdx].References[ns+":friend"]).To(BeNil())
+		}
 	}
 	assertChangeCount := func(expectedCount int) {
 		changes, _ := employees.GetChanges(0, math.MaxInt, false)
-		g.Assert(len(changes.Entities)).Eql(expectedCount)
+		Expect(len(changes.Entities)).To(Equal(expectedCount))
 	}
 	printState := func() {
 		// comment out or remove shortcut return to activate printing
 		if 1 == 1 {
 			return
 		}
+		t := GinkgoT()
 		// print out state
 		result, _ := people.GetChanges(0, math.MaxInt, false)
 		// t.Logf("\npeople change count: %v", len(result.Entities))
@@ -482,7 +493,7 @@ func entityUpdaters(people *server.Dataset, ns string, companies *server.Dataset
 	return homer, homerWithFriend, mimiro
 }
 
-func setupJob(scheduler *Scheduler, g *goblin.G, runner *Runner, latestOnly bool) *job {
+func setupJob(scheduler *Scheduler, runner *Runner, latestOnly bool) *job {
 	// now combine homer and mimiro into homer-the-employee
 	jsFun := `function transform_entities(entities) {
 			var result = []
@@ -513,7 +524,7 @@ func setupJob(scheduler *Scheduler, g *goblin.G, runner *Runner, latestOnly bool
 		base64.StdEncoding.EncodeToString([]byte(jsFun)))))
 
 	pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
-	g.Assert(err).IsNil()
+	Expect(err).To(BeNil())
 	job := &job{
 		id:       jobConfig.ID,
 		pipeline: pipeline,

--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -22,73 +22,71 @@ import (
 	"os"
 	"strconv"
 	"sync"
-	"testing"
 	"time"
 
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
-func TestPipeline(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("A pipeline", func() {
-		testCnt := 0
-		var dsm *server.DsManager
-		var scheduler *Scheduler
-		var store *server.Store
-		var runner *Runner
-		var storeLocation string
-		var mockService MockService
-		g.BeforeEach(func() {
-			// temp redirect of stdout and stderr to swallow some annoying init messages in fx and jobrunner and mockService
-			devNull, _ := os.Open("/dev/null")
-			oldErr := os.Stderr
-			oldStd := os.Stdout
-			os.Stderr = devNull
-			os.Stdout = devNull
+var _ = Describe("A pipeline", func() {
+	testCnt := 0
+	var dsm *server.DsManager
+	var scheduler *Scheduler
+	var store *server.Store
+	var runner *Runner
+	var storeLocation string
+	var mockService MockService
+	BeforeEach(func() {
+		// temp redirect of stdout and stderr to swallow some annoying init messages in fx and jobrunner and mockService
+		devNull, _ := os.Open("/dev/null")
+		oldErr := os.Stderr
+		oldStd := os.Stdout
+		os.Stderr = devNull
+		os.Stdout = devNull
 
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./testpipeline_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-			mockService = NewMockService()
-			go func() {
-				_ = mockService.echo.Start(":7777")
-			}()
-			scheduler, store, runner, dsm, _ = setupScheduler(storeLocation, t)
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./testpipeline_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+		mockService = NewMockService()
+		go func() {
+			_ = mockService.echo.Start(":7777")
+		}()
+		scheduler, store, runner, dsm, _ = setupScheduler(storeLocation)
 
-			// undo redirect of stdout and stderr after successful init of fx and jobrunner
-			os.Stderr = oldErr
-			os.Stdout = oldStd
-		})
-		g.AfterEach(func() {
-			runner.Stop()
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-			_ = mockService.echo.Shutdown(ctx)
-			cancel()
-			mockService.HTTPNotificationChannel = nil
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
+		// undo redirect of stdout and stderr after successful init of fx and jobrunner
+		os.Stderr = oldErr
+		os.Stdout = oldStd
+	})
+	AfterEach(func() {
+		runner.Stop()
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		_ = mockService.echo.Shutdown(ctx)
+		cancel()
+		mockService.HTTPNotificationChannel = nil
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
 
-		g.It("Should support internal js transform with txn writing to several datasets", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("Products", nil)
-			_, _ = dsm.CreateDataset("NewProducts", nil)
-			_, _ = dsm.CreateDataset("ProductAudit", nil)
+	It("Should support internal js transform with txn writing to several datasets", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("Products", nil)
+		_, _ = dsm.CreateDataset("NewProducts", nil)
+		_, _ = dsm.CreateDataset("ProductAudit", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entities[0] = entity
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("entities are stored")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "entities are stored")
 
-			// transform js
-			js := `
+		// transform js
+		js := `
 			function transform_entities(entities) {
 				for (e of entities) {
 					var txn = NewTransaction();
@@ -101,10 +99,10 @@ func TestPipeline(t *testing.T) {
 				return entities;
 			}
 			`
-			jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
+		jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
 
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -120,52 +118,52 @@ func TestPipeline(t *testing.T) {
 				"Type" : "DevNullSink"
 			}
 		}`
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewProducts")
-			g.Assert(peopleDataset).IsNotNil("expected dataset is not present")
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewProducts")
+		Expect(peopleDataset).NotTo(BeNil(), "expected dataset is not present")
 
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil("no result is retrieved")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil(), "no result is retrieved")
 
-			g.Assert(len(result.Entities)).Eql(1, "incorrect number of entities retrieved")
+		Expect(len(result.Entities)).To(Equal(1), "incorrect number of entities retrieved")
 
-			auditDataset := dsm.GetDataset("ProductAudit")
-			g.Assert(auditDataset).IsNotNil("expected dataset is not present")
+		auditDataset := dsm.GetDataset("ProductAudit")
+		Expect(auditDataset).NotTo(BeNil(), "expected dataset is not present")
 
-			result, err = auditDataset.GetEntities("", 50)
-			g.Assert(err).IsNil("no result is retrieved")
+		result, err = auditDataset.GetEntities("", 50)
+		Expect(err).To(BeNil(), "no result is retrieved")
 
-			g.Assert(len(result.Entities)).Eql(1, "incorrect number of entities retrieved")
-		})
+		Expect(len(result.Entities)).To(Equal(1), "incorrect number of entities retrieved")
+	})
 
-		g.It("Should support internal js transform with txn", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("Products", nil)
-			_, _ = dsm.CreateDataset("NewProducts", nil)
+	It("Should support internal js transform with txn", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("Products", nil)
+		_, _ = dsm.CreateDataset("NewProducts", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entities[0] = entity
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("entities are stored")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "entities are stored")
 
-			// transform js
-			js := `
+		// transform js
+		js := `
 			function transform_entities(entities) {
 				for (e of entities) {
 					var txn = NewTransaction();
@@ -177,10 +175,10 @@ func TestPipeline(t *testing.T) {
 				return entities;
 			}
 			`
-			jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
+		jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
 
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -196,47 +194,47 @@ func TestPipeline(t *testing.T) {
 				"Type" : "DevNullSink"
 			}
 		}`
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewProducts")
-			g.Assert(peopleDataset).IsNotNil("expected dataset is not present")
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewProducts")
+		Expect(peopleDataset).NotTo(BeNil(), "expected dataset is not present")
 
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil("no result is retrieved")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil(), "no result is retrieved")
 
-			g.Assert(len(result.Entities)).Eql(1, "incorrect number of entities retrieved")
-		})
+		Expect(len(result.Entities)).To(Equal(1), "incorrect number of entities retrieved")
+	})
 
-		g.It("Should fullsync to an HttpDatasetSink", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("Products", nil)
+	It("Should fullsync to an HttpDatasetSink", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("Products", nil)
 
-			entities := make([]*server.Entity, 2)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entities[0] = entity
+		entities := make([]*server.Entity, 2)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entities[0] = entity
 
-			entity = server.NewEntity("http://data.mimiro.io/people/homer1", 0)
-			entity.Properties["name"] = "homer"
-			entities[1] = entity
+		entity = server.NewEntity("http://data.mimiro.io/people/homer1", 0)
+		entity.Properties["name"] = "homer"
+		entities[1] = entity
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("dataset.StoreEntites returns no error")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "dataset.StoreEntites returns no error")
 
-			dsName := "fstohttp"
-			jobJSON := `{
+		dsName := "fstohttp"
+		jobJSON := `{
 			"id" : "sync-datasetssource-to-httpdatasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
 			"fullSyncSchedule" : "@every 2s",
@@ -251,30 +249,30 @@ func TestPipeline(t *testing.T) {
 				"Url" : "http://localhost:7777/datasets/` + dsName + `/fullsync"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
-			g.Assert(err).IsNil("jobConfig to Pipeline returns no error")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
+		Expect(err).To(BeNil(), "jobConfig to Pipeline returns no error")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			g.Assert(pipeline.spec().batchSize).Eql(1, "Batch size should be 1")
+		Expect(pipeline.spec().batchSize).To(Equal(1), "Batch size should be 1")
 
-			job.Run()
-			g.Assert(len(scheduler.GetRunningJobs())).Eql(0, "running job list is empty, indicating job done")
-			g.Assert(len(mockService.getRecordedEntitiesForDataset(dsName))).Eql(2, "both 'pages' have been posted")
-		})
+		job.Run()
+		Expect(len(scheduler.GetRunningJobs())).To(Equal(0), "running job list is empty, indicating job done")
+		Expect(len(mockService.getRecordedEntitiesForDataset(dsName))).To(Equal(2), "both 'pages' have been posted")
+	})
 
-		g.It("Should fullsync from an untokenized HttpDatasetSource", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("People", nil)
+	It("Should fullsync from an untokenized HttpDatasetSource", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("People", nil)
 
-			// define job
-			jobJSON := `{
+		// define job
+		jobJSON := `{
 			"id" : "sync-httpdatasetsource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
 			"source" : {
@@ -286,30 +284,30 @@ func TestPipeline(t *testing.T) {
 				"Name" : "People"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
-			g.Assert(err).IsNil("jobConfig to Pipeline returns no error")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
+		Expect(err).To(BeNil(), "jobConfig to Pipeline returns no error")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			g.Assert(len(scheduler.GetRunningJobs())).Eql(0, "running job list is empty")
-			rs, err := ds.GetEntities("", 100)
-			g.Assert(err).IsNil("we found data in sink")
-			g.Assert(len(rs.Entities)).Eql(10, "we found 10 entites (MockService generates 10 results)")
-		})
+		job.Run()
+		Expect(len(scheduler.GetRunningJobs())).To(Equal(0), "running job list is empty")
+		rs, err := ds.GetEntities("", 100)
+		Expect(err).To(BeNil(), "we found data in sink")
+		Expect(len(rs.Entities)).To(Equal(10), "we found 10 entites (MockService generates 10 results)")
+	})
 
-		g.It("Should fullsync from a tokenized HttpDatasetSource", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("People", nil)
+	It("Should fullsync from a tokenized HttpDatasetSource", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("People", nil)
 
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 		{
 			"id" : "sync-httpdatasetsource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
@@ -323,41 +321,41 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
-			g.Assert(err).IsNil("jobConfig to Pipeline returns no error")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
+		Expect(err).To(BeNil(), "jobConfig to Pipeline returns no error")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			g.Assert(len(scheduler.GetRunningJobs())).Eql(0, "running job list is empty")
-			rs, err := ds.GetEntities("", 100)
-			g.Assert(err).IsNil("we found data in sink")
-			g.Assert(len(rs.Entities)).Eql(20, "we found 10 entites (MockService generates 20 results)")
-		})
+		job.Run()
+		Expect(len(scheduler.GetRunningJobs())).To(Equal(0), "running job list is empty")
+		rs, err := ds.GetEntities("", 100)
+		Expect(err).To(BeNil(), "we found data in sink")
+		Expect(len(rs.Entities)).To(Equal(20), "we found 10 entites (MockService generates 20 results)")
+	})
 
-		// func TestDatasetToHttpDatasetSink(m *testing.T) {
-		g.It("Should incrementally sync to an HttpDatasetSink", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("Products", nil)
+	// func TestDatasetToHttpDatasetSink(m *testing.T) {
+	It("Should incrementally sync to an HttpDatasetSink", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("Products", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entity.References["type"] = "http://data.mimiro.io/model/Person"
-			entity.References["typed"] = "http://data.mimiro.io/model/Person"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entity.References["type"] = "http://data.mimiro.io/model/Person"
+		entity.References["typed"] = "http://data.mimiro.io/model/Person"
+		entities[0] = entity
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("Entities are stored correctly")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "Entities are stored correctly")
 
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 		{
 			"id" : "sync-datasetssource-to-httpdatasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -371,40 +369,40 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed correctly")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed correctly")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			g.Assert(len(scheduler.GetRunningJobs())).Eql(0, "running job list not empty")
-		})
+		job.Run()
+		Expect(len(scheduler.GetRunningJobs())).To(Equal(0), "running job list not empty")
+	})
 
-		g.It("Should incrementally do internal sync with js transform in parallel", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("Products", nil)
-			_, _ = dsm.CreateDataset("NewProducts", nil)
+	It("Should incrementally do internal sync with js transform in parallel", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("Products", nil)
+		_, _ = dsm.CreateDataset("NewProducts", nil)
 
-			count := 19
-			entities := make([]*server.Entity, count)
-			for i := 0; i < count; i++ {
-				entity := server.NewEntity("http://data.mimiro.io/people/p"+strconv.Itoa(i), 0)
-				entity.Properties["name"] = "homer" + strconv.Itoa(i)
-				entity.References["type"] = "http://data.mimiro.io/model/Person"
-				entities[i] = entity
-			}
+		count := 19
+		entities := make([]*server.Entity, count)
+		for i := 0; i < count; i++ {
+			entity := server.NewEntity("http://data.mimiro.io/people/p"+strconv.Itoa(i), 0)
+			entity.Properties["name"] = "homer" + strconv.Itoa(i)
+			entity.References["type"] = "http://data.mimiro.io/model/Person"
+			entities[i] = entity
+		}
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("entities are stored")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "entities are stored")
 
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -423,49 +421,49 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewProducts")
-			g.Assert(peopleDataset).IsNotNil("dataset is present")
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewProducts")
+		Expect(peopleDataset).NotTo(BeNil(), "dataset is present")
 
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil("result is retrieved")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil(), "result is retrieved")
 
-			g.Assert(len(result.Entities)).Eql(19, "correct number of entities retrieved")
-		})
+		Expect(len(result.Entities)).To(Equal(19), "correct number of entities retrieved")
+	})
 
-		g.It("Should incrementally do internal sync with js transform in parallel when les than workers count", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("Products", nil)
-			_, _ = dsm.CreateDataset("NewProducts", nil)
+	It("Should incrementally do internal sync with js transform in parallel when les than workers count", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("Products", nil)
+		_, _ = dsm.CreateDataset("NewProducts", nil)
 
-			entities := make([]*server.Entity, 2)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entity.References["type"] = "http://data.mimiro.io/model/Person"
-			entities[0] = entity
-			entity1 := server.NewEntity("http://data.mimiro.io/people/marge", 0)
-			entity1.Properties["name"] = "marge"
-			entity1.References["type"] = "http://data.mimiro.io/model/Person"
-			entities[1] = entity1
+		entities := make([]*server.Entity, 2)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entity.References["type"] = "http://data.mimiro.io/model/Person"
+		entities[0] = entity
+		entity1 := server.NewEntity("http://data.mimiro.io/people/marge", 0)
+		entity1.Properties["name"] = "marge"
+		entity1.References["type"] = "http://data.mimiro.io/model/Person"
+		entities[1] = entity1
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("entities are stored")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "entities are stored")
 
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -483,47 +481,47 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewProducts")
-			g.Assert(peopleDataset).IsNotNil("dataset is present")
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewProducts")
+		Expect(peopleDataset).NotTo(BeNil(), "dataset is present")
 
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil("result is retrieved")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil(), "result is retrieved")
 
-			g.Assert(len(result.Entities)).Eql(2, "correct number of entities retrieved")
-		})
+		Expect(len(result.Entities)).To(Equal(2), "correct number of entities retrieved")
+	})
 
-		// func TestDatasetToDatasetWithJavascriptTransformJob(m *testing.T) {
-		g.It("Should incrementally do internal sync with js transform", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("Products", nil)
-			_, _ = dsm.CreateDataset("NewProducts", nil)
+	// func TestDatasetToDatasetWithJavascriptTransformJob(m *testing.T) {
+	It("Should incrementally do internal sync with js transform", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("Products", nil)
+		_, _ = dsm.CreateDataset("NewProducts", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entity.References["type"] = "http://data.mimiro.io/model/Person"
-			entity.References["typed"] = "http://data.mimiro.io/model/Person"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entity.References["type"] = "http://data.mimiro.io/model/Person"
+		entity.References["typed"] = "http://data.mimiro.io/model/Person"
+		entities[0] = entity
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("entities are stored")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "entities are stored")
 
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 		{
 			"id" : "sync-datasetsource-to-datasetsink-with-js",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -541,56 +539,56 @@ func TestPipeline(t *testing.T) {
 			}
 		}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewProducts")
-			g.Assert(peopleDataset).IsNotNil("dataset is present")
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewProducts")
+		Expect(peopleDataset).NotTo(BeNil(), "dataset is present")
 
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil("result is retrieved")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil(), "result is retrieved")
 
-			g.Assert(len(result.Entities)).Eql(1, "correct number of entities retrieved")
-		})
-		g.It("Should run a transform with query in internal jobs", func() {
-			testNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/test/",
-			)
-			g.Assert(err).IsNil()
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("People", nil)
-			ds1, _ := dsm.CreateDataset("Companies", nil)
-			_, _ = dsm.CreateDataset("NewPeople", nil)
+		Expect(len(result.Entities)).To(Equal(1), "correct number of entities retrieved")
+	})
+	It("Should run a transform with query in internal jobs", func() {
+		testNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/test/",
+		)
+		Expect(err).To(BeNil())
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("People", nil)
+		ds1, _ := dsm.CreateDataset("Companies", nil)
+		_, _ = dsm.CreateDataset("NewPeople", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity(testNamespacePrefix+":gra", 0)
-			entity.Properties[testNamespacePrefix+":name"] = "homer"
-			entity.References[testNamespacePrefix+":type"] = testNamespacePrefix + ":Person"
-			entity.References[testNamespacePrefix+":worksfor"] = testNamespacePrefix + ":mimiro"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity(testNamespacePrefix+":gra", 0)
+		entity.Properties[testNamespacePrefix+":name"] = "homer"
+		entity.References[testNamespacePrefix+":type"] = testNamespacePrefix + ":Person"
+		entity.References[testNamespacePrefix+":worksfor"] = testNamespacePrefix + ":mimiro"
+		entities[0] = entity
 
-			g.Assert(ds.StoreEntities(entities)).IsNil()
+		Expect(ds.StoreEntities(entities)).To(BeNil())
 
-			companies := make([]*server.Entity, 1)
-			mimiro := server.NewEntity(testNamespacePrefix+":mimiro", 0)
-			mimiro.Properties[testNamespacePrefix+":name"] = "Mimiro"
-			mimiro.References[testNamespacePrefix+":type"] = testNamespacePrefix + ":Company"
-			companies[0] = mimiro
+		companies := make([]*server.Entity, 1)
+		mimiro := server.NewEntity(testNamespacePrefix+":mimiro", 0)
+		mimiro.Properties[testNamespacePrefix+":name"] = "Mimiro"
+		mimiro.References[testNamespacePrefix+":type"] = testNamespacePrefix + ":Company"
+		companies[0] = mimiro
 
-			g.Assert(ds1.StoreEntities(companies)).IsNil()
+		Expect(ds1.StoreEntities(companies)).To(BeNil())
 
-			jsFun := `function transform_entities(entities) {
+		jsFun := `function transform_entities(entities) {
 		    var test_ns = GetNamespacePrefix("http://data.mimiro.io/test/")
 		    for (e of entities) {
 		        Log(e["ID"])
@@ -603,8 +601,8 @@ func TestPipeline(t *testing.T) {
 		    }
 		    return entities;
 		}`
-			// define job
-			jobJSON := fmt.Sprintf(`{
+		// define job
+		jobJSON := fmt.Sprintf(`{
 			"id" : "sync-datasetsource-to-datasetsink-with-js-and-query",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -620,58 +618,58 @@ func TestPipeline(t *testing.T) {
                 "Name" : "NewPeople"
 			}}`, base64.StdEncoding.EncodeToString([]byte(jsFun)))
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil())
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewPeople")
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(1)
-			g.Assert(result.Entities[0].Properties["ns3:companyname"]).Eql("Mimiro")
-		})
-		g.It("Should run a transform with subentities in internal jobs", func() {
-			testNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/test/",
-			)
-			g.Assert(err).IsNil()
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewPeople")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(1))
+		Expect(result.Entities[0].Properties["ns3:companyname"]).To(Equal("Mimiro"))
+	})
+	It("Should run a transform with subentities in internal jobs", func() {
+		testNamespacePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/test/",
+		)
+		Expect(err).To(BeNil())
 
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("People", nil)
-			_, _ = dsm.CreateDataset("NewPeople", nil)
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("People", nil)
+		_, _ = dsm.CreateDataset("NewPeople", nil)
 
-			address := server.NewEntity(testNamespacePrefix+":home", 0)
-			address.Properties[testNamespacePrefix+":street"] = "homestreet"
+		address := server.NewEntity(testNamespacePrefix+":home", 0)
+		address.Properties[testNamespacePrefix+":street"] = "homestreet"
 
-			entities := make([]*server.Entity, 2)
+		entities := make([]*server.Entity, 2)
 
-			entities[0] = server.NewEntity(testNamespacePrefix+":homer", 0)
-			entities[0].Properties[testNamespacePrefix+":name"] = "homer"
-			entities[0].Properties[testNamespacePrefix+":address"] = address
-			entities[0].Properties[testNamespacePrefix+":listref"] = []string{"//homer", "//male"}
-			entities[0].Properties[testNamespacePrefix+":ref"] = "//homer"
+		entities[0] = server.NewEntity(testNamespacePrefix+":homer", 0)
+		entities[0].Properties[testNamespacePrefix+":name"] = "homer"
+		entities[0].Properties[testNamespacePrefix+":address"] = address
+		entities[0].Properties[testNamespacePrefix+":listref"] = []string{"//homer", "//male"}
+		entities[0].Properties[testNamespacePrefix+":ref"] = "//homer"
 
-			entities[1] = server.NewEntity(testNamespacePrefix+":barney", 0)
-			entities[1].Properties[testNamespacePrefix+":name"] = "barney"
-			entities[1].Properties[testNamespacePrefix+":address"] = map[string]interface{}{
-				"id":    testNamespacePrefix + ":barn",
-				"props": map[string]interface{}{testNamespacePrefix + ":street": "barnstreet"},
-				"refs":  map[string]interface{}{},
-			}
+		entities[1] = server.NewEntity(testNamespacePrefix+":barney", 0)
+		entities[1].Properties[testNamespacePrefix+":name"] = "barney"
+		entities[1].Properties[testNamespacePrefix+":address"] = map[string]interface{}{
+			"id":    testNamespacePrefix + ":barn",
+			"props": map[string]interface{}{testNamespacePrefix + ":street": "barnstreet"},
+			"refs":  map[string]interface{}{},
+		}
 
-			g.Assert(ds.StoreEntities(entities)).IsNil()
+		Expect(ds.StoreEntities(entities)).To(BeNil())
 
-			jsFun := `function transform_entities(entities) {
+		jsFun := `function transform_entities(entities) {
 		    var test_ns = GetNamespacePrefix("http://data.mimiro.io/test/");
 			var result = [];
 		    for (e of entities) {
@@ -693,8 +691,8 @@ func TestPipeline(t *testing.T) {
 
 		    return result;
 		}`
-			// define job
-			jobJSON := fmt.Sprintf(`{
+		// define job
+		jobJSON := fmt.Sprintf(`{
 			"id" : "sync-datasetsource-to-datasetsink-with-js-and-query",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -710,45 +708,45 @@ func TestPipeline(t *testing.T) {
                 "Name" : "NewPeople"
 			}}`, base64.StdEncoding.EncodeToString([]byte(jsFun)))
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil())
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewPeople")
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(2)
-			g.Assert(result.Entities[0].Properties["ns3:street"]).Eql("homestreet")
-			g.Assert(result.Entities[0].Properties["ns3:no_address"]).IsNil()
-			g.Assert(result.Entities[0].Properties["ns3:address"]).IsNotNil()
-			g.Assert(result.Entities[1].Properties["ns3:street"]).Eql("barnstreet")
-		})
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewPeople")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(2))
+		Expect(result.Entities[0].Properties["ns3:street"]).To(Equal("homestreet"))
+		Expect(result.Entities[0].Properties["ns3:no_address"]).To(BeNil())
+		Expect(result.Entities[0].Properties["ns3:address"]).NotTo(BeNil())
+		Expect(result.Entities[1].Properties["ns3:street"]).To(Equal("barnstreet"))
+	})
 
-		g.It("Should run external transforms in internal jobs", func() {
-			ds, _ := dsm.CreateDataset("Products", nil)
-			_, _ = dsm.CreateDataset("NewProducts", nil)
+	It("Should run external transforms in internal jobs", func() {
+		ds, _ := dsm.CreateDataset("Products", nil)
+		_, _ = dsm.CreateDataset("NewProducts", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entity.References["type"] = "http://data.mimiro.io/model/Person"
-			entity.References["typed"] = "http://data.mimiro.io/model/Person"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entity.References["type"] = "http://data.mimiro.io/model/Person"
+		entity.References["typed"] = "http://data.mimiro.io/model/Person"
+		entities[0] = entity
 
-			g.Assert(ds.StoreEntities(entities)).IsNil()
+		Expect(ds.StoreEntities(entities)).To(BeNil())
 
-			// define job
-			jobJSON := `{
+		// define job
+		jobJSON := `{
 			"id" : "sync-datasetsource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -764,28 +762,28 @@ func TestPipeline(t *testing.T) {
                 "Name" : "NewProducts"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil())
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewProducts")
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(1)
-		})
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewProducts")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(1))
+	})
 
-		g.It("Should not write to the sink if an external transform endpoint is 404", func() {
-			jobJSON := ` {
+	It("Should not write to the sink if an external transform endpoint is 404", func() {
+		jobJSON := ` {
 			"id" : "sync-httpdatasetsource-to-datasetsink-1",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -797,35 +795,35 @@ func TestPipeline(t *testing.T) {
 				"Name" : "People"
 			} }`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil())
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			g.Assert(dsm.GetDataset("People")).IsZero("dataset should not exist as job failed")
-		})
+		job.Run()
+		Expect(dsm.GetDataset("People")).To(BeZero(), "dataset should not exist as job failed")
+	})
 
-		g.It("Should copy datasetsource to datasetsink in first run of internal job", func() {
-			ds, _ := dsm.CreateDataset("Products", nil)
-			_, _ = dsm.CreateDataset("NewProducts", nil)
+	It("Should copy datasetsource to datasetsink in first run of internal job", func() {
+		ds, _ := dsm.CreateDataset("Products", nil)
+		_, _ = dsm.CreateDataset("NewProducts", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entity.References["type"] = "http://data.mimiro.io/model/Person"
-			entity.References["typed"] = "http://data.mimiro.io/model/Person"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entity.References["type"] = "http://data.mimiro.io/model/Person"
+		entity.References["typed"] = "http://data.mimiro.io/model/Person"
+		entities[0] = entity
 
-			g.Assert(ds.StoreEntities(entities)).IsNil()
+		Expect(ds.StoreEntities(entities)).To(BeNil())
 
-			jobJSON := ` {
+		jobJSON := ` {
 			"id" : "sync-datasetsource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -837,30 +835,30 @@ func TestPipeline(t *testing.T) {
                 "Name" : "NewProducts"
 			} }`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil())
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// check number of entities in target dataset
-			peopleDataset := dsm.GetDataset("NewProducts")
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(1)
-		})
+		// check number of entities in target dataset
+		peopleDataset := dsm.GetDataset("NewProducts")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(1))
+	})
 
-		g.It("Should copy from samplesource to datasetsink in first run of new job", func() {
-			_, _ = dsm.CreateDataset("People", nil)
+	It("Should copy from samplesource to datasetsink in first run of new job", func() {
+		_, _ = dsm.CreateDataset("People", nil)
 
-			jobJSON := `{
+		jobJSON := `{
 			"id" : "sync-samplesource-to-datasetsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -872,30 +870,30 @@ func TestPipeline(t *testing.T) {
 				"Name" : "People"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil())
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// get entities from people dataset
-			peopleDataset := dsm.GetDataset("People")
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(1)
-		})
+		// get entities from people dataset
+		peopleDataset := dsm.GetDataset("People")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(1))
+	})
 
-		g.It("Should copy from HttpDatasetSource to datasetSink in first run of new job", func() {
-			_, _ = dsm.CreateDataset("People", nil)
+	It("Should copy from HttpDatasetSource to datasetSink in first run of new job", func() {
+		_, _ = dsm.CreateDataset("People", nil)
 
-			jobJSON := `{
+		jobJSON := `{
 			"id" : "sync-httpdatasetsource-to-datasetsink-1",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -907,31 +905,31 @@ func TestPipeline(t *testing.T) {
 				"Name" : "People"
 			}}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil())
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			// get entities from people dataset
-			peopleDataset := dsm.GetDataset("People")
-			result, err := peopleDataset.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(10)
-		})
-		g.It(
-			"Should copy all pages using continuatin tokens from httpDatasetSource to datasetSink if first run",
-			func() {
-				_, _ = dsm.CreateDataset("People", nil)
+		// get entities from people dataset
+		peopleDataset := dsm.GetDataset("People")
+		result, err := peopleDataset.GetEntities("", 50)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(10))
+	})
+	It(
+		"Should copy all pages using continuatin tokens from httpDatasetSource to datasetSink if first run",
+		func() {
+			_, _ = dsm.CreateDataset("People", nil)
 
-				jobJSON := `{
+			jobJSON := `{
 					"id" : "sync-httpdatasetsource-to-datasetsink-1",
 					"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 					"source" : {
@@ -943,350 +941,350 @@ func TestPipeline(t *testing.T) {
 						"Name" : "People"
 					} }`
 
-				jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-				pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-				g.Assert(err).IsNil()
+			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+			Expect(err).To(BeNil())
 
-				job := &job{
-					id:       jobConfig.ID,
-					pipeline: pipeline,
-					schedule: jobConfig.Triggers[0].Schedule,
-					runner:   runner,
-				}
-
-				// run once
-				job.Run()
-
-				// get entities from people dataset
-				peopleDataset := dsm.GetDataset("People")
-				result, err := peopleDataset.GetEntities("", 50)
-				g.Assert(err).IsNil()
-				g.Assert(len(result.Entities)).Eql(20)
-
-				// run again
-				job.Run()
-				peopleDataset = dsm.GetDataset("People")
-				result, err = peopleDataset.GetEntities("", 50)
-				g.Assert(err).IsNil()
-				g.Assert(len(result.Entities)).Eql(20, "results should stay the same")
-			},
-		)
-
-		g.It(
-			"Should mark entities that have not been received again during fullsync to internal dataset as deleted",
-			func() {
-				sourceDs, _ := dsm.CreateDataset("people", nil)
-				sinkDs, _ := dsm.CreateDataset("people2", nil)
-
-				e1 := server.NewEntity("1", 0)
-				e2 := server.NewEntity("2", 0)
-				_ = sourceDs.StoreEntities([]*server.Entity{e1, e2})
-
-				pipeline := &FullSyncPipeline{PipelineSpec{
-					source: &source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm},
-					sink:   &datasetSink{DatasetName: "people2", Store: store, DatasetManager: dsm},
-				}}
-
-				job := &job{id: "fullsync-1", pipeline: pipeline, runner: runner}
-
-				// run once, both entities should sync
-				job.Run()
-
-				res, err := sinkDs.GetEntities("", 100)
-				g.Assert(err).IsNil()
-				g.Assert(len(res.Entities)).Eql(2)
-				g.Assert(res.Entities[0].ID).Eql("1")
-				g.Assert(res.Entities[0].IsDeleted).Eql(false)
-				g.Assert(res.Entities[1].ID).Eql("2")
-				g.Assert(res.Entities[1].IsDeleted).Eql(false)
-
-				// delete ds and recreate with only 1 entity
-				g.Assert(dsm.DeleteDataset("people")).IsNil()
-				sourceDs, _ = dsm.CreateDataset("people", nil)
-				g.Assert(sourceDs.StoreEntities([]*server.Entity{e2})).IsNil()
-
-				// run again. deletion detection should apply
-				job.Run()
-
-				res, err = sinkDs.GetEntities("", 100)
-				g.Assert(err).IsNil()
-				g.Assert(len(res.Entities)).Eql(2)
-				g.Assert(res.Entities[0].ID).Eql("1")
-				g.Assert(res.Entities[0].IsDeleted).Eql(true, "Entity 1 should be deleted now")
-				g.Assert(res.Entities[1].ID).Eql("2")
-				g.Assert(res.Entities[1].IsDeleted).Eql(false)
-			},
-		)
-		g.It("Should store continuation token after every page in incremental job", func() {
-			pipeline := &IncrementalPipeline{PipelineSpec{
-				batchSize: 5,
-				source:    &source.SampleSource{NumberOfEntities: 10, Store: store},
-				sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/inctest/fullsync", Store: store},
-			}}
-			job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
-
-			// run async, so we can verify tokens in parallel
-			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				job.Run()
-				wg.Done()
-			}()
-
-			// block and wait for channel notification - indicating the first page/batch has been received
-			<-mockService.HTTPNotificationChannel
-			g.Assert(len(mockService.getRecordedEntitiesForDataset("inctest"))).
-				Eql(5, "After first batch, 5 entities should have been postet to httpSink")
-
-			// block for next batch request finished - this should be before syncState is updated
-			<-mockService.HTTPNotificationChannel
-			syncJobState := &SyncJobState{}
-			err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token := syncJobState.ContinuationToken
-			g.Assert(token).Eql("5", "Between batch 1 and 2, token should be continuation of batch 1")
-
-			wg.Wait()
-			syncJobState = &SyncJobState{}
-			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token = syncJobState.ContinuationToken
-			g.Assert(token).Eql("10")
-		})
-		g.It("Should store continuation token only after finished run in fullsync job", func() {
-			pipeline := &FullSyncPipeline{PipelineSpec{
-				batchSize: 5,
-				source:    &source.SampleSource{NumberOfEntities: 10, Store: store},
-				// sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
-				sink: &devNullSink{},
-			}}
-			job := &job{id: "full-1", pipeline: pipeline, runner: runner}
-
-			// run async, so we can verify tokens in parallel
-			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				job.Run()
-				wg.Done()
-			}()
-			//block and wait for channel notification - indicating the first page/batch has been received
-			//_ = <-mockService.HttpNotificationChannel
-			//g.Assert(len(mockService.getRecordedEntitiesForDataset("fulltest"))).
-			//	Eql(5, "After first batch, 5 entities should have been postet to httpSink")
-
-			//wait for first syncState (token) update in badger (should be in db when 2nd batch arrives)
-			//_ = <-mockService.HttpNotificationChannel
-			syncJobState := &SyncJobState{}
-			err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token := syncJobState.ContinuationToken
-			g.Assert(token).Eql("", "there should not be a token stored after first batch")
-
-			// wait for job to finish
-			wg.Wait()
-			syncJobState = &SyncJobState{}
-			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token = syncJobState.ContinuationToken
-			g.Assert(token).Eql("10", "First after job there should be a token")
-		})
-
-		g.It("Should post changes to HttpDatasetSink endpoint if jobType is incremental", func() {
-			srcDs, _ := dsm.CreateDataset("src", nil)
-			e1 := server.NewEntity("1", 0)
-			e2 := server.NewEntity("2", 0)
-			_ = srcDs.StoreEntities([]*server.Entity{e1, e2})
-			e1.IsDeleted = true
-			_ = srcDs.StoreEntities([]*server.Entity{e1})
-			e1.IsDeleted = false
-			_ = srcDs.StoreEntities([]*server.Entity{e1})
-
-			var sourceChanges []*server.Entity
-			_, err := srcDs.ProcessChanges(0, 100, false, func(entity *server.Entity) {
-				sourceChanges = append(sourceChanges, entity)
-			})
-			g.Assert(err).IsNil()
-			g.Assert(len(sourceChanges)).Eql(4, "Expected 4 changes for our two entities in source")
-
-			pipeline := &IncrementalPipeline{PipelineSpec{
-				batchSize: 5,
-				source:    &source.DatasetSource{DatasetName: "src", Store: store, DatasetManager: dsm},
-				sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/inctest/fullsync", Store: store},
-			}}
-			job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
-			job.Run()
-			sinkChanges := mockService.getRecordedEntitiesForDataset("inctest")
-			g.Assert(len(sinkChanges)).Eql(4, "Expected all 4 changes in sink for incremental")
-		})
-
-		g.It("Should post entities to HttpDatasetSink endpoint if jobType is fullsync", func() {
-			srcDs, _ := dsm.CreateDataset("src", nil)
-			e1 := server.NewEntity("1", 0)
-			e2 := server.NewEntity("2", 0)
-			_ = srcDs.StoreEntities([]*server.Entity{e1, e2})
-			e1.IsDeleted = true
-			_ = srcDs.StoreEntities([]*server.Entity{e1})
-			e1.IsDeleted = false
-			_ = srcDs.StoreEntities([]*server.Entity{e1})
-
-			var sourceChanges []*server.Entity
-			_, err := srcDs.ProcessChanges(0, 100, false, func(entity *server.Entity) {
-				sourceChanges = append(sourceChanges, entity)
-			})
-			g.Assert(err).IsNil()
-			g.Assert(len(sourceChanges)).Eql(4, "Expected 4 changes for our two entities in source")
-
-			pipeline := &FullSyncPipeline{PipelineSpec{
-				batchSize: 5,
-				source:    &source.DatasetSource{DatasetName: "src", Store: store, DatasetManager: dsm},
-				sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
-			}}
-			job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
-			job.Run()
-			sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
-			g.Assert(len(sinkChanges)).Eql(2, "Expected only 2 entities in current state in fullsync")
-		})
-
-		g.It("Should store dependency watermarks after fullsync in MultiSource jobs", func() {
-			srcDs, _ := dsm.CreateDataset("src", nil)
-			_ = srcDs.StoreEntities([]*server.Entity{
-				server.NewEntity("1", 0),
-				server.NewEntity("2", 0),
-			})
-
-			depDs, _ := dsm.CreateDataset("dep", nil)
-			_ = depDs.StoreEntities([]*server.Entity{
-				server.NewEntity("3", 0),
-				server.NewEntity("4", 0),
-				server.NewEntity("5", 0),
-			})
-
-			pipeline := &FullSyncPipeline{PipelineSpec{
-				batchSize: 5,
-				source: &source.MultiSource{
-					DatasetName:    "src",
-					Store:          store,
-					DatasetManager: dsm,
-					Dependencies: []source.Dependency{
-						{
-							Dataset: "dep",
-							Joins:   []source.Join{{Dataset: "src", Predicate: "http:/a/predicate", Inverse: false}},
-						},
-					},
-				},
-				sink: &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
-			}}
-			job := &job{id: "fs-1", pipeline: pipeline, runner: runner}
-			job.Run()
-
-			sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
-			g.Assert(len(sinkChanges)).Eql(2, "Expected only 2 entities in current state in fullsync")
-
-			syncJobState := &SyncJobState{}
-			err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token := syncJobState.ContinuationToken
-			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"3\"}}}",
-				"after job there should be a token")
-		})
-
-		g.It("Should store dependency watermarks after incremental in MultiSource jobs", func() {
-			srcDs, _ := dsm.CreateDataset("src", nil)
-			ns, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://namespace/")
-			_ = srcDs.StoreEntities([]*server.Entity{
-				server.NewEntity(ns+":1", 0),
-				server.NewEntity(ns+":2", 0),
-			})
-
-			depDs, _ := dsm.CreateDataset("dep", nil)
-			_ = depDs.StoreEntities([]*server.Entity{
-				server.NewEntity(ns+":3", 0),
-				server.NewEntity(ns+":4", 0),
-				server.NewEntity(ns+":5", 0),
-			})
-
-			pipeline := &IncrementalPipeline{PipelineSpec{
-				batchSize: 5,
-				source: &source.MultiSource{
-					DatasetName:    "src",
-					Store:          store,
-					DatasetManager: dsm,
-					Dependencies: []source.Dependency{
-						{
-							Dataset: "dep",
-							Joins:   []source.Join{{Dataset: "src", Predicate: ns + ":predicate", Inverse: false}},
-						},
-					},
-				},
-				sink: &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
-			}}
-			job := &job{id: "fs-1", pipeline: pipeline, runner: runner}
-			job.Run()
-
-			sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
-			g.Assert(len(sinkChanges)).Eql(2, "Expected only 2 entities")
-
-			syncJobState := &SyncJobState{}
-			err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token := syncJobState.ContinuationToken
-			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"3\"}}}",
-				"after job there should be a token")
-
-			// reset recorder
-			for k := range mockService.RecordedEntities {
-				delete(mockService.RecordedEntities, k)
-			}
-			// add dependency link
-			e := server.NewEntity(ns+":5", 0)
-			e.References[ns+":predicate"] = ns + ":1"
-			_ = depDs.StoreEntities([]*server.Entity{e})
-
-			job.Run()
-
-			sinkChanges = mockService.getRecordedEntitiesForDataset("fulltest")
-			g.Assert(len(sinkChanges)).Eql(1, "Expected only 1 entity (id=1 was linked to by dependency)")
-			g.Assert(sinkChanges[0].ID).Eql(ns+":1", "new dependency points to id 1")
-
-			syncJobState = &SyncJobState{}
-			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token = syncJobState.ContinuationToken
-			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"4\"}}}",
-				"dependency watermarks should be forwarded by 1")
-
-			// reset recorder
-			for k := range mockService.RecordedEntities {
-				delete(mockService.RecordedEntities, k)
+			job := &job{
+				id:       jobConfig.ID,
+				pipeline: pipeline,
+				schedule: jobConfig.Triggers[0].Schedule,
+				runner:   runner,
 			}
 
-			// run one more time without changes to source data, make sure nothing is done
+			// run once
 			job.Run()
 
-			sinkChanges = mockService.getRecordedEntitiesForDataset("fulltest")
-			g.Assert(len(sinkChanges)).Eql(0)
+			// get entities from people dataset
+			peopleDataset := dsm.GetDataset("People")
+			result, err := peopleDataset.GetEntities("", 50)
+			Expect(err).To(BeNil())
+			Expect(len(result.Entities)).To(Equal(20))
 
-			syncJobState = &SyncJobState{}
-			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token = syncJobState.ContinuationToken
-			g.Assert(token).Eql("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"4\"}}}",
-				"dependency watermarks should be unchanged")
+			// run again
+			job.Run()
+			peopleDataset = dsm.GetDataset("People")
+			result, err = peopleDataset.GetEntities("", 50)
+			Expect(err).To(BeNil())
+			Expect(len(result.Entities)).To(Equal(20), "results should stay the same")
+		},
+	)
+
+	It(
+		"Should mark entities that have not been received again during fullsync to internal dataset as deleted",
+		func() {
+			sourceDs, _ := dsm.CreateDataset("people", nil)
+			sinkDs, _ := dsm.CreateDataset("people2", nil)
+
+			e1 := server.NewEntity("1", 0)
+			e2 := server.NewEntity("2", 0)
+			_ = sourceDs.StoreEntities([]*server.Entity{e1, e2})
+
+			pipeline := &FullSyncPipeline{PipelineSpec{
+				source: &source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm},
+				sink:   &datasetSink{DatasetName: "people2", Store: store, DatasetManager: dsm},
+			}}
+
+			job := &job{id: "fullsync-1", pipeline: pipeline, runner: runner}
+
+			// run once, both entities should sync
+			job.Run()
+
+			res, err := sinkDs.GetEntities("", 100)
+			Expect(err).To(BeNil())
+			Expect(len(res.Entities)).To(Equal(2))
+			Expect(res.Entities[0].ID).To(Equal("1"))
+			Expect(res.Entities[0].IsDeleted).To(Equal(false))
+			Expect(res.Entities[1].ID).To(Equal("2"))
+			Expect(res.Entities[1].IsDeleted).To(Equal(false))
+
+			// delete ds and recreate with only 1 entity
+			Expect(dsm.DeleteDataset("people")).To(BeNil())
+			sourceDs, _ = dsm.CreateDataset("people", nil)
+			Expect(sourceDs.StoreEntities([]*server.Entity{e2})).To(BeNil())
+
+			// run again. deletion detection should apply
+			job.Run()
+
+			res, err = sinkDs.GetEntities("", 100)
+			Expect(err).To(BeNil())
+			Expect(len(res.Entities)).To(Equal(2))
+			Expect(res.Entities[0].ID).To(Equal("1"))
+			Expect(res.Entities[0].IsDeleted).To(Equal(true), "Entity 1 should be deleted now")
+			Expect(res.Entities[1].ID).To(Equal("2"))
+			Expect(res.Entities[1].IsDeleted).To(Equal(false))
+		},
+	)
+	It("Should store continuation token after every page in incremental job", func() {
+		pipeline := &IncrementalPipeline{PipelineSpec{
+			batchSize: 5,
+			source:    &source.SampleSource{NumberOfEntities: 10, Store: store},
+			sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/inctest/fullsync", Store: store},
+		}}
+		job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
+
+		// run async, so we can verify tokens in parallel
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			job.Run()
+			wg.Done()
+		}()
+
+		// block and wait for channel notification - indicating the first page/batch has been received
+		<-mockService.HTTPNotificationChannel
+		Expect(len(mockService.getRecordedEntitiesForDataset("inctest"))).
+			To(Equal(5), "After first batch, 5 entities should have been postet to httpSink")
+
+		// block for next batch request finished - this should be before syncState is updated
+		<-mockService.HTTPNotificationChannel
+		syncJobState := &SyncJobState{}
+		err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token := syncJobState.ContinuationToken
+		Expect(token).To(Equal("5"), "Between batch 1 and 2, token should be continuation of batch 1")
+
+		wg.Wait()
+		syncJobState = &SyncJobState{}
+		err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token = syncJobState.ContinuationToken
+		Expect(token).To(Equal("10"))
+	})
+	It("Should store continuation token only after finished run in fullsync job", func() {
+		pipeline := &FullSyncPipeline{PipelineSpec{
+			batchSize: 5,
+			source:    &source.SampleSource{NumberOfEntities: 10, Store: store},
+			// sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
+			sink: &devNullSink{},
+		}}
+		job := &job{id: "full-1", pipeline: pipeline, runner: runner}
+
+		// run async, so we can verify tokens in parallel
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			job.Run()
+			wg.Done()
+		}()
+		//block and wait for channel notification - indicating the first page/batch has been received
+		//_ = <-mockService.HttpNotificationChannel
+		//Expect(len(mockService.getRecordedEntitiesForDataset("fulltest"))).
+		//	To(Equal(5, "After first batch, 5 entities should have been postet to httpSink"))
+
+		//wait for first syncState (token) update in badger (should be in db when 2nd batch arrives)
+		//_ = <-mockService.HttpNotificationChannel
+		syncJobState := &SyncJobState{}
+		err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token := syncJobState.ContinuationToken
+		Expect(token).To(Equal(""), "there should not be a token stored after first batch")
+
+		// wait for job to finish
+		wg.Wait()
+		syncJobState = &SyncJobState{}
+		err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token = syncJobState.ContinuationToken
+		Expect(token).To(Equal("10"), "First after job there should be a token")
+	})
+
+	It("Should post changes to HttpDatasetSink endpoint if jobType is incremental", func() {
+		srcDs, _ := dsm.CreateDataset("src", nil)
+		e1 := server.NewEntity("1", 0)
+		e2 := server.NewEntity("2", 0)
+		_ = srcDs.StoreEntities([]*server.Entity{e1, e2})
+		e1.IsDeleted = true
+		_ = srcDs.StoreEntities([]*server.Entity{e1})
+		e1.IsDeleted = false
+		_ = srcDs.StoreEntities([]*server.Entity{e1})
+
+		var sourceChanges []*server.Entity
+		_, err := srcDs.ProcessChanges(0, 100, false, func(entity *server.Entity) {
+			sourceChanges = append(sourceChanges, entity)
 		})
-		g.It("Should not store UnionDatasetContinuation after fullsync on UnionDatasetSource", func() {
-			ds1, _ := dsm.CreateDataset("src1", nil)
-			_ = ds1.StoreEntities([]*server.Entity{
-				server.NewEntity("1", 0),
-				server.NewEntity("2", 0),
-			})
-			ds2, _ := dsm.CreateDataset("src2", nil)
-			_ = ds2.StoreEntities([]*server.Entity{
-				server.NewEntity("3", 0),
-				server.NewEntity("4", 0),
-				server.NewEntity("5", 0),
-			})
+		Expect(err).To(BeNil())
+		Expect(len(sourceChanges)).To(Equal(4), "Expected 4 changes for our two entities in source")
 
-			jobJSON := ` {
+		pipeline := &IncrementalPipeline{PipelineSpec{
+			batchSize: 5,
+			source:    &source.DatasetSource{DatasetName: "src", Store: store, DatasetManager: dsm},
+			sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/inctest/fullsync", Store: store},
+		}}
+		job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
+		job.Run()
+		sinkChanges := mockService.getRecordedEntitiesForDataset("inctest")
+		Expect(len(sinkChanges)).To(Equal(4), "Expected all 4 changes in sink for incremental")
+	})
+
+	It("Should post entities to HttpDatasetSink endpoint if jobType is fullsync", func() {
+		srcDs, _ := dsm.CreateDataset("src", nil)
+		e1 := server.NewEntity("1", 0)
+		e2 := server.NewEntity("2", 0)
+		_ = srcDs.StoreEntities([]*server.Entity{e1, e2})
+		e1.IsDeleted = true
+		_ = srcDs.StoreEntities([]*server.Entity{e1})
+		e1.IsDeleted = false
+		_ = srcDs.StoreEntities([]*server.Entity{e1})
+
+		var sourceChanges []*server.Entity
+		_, err := srcDs.ProcessChanges(0, 100, false, func(entity *server.Entity) {
+			sourceChanges = append(sourceChanges, entity)
+		})
+		Expect(err).To(BeNil())
+		Expect(len(sourceChanges)).To(Equal(4), "Expected 4 changes for our two entities in source")
+
+		pipeline := &FullSyncPipeline{PipelineSpec{
+			batchSize: 5,
+			source:    &source.DatasetSource{DatasetName: "src", Store: store, DatasetManager: dsm},
+			sink:      &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
+		}}
+		job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
+		job.Run()
+		sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
+		Expect(len(sinkChanges)).To(Equal(2), "Expected only 2 entities in current state in fullsync")
+	})
+
+	It("Should store dependency watermarks after fullsync in MultiSource jobs", func() {
+		srcDs, _ := dsm.CreateDataset("src", nil)
+		_ = srcDs.StoreEntities([]*server.Entity{
+			server.NewEntity("1", 0),
+			server.NewEntity("2", 0),
+		})
+
+		depDs, _ := dsm.CreateDataset("dep", nil)
+		_ = depDs.StoreEntities([]*server.Entity{
+			server.NewEntity("3", 0),
+			server.NewEntity("4", 0),
+			server.NewEntity("5", 0),
+		})
+
+		pipeline := &FullSyncPipeline{PipelineSpec{
+			batchSize: 5,
+			source: &source.MultiSource{
+				DatasetName:    "src",
+				Store:          store,
+				DatasetManager: dsm,
+				Dependencies: []source.Dependency{
+					{
+						Dataset: "dep",
+						Joins:   []source.Join{{Dataset: "src", Predicate: "http:/a/predicate", Inverse: false}},
+					},
+				},
+			},
+			sink: &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
+		}}
+		job := &job{id: "fs-1", pipeline: pipeline, runner: runner}
+		job.Run()
+
+		sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
+		Expect(len(sinkChanges)).To(Equal(2), "Expected only 2 entities in current state in fullsync")
+
+		syncJobState := &SyncJobState{}
+		err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token := syncJobState.ContinuationToken
+		Expect(token).To(Equal("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"3\"}}}"),
+			"after job there should be a token")
+	})
+
+	It("Should store dependency watermarks after incremental in MultiSource jobs", func() {
+		srcDs, _ := dsm.CreateDataset("src", nil)
+		ns, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://namespace/")
+		_ = srcDs.StoreEntities([]*server.Entity{
+			server.NewEntity(ns+":1", 0),
+			server.NewEntity(ns+":2", 0),
+		})
+
+		depDs, _ := dsm.CreateDataset("dep", nil)
+		_ = depDs.StoreEntities([]*server.Entity{
+			server.NewEntity(ns+":3", 0),
+			server.NewEntity(ns+":4", 0),
+			server.NewEntity(ns+":5", 0),
+		})
+
+		pipeline := &IncrementalPipeline{PipelineSpec{
+			batchSize: 5,
+			source: &source.MultiSource{
+				DatasetName:    "src",
+				Store:          store,
+				DatasetManager: dsm,
+				Dependencies: []source.Dependency{
+					{
+						Dataset: "dep",
+						Joins:   []source.Join{{Dataset: "src", Predicate: ns + ":predicate", Inverse: false}},
+					},
+				},
+			},
+			sink: &httpDatasetSink{Endpoint: "http://localhost:7777/datasets/fulltest/fullsync", Store: store},
+		}}
+		job := &job{id: "fs-1", pipeline: pipeline, runner: runner}
+		job.Run()
+
+		sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
+		Expect(len(sinkChanges)).To(Equal(2), "Expected only 2 entities")
+
+		syncJobState := &SyncJobState{}
+		err := store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token := syncJobState.ContinuationToken
+		Expect(token).To(Equal("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"3\"}}}"),
+			"after job there should be a token")
+
+		// reset recorder
+		for k := range mockService.RecordedEntities {
+			delete(mockService.RecordedEntities, k)
+		}
+		// add dependency link
+		e := server.NewEntity(ns+":5", 0)
+		e.References[ns+":predicate"] = ns + ":1"
+		_ = depDs.StoreEntities([]*server.Entity{e})
+
+		job.Run()
+
+		sinkChanges = mockService.getRecordedEntitiesForDataset("fulltest")
+		Expect(len(sinkChanges)).To(Equal(1), "Expected only 1 entity (id=1 was linked to by dependency)")
+		Expect(sinkChanges[0].ID).To(Equal(ns+":1"), "new dependency points to id 1")
+
+		syncJobState = &SyncJobState{}
+		err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token = syncJobState.ContinuationToken
+		Expect(token).To(Equal("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"4\"}}}"),
+			"dependency watermarks should be forwarded by 1")
+
+		// reset recorder
+		for k := range mockService.RecordedEntities {
+			delete(mockService.RecordedEntities, k)
+		}
+
+		// run one more time without changes to source data, make sure nothing is done
+		job.Run()
+
+		sinkChanges = mockService.getRecordedEntitiesForDataset("fulltest")
+		Expect(len(sinkChanges)).To(Equal(0))
+
+		syncJobState = &SyncJobState{}
+		err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token = syncJobState.ContinuationToken
+		Expect(token).To(Equal("{\"MainToken\":\"2\",\"DependencyTokens\":{\"dep\":{\"Token\":\"4\"}}}"),
+			"dependency watermarks should be unchanged")
+	})
+	It("Should not store UnionDatasetContinuation after fullsync on UnionDatasetSource", func() {
+		ds1, _ := dsm.CreateDataset("src1", nil)
+		_ = ds1.StoreEntities([]*server.Entity{
+			server.NewEntity("1", 0),
+			server.NewEntity("2", 0),
+		})
+		ds2, _ := dsm.CreateDataset("src2", nil)
+		_ = ds2.StoreEntities([]*server.Entity{
+			server.NewEntity("3", 0),
+			server.NewEntity("4", 0),
+			server.NewEntity("5", 0),
+		})
+
+		jobJSON := ` {
 			"id" : "sync-uniondatasetsource-to-nullsink",
 			"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
 			"source" : {
@@ -1298,37 +1296,37 @@ func TestPipeline(t *testing.T) {
 				"Url":"http://localhost:7777/datasets/fulltest/fullsync"
 			} }`
 
-			jobConfig, err := scheduler.Parse([]byte(jobJSON))
-			g.Assert(err).IsNil()
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
-			g.Assert(err).IsNil()
-			job := &job{id: "fs-1", pipeline: pipeline, runner: runner}
-			job.Run()
+		jobConfig, err := scheduler.Parse([]byte(jobJSON))
+		Expect(err).To(BeNil())
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
+		Expect(err).To(BeNil())
+		job := &job{id: "fs-1", pipeline: pipeline, runner: runner}
+		job.Run()
 
-			sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
-			g.Assert(len(sinkChanges)).Eql(5, "Expected 5 entities in current state in fullsync")
+		sinkChanges := mockService.getRecordedEntitiesForDataset("fulltest")
+		Expect(len(sinkChanges)).To(Equal(5), "Expected 5 entities in current state in fullsync")
 
-			syncJobState := &SyncJobState{}
-			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token := syncJobState.ContinuationToken
-			g.Assert(token).Eql("",
-				"after job there should be NO token because fullsync uses entities towards httpsink")
+		syncJobState := &SyncJobState{}
+		err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token := syncJobState.ContinuationToken
+		Expect(token).To(Equal(""),
+			"after job there should be NO token because fullsync uses entities towards httpsink")
+	})
+	It("Should store UnionDatasetContinuation after incremental on UnionDatasetSource", func() {
+		ds1, _ := dsm.CreateDataset("src1", nil)
+		_ = ds1.StoreEntities([]*server.Entity{
+			server.NewEntity("1", 0),
+			server.NewEntity("2", 0),
 		})
-		g.It("Should store UnionDatasetContinuation after incremental on UnionDatasetSource", func() {
-			ds1, _ := dsm.CreateDataset("src1", nil)
-			_ = ds1.StoreEntities([]*server.Entity{
-				server.NewEntity("1", 0),
-				server.NewEntity("2", 0),
-			})
-			ds2, _ := dsm.CreateDataset("src2", nil)
-			_ = ds2.StoreEntities([]*server.Entity{
-				server.NewEntity("3", 0),
-				server.NewEntity("4", 0),
-				server.NewEntity("5", 0),
-			})
+		ds2, _ := dsm.CreateDataset("src2", nil)
+		_ = ds2.StoreEntities([]*server.Entity{
+			server.NewEntity("3", 0),
+			server.NewEntity("4", 0),
+			server.NewEntity("5", 0),
+		})
 
-			jobJSON := ` {
+		jobJSON := ` {
 			"id" : "sync-uniondatasetsource-to-nullsink",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
 			"source" : {
@@ -1340,38 +1338,38 @@ func TestPipeline(t *testing.T) {
 				"Url":"http://localhost:7777/datasets/inctest/fullsync"
 			} }`
 
-			jobConfig, err := scheduler.Parse([]byte(jobJSON))
-			g.Assert(err).IsNil()
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil()
-			job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
-			job.Run()
+		jobConfig, err := scheduler.Parse([]byte(jobJSON))
+		Expect(err).To(BeNil())
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil())
+		job := &job{id: "inc-1", pipeline: pipeline, runner: runner}
+		job.Run()
 
-			sinkChanges := mockService.getRecordedEntitiesForDataset("inctest")
-			g.Assert(len(sinkChanges)).Eql(5, "Expected 5 entities in current state")
+		sinkChanges := mockService.getRecordedEntitiesForDataset("inctest")
+		Expect(len(sinkChanges)).To(Equal(5), "Expected 5 entities in current state")
 
-			syncJobState := &SyncJobState{}
-			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			token := syncJobState.ContinuationToken
-			g.Assert(token).
-				Eql("{\"Tokens\":[{\"Token\":\"2\"},{\"Token\":\"3\"}],\"DatasetNames\":[\"src1\",\"src2\"]}",
-					"after job there should be a token stored")
-		})
-		g.It("Should fail run and return error when error in transform js", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("Products", nil)
+		syncJobState := &SyncJobState{}
+		err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		token := syncJobState.ContinuationToken
+		Expect(token).To(Equal(
+			"{\"Tokens\":[{\"Token\":\"2\"},{\"Token\":\"3\"}],\"DatasetNames\":[\"src1\",\"src2\"]}"),
+			"after job there should be a token stored")
+	})
+	It("Should fail run and return error when error in transform js", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("Products", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entities[0] = entity
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("entities are stored")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "entities are stored")
 
-			// transform js
-			js := `
+		// transform js
+		js := `
 			function transform_entities(entities) {
 				for (e of entities) {
 					var something = null;
@@ -1380,10 +1378,10 @@ func TestPipeline(t *testing.T) {
 				return entities;
 			}
 			`
-			jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
+		jscriptEnc := base64.StdEncoding.EncodeToString([]byte(js))
 
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 			{
 				"id" : "sync-datasetsource-to-datasetsink-with-js",
 				"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -1400,41 +1398,41 @@ func TestPipeline(t *testing.T) {
 					"Type" : "DevNullSink"
 				}
 			}`
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed")
-			g.Assert(pipeline.spec().source.(*source.DatasetSource).LatestOnly).IsTrue()
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed")
+		Expect(pipeline.spec().source.(*source.DatasetSource).LatestOnly).To(BeTrue())
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
+		job.Run()
 
-			syncJobState := &SyncJobState{}
-			err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
-			g.Assert(err).IsNil()
-			g.Assert(syncJobState.LastRunCompletedOk).IsFalse()
+		syncJobState := &SyncJobState{}
+		err = store.GetObject(server.JobDataIndex, job.id, syncJobState)
+		Expect(err).To(BeNil())
+		Expect(syncJobState.LastRunCompletedOk).To(BeFalse())
 
-			jobResult := &jobResult{}
-			err = store.GetObject(server.JobResultIndex, job.id, jobResult)
-			g.Assert(err).IsNil()
-			g.Assert(jobResult.LastError == "").IsFalse()
+		jobResult := &jobResult{}
+		err = store.GetObject(server.JobResultIndex, job.id, jobResult)
+		Expect(err).To(BeNil())
+		Expect(jobResult.LastError == "").To(BeFalse())
+	})
+
+	It("Should support proxy dataset as incremental datasetSource", func() {
+		_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
+			ProxyDatasetConfig: &server.ProxyDatasetConfig{
+				RemoteURL: "http://localhost:7777/datasets/people",
+			},
 		})
+		Expect(err).To(BeNil())
 
-		g.It("Should support proxy dataset as incremental datasetSource", func() {
-			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
-				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteURL: "http://localhost:7777/datasets/people",
-				},
-			})
-			g.Assert(err).IsNil()
-
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 			{
 				"id" : "sync-proxydatasetsource-to-httpdatasetsink",
 				"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -1448,32 +1446,32 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed correctly")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed correctly")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			g.Assert(len(mockService.RecordedEntities["proxysink"])).Eql(11, "sink received content")
-			g.Assert(mockService.RecordedEntities["proxysink"][1].ID).Eql("ns3:e-0", "sink received entity from proxy")
+		job.Run()
+		Expect(len(mockService.RecordedEntities["proxysink"])).To(Equal(11), "sink received content")
+		Expect(mockService.RecordedEntities["proxysink"][1].ID).To(Equal("ns3:e-0"), "sink received entity from proxy")
+	})
+
+	It("Should support proxy dataset as fullsync datasetSource", func() {
+		_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
+			ProxyDatasetConfig: &server.ProxyDatasetConfig{
+				RemoteURL: "http://localhost:7777/datasets/people",
+			},
 		})
+		Expect(err).To(BeNil())
 
-		g.It("Should support proxy dataset as fullsync datasetSource", func() {
-			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
-				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteURL: "http://localhost:7777/datasets/people",
-				},
-			})
-			g.Assert(err).IsNil()
-
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 			{
 				"id" : "sync-proxydatasetsource-to-httpdatasetsink",
 				"triggers": [{"triggerType": "cron", "jobType": "fullsync", "schedule": "@every 2s"}],
@@ -1487,34 +1485,34 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
-			g.Assert(err).IsNil("pipeline is parsed correctly")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
+		Expect(err).To(BeNil(), "pipeline is parsed correctly")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			ents := mockService.getRecordedEntitiesForDataset("proxysink")
-			g.Assert(len(ents)).Eql(10, "sink received content")
-			g.Assert(ents[0].ID).Eql("ns3:fs-0", "sink received entity from proxy")
+		job.Run()
+		ents := mockService.getRecordedEntitiesForDataset("proxysink")
+		Expect(len(ents)).To(Equal(10), "sink received content")
+		Expect(ents[0].ID).To(Equal("ns3:fs-0"), "sink received entity from proxy")
+	})
+
+	It("Should support proxy dataset as incremental datasetSink", func() {
+		_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
+			ProxyDatasetConfig: &server.ProxyDatasetConfig{
+				RemoteURL:        "http://localhost:7777/datasets/people",
+				AuthProviderName: "local",
+			},
 		})
+		Expect(err).To(BeNil())
 
-		g.It("Should support proxy dataset as incremental datasetSink", func() {
-			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
-				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteURL:        "http://localhost:7777/datasets/people",
-					AuthProviderName: "local",
-				},
-			})
-			g.Assert(err).IsNil()
-
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 			{
 				"id" : "sync-proxydatasetsource-to-httpdatasetsink",
 				"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -1528,53 +1526,53 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
-			g.Assert(err).IsNil("pipeline is parsed correctly")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeIncremental)
+		Expect(err).To(BeNil(), "pipeline is parsed correctly")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			var receivedMockRequests []*http.Request
-			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for afterCh := time.After(100 * time.Millisecond); ; {
-					select {
-					case d := <-mockService.HTTPNotificationChannel:
-						receivedMockRequests = append(receivedMockRequests, d)
-					case <-afterCh:
-						return
-					}
+		job.Run()
+		var receivedMockRequests []*http.Request
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for afterCh := time.After(100 * time.Millisecond); ; {
+				select {
+				case d := <-mockService.HTTPNotificationChannel:
+					receivedMockRequests = append(receivedMockRequests, d)
+				case <-afterCh:
+					return
 				}
-			}()
-			wg.Wait()
-			g.Assert(len(receivedMockRequests) > 0).IsTrue()
-			firstSinkReq := receivedMockRequests[1]
-			g.Assert(firstSinkReq.Header["Authorization"]).Eql([]string{"Basic dTEwMDpwMjAw"})
-			ents := mockService.getRecordedEntitiesForDataset("people")
-			g.Assert(len(receivedMockRequests)).Eql(4, "2 requests to source and 2 to sink")
-			g.Assert(len(ents)).Eql(20, "sink received 2 batches of content")
-			g.Assert(ents[10].ID).Eql("ns3:e-0")
+			}
+		}()
+		wg.Wait()
+		Expect(len(receivedMockRequests) > 0).To(BeTrue())
+		firstSinkReq := receivedMockRequests[1]
+		Expect(firstSinkReq.Header["Authorization"]).To(Equal([]string{"Basic dTEwMDpwMjAw"}))
+		ents := mockService.getRecordedEntitiesForDataset("people")
+		Expect(len(receivedMockRequests)).To(Equal(4), "2 requests to source and 2 to sink")
+		Expect(len(ents)).To(Equal(20), "sink received 2 batches of content")
+		Expect(ents[10].ID).To(Equal("ns3:e-0"))
+	})
+
+	It("Should support proxy dataset as fullsync datasetSink", func() {
+		_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
+			ProxyDatasetConfig: &server.ProxyDatasetConfig{
+				RemoteURL:        "http://localhost:7777/datasets/people",
+				AuthProviderName: "local",
+			},
 		})
+		Expect(err).To(BeNil())
 
-		g.It("Should support proxy dataset as fullsync datasetSink", func() {
-			_, err := dsm.CreateDataset("proxy", &server.CreateDatasetConfig{
-				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteURL:        "http://localhost:7777/datasets/people",
-					AuthProviderName: "local",
-				},
-			})
-			g.Assert(err).IsNil()
-
-			// define job
-			jobJSON := `
+		// define job
+		jobJSON := `
 			{
 				"id" : "sync-proxydatasetsource-to-httpdatasetsink",
 				"triggers": [{"triggerType": "cron", "jobType": "fullSync", "schedule": "@every 2s"}],
@@ -1588,59 +1586,59 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
-			g.Assert(err).IsNil("pipeline is parsed correctly")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
+		Expect(err).To(BeNil(), "pipeline is parsed correctly")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			var receivedMockRequests []*http.Request
-			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for afterCh := time.After(100 * time.Millisecond); ; {
-					select {
-					case d := <-mockService.HTTPNotificationChannel:
-						receivedMockRequests = append(receivedMockRequests, d)
-					case <-afterCh:
-						return
-					}
+		job.Run()
+		var receivedMockRequests []*http.Request
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for afterCh := time.After(100 * time.Millisecond); ; {
+				select {
+				case d := <-mockService.HTTPNotificationChannel:
+					receivedMockRequests = append(receivedMockRequests, d)
+				case <-afterCh:
+					return
 				}
-			}()
-			wg.Wait()
+			}
+		}()
+		wg.Wait()
 
-			g.Assert(len(receivedMockRequests) > 0).IsTrue()
-			firstSinkReq := receivedMockRequests[1]
-			g.Assert(firstSinkReq.Header["Authorization"]).Eql([]string{"Basic dTEwMDpwMjAw"})
-			g.Assert(firstSinkReq.Header["Universal-Data-Api-Full-Sync-Id"]).IsNotZero()
-			g.Assert(firstSinkReq.Header["Universal-Data-Api-Full-Sync-Start"]).Eql([]string{"true"})
-			g.Assert(firstSinkReq.Header["Universal-Data-Api-Full-Sync-End"]).IsZero()
-			secondSinkReq := receivedMockRequests[3]
-			g.Assert(secondSinkReq.Header["Authorization"]).Eql([]string{"Basic dTEwMDpwMjAw"})
-			g.Assert(secondSinkReq.Header["Universal-Data-Api-Full-Sync-Id"]).IsNotZero()
-			g.Assert(secondSinkReq.Header["Universal-Data-Api-Full-Sync-Start"]).IsZero()
-			g.Assert(secondSinkReq.Header["Universal-Data-Api-Full-Sync-End"]).IsZero()
-			thirdSinkReq := receivedMockRequests[4]
-			g.Assert(thirdSinkReq.Header["Authorization"]).Eql([]string{"Basic dTEwMDpwMjAw"})
-			g.Assert(thirdSinkReq.Header["Universal-Data-Api-Full-Sync-Id"]).IsNotZero()
-			g.Assert(thirdSinkReq.Header["Universal-Data-Api-Full-Sync-Start"]).IsZero()
-			g.Assert(thirdSinkReq.Header["Universal-Data-Api-Full-Sync-End"]).Eql([]string{"true"})
-			ents := mockService.getRecordedEntitiesForDataset("people")
-			g.Assert(len(receivedMockRequests)).Eql(5, "2 requests to source and 2 to sink plus fullsync end to sink")
-			g.Assert(len(ents)).Eql(20, "sink received 2 batches of content")
-			g.Assert(ents[10].ID).Eql("ns3:e-0")
-		})
+		Expect(len(receivedMockRequests) > 0).To(BeTrue())
+		firstSinkReq := receivedMockRequests[1]
+		Expect(firstSinkReq.Header["Authorization"]).To(Equal([]string{"Basic dTEwMDpwMjAw"}))
+		Expect(firstSinkReq.Header["Universal-Data-Api-Full-Sync-Id"]).NotTo(BeZero())
+		Expect(firstSinkReq.Header["Universal-Data-Api-Full-Sync-Start"]).To(Equal([]string{"true"}))
+		Expect(firstSinkReq.Header["Universal-Data-Api-Full-Sync-End"]).To(BeZero())
+		secondSinkReq := receivedMockRequests[3]
+		Expect(secondSinkReq.Header["Authorization"]).To(Equal([]string{"Basic dTEwMDpwMjAw"}))
+		Expect(secondSinkReq.Header["Universal-Data-Api-Full-Sync-Id"]).NotTo(BeZero())
+		Expect(secondSinkReq.Header["Universal-Data-Api-Full-Sync-Start"]).To(BeZero())
+		Expect(secondSinkReq.Header["Universal-Data-Api-Full-Sync-End"]).To(BeZero())
+		thirdSinkReq := receivedMockRequests[4]
+		Expect(thirdSinkReq.Header["Authorization"]).To(Equal([]string{"Basic dTEwMDpwMjAw"}))
+		Expect(thirdSinkReq.Header["Universal-Data-Api-Full-Sync-Id"]).NotTo(BeZero())
+		Expect(thirdSinkReq.Header["Universal-Data-Api-Full-Sync-Start"]).To(BeZero())
+		Expect(thirdSinkReq.Header["Universal-Data-Api-Full-Sync-End"]).To(Equal([]string{"true"}))
+		ents := mockService.getRecordedEntitiesForDataset("people")
+		Expect(len(receivedMockRequests)).To(Equal(5), "2 requests to source and 2 to sink plus fullsync end to sink")
+		Expect(len(ents)).To(Equal(20), "sink received 2 batches of content")
+		Expect(ents[10].ID).To(Equal("ns3:e-0"))
+	})
 
-		g.It("Should not panic when pipeline sink dataset is missing", func() {
-			// define job where datasets in source and sink are missing
-			jobJSON := `
+	It("Should not panic when pipeline sink dataset is missing", func() {
+		// define job where datasets in source and sink are missing
+		jobJSON := `
 			{
 				"id" : "sync-multi-to-dataset",
 				"triggers": [{"triggerType": "cron", "jobType": "fullSync", "schedule": "@every 2s"}],
@@ -1661,32 +1659,31 @@ func TestPipeline(t *testing.T) {
 				}
 			}`
 
-			jobConfig, _ := scheduler.Parse([]byte(jobJSON))
-			pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
-			g.Assert(err).IsNil("pipeline is parsed correctly")
+		jobConfig, _ := scheduler.Parse([]byte(jobJSON))
+		pipeline, err := scheduler.toPipeline(jobConfig, JobTypeFull)
+		Expect(err).To(BeNil(), "pipeline is parsed correctly")
 
-			job := &job{
-				id:       jobConfig.ID,
-				pipeline: pipeline,
-				schedule: jobConfig.Triggers[0].Schedule,
-				runner:   runner,
-			}
+		job := &job{
+			id:       jobConfig.ID,
+			pipeline: pipeline,
+			schedule: jobConfig.Triggers[0].Schedule,
+			runner:   runner,
+		}
 
-			job.Run()
-			history := scheduler.GetJobHistory()
-			g.Assert(history[0].LastError).Eql("dataset does not exist: testsink")
+		job.Run()
+		history := scheduler.GetJobHistory()
+		Expect(history[0].LastError).To(Equal("dataset does not exist: testsink"))
 
-			// fix sink, now missing source should not panic
-			_, _ = dsm.CreateDataset("testsink", nil)
-			job.Run()
-			history = scheduler.GetJobHistory()
-			g.Assert(history[0].LastError).Eql("dataset people is missing, dataset is missing")
+		// fix sink, now missing source should not panic
+		_, _ = dsm.CreateDataset("testsink", nil)
+		job.Run()
+		history = scheduler.GetJobHistory()
+		Expect(history[0].LastError).To(Equal("dataset people is missing, dataset is missing"))
 
-			// fix main source as well, errors should be gone
-			_, _ = dsm.CreateDataset("people", nil)
-			job.Run()
-			history = scheduler.GetJobHistory()
-			g.Assert(history[0].LastError).IsZero()
-		})
+		// fix main source as well, errors should be gone
+		_, _ = dsm.CreateDataset("people", nil)
+		job.Run()
+		history = scheduler.GetJobHistory()
+		Expect(history[0].LastError).To(BeZero())
 	})
-}
+})

--- a/internal/jobs/query_test.go
+++ b/internal/jobs/query_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
@@ -31,76 +31,73 @@ func (t *TestQueryResultWriter) WriteObject(result interface{}) error {
 	return nil
 }
 
-func TestQuery(test *testing.T) {
-	g := goblin.Goblin(test)
+var _ = Describe("QueryExecution", func() {
+	testCnt := 0
+	var dsm *server.DsManager
+	var store *server.Store
+	var storeLocation string
+	BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_store_relations_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean test files in "+storeLocation)
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(GinkgoT(), false))
+		store = server.NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
 
-	g.Describe("QueryExecution", func() {
-		testCnt := 0
-		var dsm *server.DsManager
-		var store *server.Store
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_store_relations_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean test files in " + storeLocation)
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(test, false))
-			store = server.NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
+	})
+	AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
 
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-
-		g.It("Should support js query that just writes to the response writer", func() {
-			// transform js
-			js := `
+	It("Should support js query that just writes to the response writer", func() {
+		// transform js
+		js := `
 			function do_query() {
 				let obj = { "name": "homer" };
 				WriteQueryResult(obj);
 			}
 			`
-			queryEncoded := base64.StdEncoding.EncodeToString([]byte(js))
+		queryEncoded := base64.StdEncoding.EncodeToString([]byte(js))
 
-			// create query transform
-			transform, _ := NewJavascriptTransform(zap.NewNop().Sugar(), queryEncoded, store, dsm)
+		// create query transform
+		transform, _ := NewJavascriptTransform(zap.NewNop().Sugar(), queryEncoded, store, dsm)
 
-			// create test result writer
-			resultWriter := NewTestQueryResultWriter()
+		// create test result writer
+		resultWriter := NewTestQueryResultWriter()
 
-			// run query
-			err := transform.ExecuteQuery(resultWriter)
-			if err != nil {
-				g.Fail(err)
-			}
+		// run query
+		err := transform.ExecuteQuery(resultWriter)
+		if err != nil {
+			Fail(err.Error())
+		}
 
-			// check result
-			g.Assert(len(resultWriter.Results)).Equal(1)
-			g.Assert(resultWriter.Results[0]).Equal(map[string]interface{}{"name": "homer"})
-		})
+		// check result
+		Expect(len(resultWriter.Results)).To(Equal(1))
+		Expect(resultWriter.Results[0]).To(Equal(map[string]interface{}{"name": "homer"}))
+	})
 
-		g.It("Should support js query that can access dataset changes", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("people", nil)
+	It("Should support js query that can access dataset changes", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("people", nil)
 
-			entities := make([]*server.Entity, 1)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entities[0] = entity
+		entities := make([]*server.Entity, 1)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entities[0] = entity
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("entities are stored")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "entities are stored")
 
-			// transform js
-			js := `
+		// transform js
+		js := `
 			function do_query() {
 				let obj = GetDatasetChanges("people", 0, 5);
 				let entities = obj.Entities;
@@ -114,43 +111,43 @@ func TestQuery(test *testing.T) {
 			}
 			`
 
-			queryEncoded := base64.StdEncoding.EncodeToString([]byte(js))
+		queryEncoded := base64.StdEncoding.EncodeToString([]byte(js))
 
-			// create query transform
-			transform, _ := NewJavascriptTransform(zap.NewNop().Sugar(), queryEncoded, store, dsm)
+		// create query transform
+		transform, _ := NewJavascriptTransform(zap.NewNop().Sugar(), queryEncoded, store, dsm)
 
-			// create test result writer
-			resultWriter := NewTestQueryResultWriter()
+		// create test result writer
+		resultWriter := NewTestQueryResultWriter()
 
-			// run query
-			err = transform.ExecuteQuery(resultWriter)
-			if err != nil {
-				g.Fail(err)
-			}
+		// run query
+		err = transform.ExecuteQuery(resultWriter)
+		if err != nil {
+			Fail(err.Error())
+		}
 
-			// check result
-			g.Assert(len(resultWriter.Results)).Equal(1)
-			g.Assert(resultWriter.Results[0]).Equal(map[string]interface{}{"count": 1})
-		})
+		// check result
+		Expect(len(resultWriter.Results)).To(Equal(1))
+		Expect(resultWriter.Results[0]).To(Equal(map[string]interface{}{"count": int64(1)}))
+	})
 
-		g.It("Should support js query that can access dataset changes with continuation token", func() {
-			// populate dataset with some entities
-			ds, _ := dsm.CreateDataset("people", nil)
+	It("Should support js query that can access dataset changes with continuation token", func() {
+		// populate dataset with some entities
+		ds, _ := dsm.CreateDataset("people", nil)
 
-			entities := make([]*server.Entity, 2)
-			entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["name"] = "homer"
-			entities[0] = entity
+		entities := make([]*server.Entity, 2)
+		entity := server.NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["name"] = "homer"
+		entities[0] = entity
 
-			entity = server.NewEntity("http://data.mimiro.io/people/marge", 0)
-			entity.Properties["name"] = "marge"
-			entities[1] = entity
+		entity = server.NewEntity("http://data.mimiro.io/people/marge", 0)
+		entity.Properties["name"] = "marge"
+		entities[1] = entity
 
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("entities are stored")
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "entities are stored")
 
-			// transform js
-			js := `
+		// transform js
+		js := `
 			function do_query() {
 				let count = 0;
 				let names = [];
@@ -174,27 +171,32 @@ func TestQuery(test *testing.T) {
 			}
 			`
 
-			queryEncoded := base64.StdEncoding.EncodeToString([]byte(js))
+		queryEncoded := base64.StdEncoding.EncodeToString([]byte(js))
 
-			// create query transform
-			transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), queryEncoded, store, dsm)
-			if err != nil {
-				g.Fail(err)
-			}
+		// create query transform
+		transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), queryEncoded, store, dsm)
+		if err != nil {
+			Fail(err.Error())
+		}
 
-			// create test result writer
-			resultWriter := NewTestQueryResultWriter()
+		// create test result writer
+		resultWriter := NewTestQueryResultWriter()
 
-			// run query
-			err = transform.ExecuteQuery(resultWriter)
-			if err != nil {
-				g.Fail(err)
-			}
+		// run query
+		err = transform.ExecuteQuery(resultWriter)
+		if err != nil {
+			Fail(err.Error())
+		}
 
-			// check result
-			g.Assert(len(resultWriter.Results)).Equal(1)
-			g.Assert(resultWriter.Results[0]).
-				Equal(map[string]interface{}{"count": 2, "names": []interface{}{"http://data.mimiro.io/people/homer", "http://data.mimiro.io/people/marge"}})
-		})
+		// check result
+		Expect(len(resultWriter.Results)).To(Equal(1))
+		Expect(resultWriter.Results[0]).
+			To(Equal(map[string]interface{}{
+				"count": int64(2),
+				"names": []interface{}{
+					"http://data.mimiro.io/people/homer",
+					"http://data.mimiro.io/people/marge",
+				},
+			}))
 	})
-}
+})

--- a/internal/jobs/raffle_test.go
+++ b/internal/jobs/raffle_test.go
@@ -17,79 +17,76 @@ package jobs
 import (
 	"strconv"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 )
 
-func TestRaffle(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("The raffle", func() {
-		g.It("Should only give out one ticker per job", func() {
-			raffle := NewRaffle(0, 2, zap.NewNop().Sugar(), &statsd.NoOpClient{})
-			job := &job{id: "test1", pipeline: &IncrementalPipeline{}}
+var _ = Describe("The raffle", func() {
+	It("Should only give out one ticker per job", func() {
+		raffle := NewRaffle(0, 2, zap.NewNop().Sugar(), &statsd.NoOpClient{})
+		job := &job{id: "test1", pipeline: &IncrementalPipeline{}}
 
-			ticket := raffle.borrowTicket(job)
-			g.Assert(ticket).IsNotZero("Expected to get ticket")
+		ticket := raffle.borrowTicket(job)
+		Expect(ticket).NotTo(BeZero(), "Expected to get ticket")
 
-			ticket2 := raffle.borrowTicket(job)
-			g.Assert(ticket2).IsZero("Expected ticket to be taken")
-		})
-
-		g.It("Should not exceed ticket limit", func() {
-			raffle := NewRaffle(0, 1, zap.NewNop().Sugar(), &statsd.NoOpClient{})
-			job1 := &job{id: "test1", pipeline: &IncrementalPipeline{}}
-
-			ticket := raffle.borrowTicket(job1)
-			g.Assert(ticket).IsNotZero("Expected to get ticket")
-
-			job2 := &job{id: "test2", pipeline: &IncrementalPipeline{}}
-			ticket2 := raffle.borrowTicket(job2)
-			g.Assert(ticket2).IsZero("Expected limit to be respected")
-		})
-
-		g.It("Should give out ticket again after it was returned", func() {
-			raffle := NewRaffle(0, 1, zap.NewNop().Sugar(), &statsd.NoOpClient{})
-			job1 := &job{id: "test1", pipeline: &IncrementalPipeline{}}
-
-			ticket := raffle.borrowTicket(job1)
-			g.Assert(ticket).IsNotZero("Expected to get ticket")
-			raffle.returnTicket(ticket)
-
-			job2 := &job{id: "test2", pipeline: &IncrementalPipeline{}}
-			ticket2 := raffle.borrowTicket(job2)
-			g.Assert(ticket2).IsNotZero("Expected to get ticket")
-		})
-		g.It("Should not get confused about tickets in concurrent situations", func() {
-			raffle := NewRaffle(0, 3, zap.NewNop().Sugar(), &statsd.NoOpClient{})
-
-			var wg sync.WaitGroup
-			running := 0
-
-			// start 30 jobs
-			for i := 0; i < 30; i++ {
-				if running == 3 {
-					// make sure we only start 3 at a time by using a wait-group
-					wg.Wait()
-					running = 0
-				} else {
-					wg.Add(1)
-					running = running + 1
-					id := strconv.Itoa(i)
-					go func() {
-						job := &job{id: "test" + id, pipeline: &IncrementalPipeline{}}
-						ticket := raffle.borrowTicket(job)
-						g.Assert(ticket).IsNotZero("Expected to get ticket for job " + id)
-						// simulate work
-						time.Sleep(10 * time.Millisecond)
-						raffle.returnTicket(ticket)
-						wg.Done()
-					}()
-				}
-			}
-		})
+		ticket2 := raffle.borrowTicket(job)
+		Expect(ticket2).To(BeZero(), "Expected ticket to be taken")
 	})
-}
+
+	It("Should not exceed ticket limit", func() {
+		raffle := NewRaffle(0, 1, zap.NewNop().Sugar(), &statsd.NoOpClient{})
+		job1 := &job{id: "test1", pipeline: &IncrementalPipeline{}}
+
+		ticket := raffle.borrowTicket(job1)
+		Expect(ticket).NotTo(BeZero(), "Expected to get ticket")
+
+		job2 := &job{id: "test2", pipeline: &IncrementalPipeline{}}
+		ticket2 := raffle.borrowTicket(job2)
+		Expect(ticket2).To(BeZero(), "Expected limit to be respected")
+	})
+
+	It("Should give out ticket again after it was returned", func() {
+		raffle := NewRaffle(0, 1, zap.NewNop().Sugar(), &statsd.NoOpClient{})
+		job1 := &job{id: "test1", pipeline: &IncrementalPipeline{}}
+
+		ticket := raffle.borrowTicket(job1)
+		Expect(ticket).NotTo(BeZero(), "Expected to get ticket")
+		raffle.returnTicket(ticket)
+
+		job2 := &job{id: "test2", pipeline: &IncrementalPipeline{}}
+		ticket2 := raffle.borrowTicket(job2)
+		Expect(ticket2).NotTo(BeZero(), "Expected to get ticket")
+	})
+	It("Should not get confused about tickets in concurrent situations", func() {
+		raffle := NewRaffle(0, 3, zap.NewNop().Sugar(), &statsd.NoOpClient{})
+
+		var wg sync.WaitGroup
+		running := 0
+
+		// start 30 jobs
+		for i := 0; i < 30; i++ {
+			if running == 3 {
+				// make sure we only start 3 at a time by using a wait-group
+				wg.Wait()
+				running = 0
+			} else {
+				wg.Add(1)
+				running = running + 1
+				id := strconv.Itoa(i)
+				go func() {
+					job := &job{id: "test" + id, pipeline: &IncrementalPipeline{}}
+					ticket := raffle.borrowTicket(job)
+					Expect(ticket).NotTo(BeZero(), "Expected to get ticket for job "+id)
+					// simulate work
+					time.Sleep(10 * time.Millisecond)
+					raffle.returnTicket(ticket)
+					wg.Done()
+				}()
+			}
+		}
+	})
+})

--- a/internal/jobs/source/dataset_source_test.go
+++ b/internal/jobs/source/dataset_source_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
@@ -32,206 +33,209 @@ import (
 )
 
 func TestDatasetSource(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("a datasetSource", func() {
-		testCnt := 0
-		var dsm *server.DsManager
-		var store *server.Store
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_dataset_source_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(t, false))
-
-			store = server.NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
-
-			err = lc.Start(context.Background())
-			if err != nil {
-				fmt.Println(err.Error())
-				t.FailNow()
-			}
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-
-		g.It("should emit changes if not in fullsync mode", func() {
-			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			// add one change to each entity -> 4 changes
-			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
-
-			testSource := source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.StringDatasetContinuation{}
-			// testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).Eql(4, "two entities with 2 changes each expected")
-
-			// now, modify alice and verify that we get alice emitted in next read
-			err = people.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Alice",
-					"props": map[string]interface{}{"name": "Alice-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			since := tokens[len(tokens)-1]
-			tokens = []source.DatasetContinuation{}
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				since,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
-		})
-
-		g.It("should emit entities (latest) if in fullsync mode", func() {
-			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			// add one change to each entity -> 4 changes, still 2 entities
-			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
-
-			testSource := source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.StringDatasetContinuation{}
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).Eql(2, "two entities")
-
-			// changing an existing entity would not emit anything. but new entities should be emitted
-			err = people.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Alice",
-					"props": map[string]interface{}{"name": "Alice-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Jim",
-					"props": map[string]interface{}{"name": "Jim-new"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			since := tokens[len(tokens)-1]
-			tokens = []source.DatasetContinuation{}
-			recordedEntities = []server.Entity{}
-			testSource.StartFullSync()
-			err = testSource.ReadEntities(
-				since,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).Eql(1)
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Jim-new")
-		})
-
-		g.It("should emit only latest changes if not in fullsync mode", func() {
-			// prime dataset with 2 entities
-			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			// add one change to each entity -> 4 changes
-			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
-
-			testSource := source.DatasetSource{
-				DatasetName: "people", Store: store, DatasetManager: dsm,
-				LatestOnly: true,
-			}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.StringDatasetContinuation{}
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).
-				Eql(2, "There are 4 changes present, we expect only 2 (latest) changes emitted")
-
-			// now, modify alice and verify that we get alice emitted in next read
-			err = people.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Alice",
-					"props": map[string]interface{}{"name": "Alice-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			since := tokens[len(tokens)-1]
-			tokens = []source.DatasetContinuation{}
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				since,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
-		})
-	})
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Source Suite")
 }
+
+var _ = Describe("a datasetSource", func() {
+	testCnt := 0
+	var dsm *server.DsManager
+	var store *server.Store
+	var storeLocation string
+	BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_dataset_source_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(GinkgoT(), false))
+
+		store = server.NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
+
+		err = lc.Start(context.Background())
+		if err != nil {
+			fmt.Println(err.Error())
+			Fail(err.Error())
+
+		}
+	})
+	AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+
+	It("should emit changes if not in fullsync mode", func() {
+		people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		// add one change to each entity -> 4 changes
+		addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+		testSource := source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.StringDatasetContinuation{}
+		// testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+		Expect(len(recordedEntities)).To(Equal(4), "two entities with 2 changes each expected")
+
+		// now, modify alice and verify that we get alice emitted in next read
+		err = people.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Alice",
+				"props": map[string]interface{}{"name": "Alice-changed"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		Expect(err).To(BeNil())
+		since := tokens[len(tokens)-1]
+		tokens = []source.DatasetContinuation{}
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			since,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Alice-changed"))
+	})
+
+	It("should emit entities (latest) if in fullsync mode", func() {
+		people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		// add one change to each entity -> 4 changes, still 2 entities
+		addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+		testSource := source.DatasetSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.StringDatasetContinuation{}
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+		Expect(len(recordedEntities)).To(Equal(2), "two entities")
+
+		// changing an existing entity would not emit anything. but new entities should be emitted
+		err = people.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Alice",
+				"props": map[string]interface{}{"name": "Alice-changed"},
+				"refs":  map[string]interface{}{},
+			}),
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Jim",
+				"props": map[string]interface{}{"name": "Jim-new"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		Expect(err).To(BeNil())
+		since := tokens[len(tokens)-1]
+		tokens = []source.DatasetContinuation{}
+		recordedEntities = []server.Entity{}
+		testSource.StartFullSync()
+		err = testSource.ReadEntities(
+			since,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+		Expect(len(recordedEntities)).To(Equal(1))
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Jim-new"))
+	})
+
+	It("should emit only latest changes if not in fullsync mode", func() {
+		// prime dataset with 2 entities
+		people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		// add one change to each entity -> 4 changes
+		addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+		testSource := source.DatasetSource{
+			DatasetName: "people", Store: store, DatasetManager: dsm,
+			LatestOnly: true,
+		}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.StringDatasetContinuation{}
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+		Expect(len(recordedEntities)).
+			To(Equal(2), "There are 4 changes present, we expect only 2 (latest) changes emitted")
+
+		// now, modify alice and verify that we get alice emitted in next read
+		err = people.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Alice",
+				"props": map[string]interface{}{"name": "Alice-changed"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		Expect(err).To(BeNil())
+		since := tokens[len(tokens)-1]
+		tokens = []source.DatasetContinuation{}
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			since,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Alice-changed"))
+	})
+})

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -18,873 +18,868 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"testing"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+	"os"
 
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"github.com/mimiro-io/datahub/internal/server"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestMultiSource(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("dependency tracking", func() {
-		testCnt := 0
-		var dsm *server.DsManager
-		var store *server.Store
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_multi_source_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
+var _ = Describe("dependency tracking", func() {
+	testCnt := 0
+	var dsm *server.DsManager
+	var store *server.Store
+	var storeLocation string
+	BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_multi_source_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
 
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(t, false))
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(GinkgoT(), false))
 
-			store = server.NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
+		store = server.NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
 
-			err = lc.Start(context.Background())
-			if err != nil {
-				fmt.Println(err.Error())
-				t.FailNow()
-			}
+		err = lc.Start(context.Background())
+		if err != nil {
+			fmt.Println(err.Error())
+			Fail(err.Error())
+		}
+	})
+	AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+
+	It("should emit changes in main dataset", func() {
+		people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		// add one change to each entity -> 4 changes
+		addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+		Expect(len(recordedEntities)).To(Equal(4), "two entities with 2 changes each expected")
+
+		// now, modify alice and verify that we get alice emitted in next read
+		err = people.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Alice",
+				"props": map[string]interface{}{"name": "Alice-changed"},
+				"refs":  map[string]interface{}{},
+			}),
 		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil())
+		since := tokens[len(tokens)-1]
+		tokens = []source.DatasetContinuation{}
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			since,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Alice-changed"))
+	})
+
+	It("should emit only latest changes in main dataset", func() {
+		// prime dataset with 2 entities
+		people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		// add one change to each entity -> 4 changes
+		addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+
+		testSource := source.MultiSource{
+			DatasetName: "people", Store: store, DatasetManager: dsm,
+			LatestOnly: true,
+		}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+		Expect(len(recordedEntities)).
+			To(Equal(2), "There are 4 changes present, we expect only 2 (latest) changes emitted")
+
+		// now, modify alice and verify that we get alice emitted in next read
+		err = people.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Alice",
+				"props": map[string]interface{}{"name": "Alice-changed"},
+				"refs":  map[string]interface{}{},
+			}),
 		})
+		Expect(err).To(BeNil())
+		since := tokens[len(tokens)-1]
+		tokens = []source.DatasetContinuation{}
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			since,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Alice-changed"))
+	})
 
-		g.It("should emit changes in main dataset", func() {
-			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			// add one change to each entity -> 4 changes
-			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
+	It("should capture watermarks during initial fullsync", func() {
+		_, addressPrefix := createTestDataset("address", []string{"Mainstreet", "Sidealley"}, nil, dsm, store)
+		peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
+		createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
+			"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
+			"Alice": {peoplePrefix + ":address": addressPrefix + ":Sidealley"},
+		}, dsm, store)
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).Eql(4, "two entities with 2 changes each expected")
-
-			// now, modify alice and verify that we get alice emitted in next read
-			err = people.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Alice",
-					"props": map[string]interface{}{"name": "Alice-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			since := tokens[len(tokens)-1]
-			tokens = []source.DatasetContinuation{}
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				since,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
-		})
-
-		g.It("should emit only latest changes in main dataset", func() {
-			// prime dataset with 2 entities
-			people, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			// add one change to each entity -> 4 changes
-			addChanges("people", []string{"Bob", "Alice"}, dsm, store)
-
-			testSource := source.MultiSource{
-				DatasetName: "people", Store: store, DatasetManager: dsm,
-				LatestOnly: true,
-			}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).
-				Eql(2, "There are 4 changes present, we expect only 2 (latest) changes emitted")
-
-			// now, modify alice and verify that we get alice emitted in next read
-			err = people.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Alice",
-					"props": map[string]interface{}{"name": "Alice-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			since := tokens[len(tokens)-1]
-			tokens = []source.DatasetContinuation{}
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				since,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
-		})
-
-		g.It("should capture watermarks during initial fullsync", func() {
-			_, addressPrefix := createTestDataset("address", []string{"Mainstreet", "Sidealley"}, nil, dsm, g, store)
-			peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
-			createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
-				"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
-				"Alice": {peoplePrefix + ":address": addressPrefix + ":Sidealley"},
-			}, dsm, g, store)
-
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "address",
 							"joins": [ { "dataset": "people", "predicate": "http://people/address", "inverse": true } ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			err := json.Unmarshal([]byte(srcJSON), &srcConfig)
-			g.Assert(err).IsNil()
-			err = testSource.ParseDependencies(srcConfig["Dependencies"])
-			g.Assert(err).IsNil()
+		srcConfig := map[string]interface{}{}
+		err := json.Unmarshal([]byte(srcJSON), &srcConfig)
+		Expect(err).To(BeNil())
+		err = testSource.ParseDependencies(srcConfig["Dependencies"])
+		Expect(err).To(BeNil())
 
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err = testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err = testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// test that we do not get anything emitted without further changes. verifying that watermarks are stored in lastToken
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(0)
-		})
+		// test that we do not get anything emitted without further changes. verifying that watermarks are stored in lastToken
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(0))
+	})
 
-		g.It("should emit main entity if direct dependency was changed after fullsync", func() {
-			addresses, addressPrefix := createTestDataset(
-				"address",
-				[]string{"Mainstreet", "Sidealley"},
-				nil,
-				dsm,
-				g,
-				store,
-			)
-			peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
-			createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
-				"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
-				"Alice": {peoplePrefix + ":address": addressPrefix + ":Sidealley"},
-			}, dsm, g, store)
+	It("should emit main entity if direct dependency was changed after fullsync", func() {
+		addresses, addressPrefix := createTestDataset(
+			"address",
+			[]string{"Mainstreet", "Sidealley"},
+			nil,
+			dsm,
+			store,
+		)
+		peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
+		createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
+			"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
+			"Alice": {peoplePrefix + ":address": addressPrefix + ":Sidealley"},
+		}, dsm, store)
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "address",
 							"joins": [ { "dataset": "people", "predicate": "http://people/address", "inverse": true } ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			err := json.Unmarshal([]byte(srcJSON), &srcConfig)
-			g.Assert(err).IsNil()
-			err = testSource.ParseDependencies(srcConfig["Dependencies"])
-			g.Assert(err).IsNil()
+		srcConfig := map[string]interface{}{}
+		err := json.Unmarshal([]byte(srcJSON), &srcConfig)
+		Expect(err).To(BeNil())
+		err = testSource.ParseDependencies(srcConfig["Dependencies"])
+		Expect(err).To(BeNil())
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err = testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err = testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
-			err = addresses.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    addressPrefix + ":Mainstreet",
-					"props": map[string]interface{}{"name": "Mainstreet-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
+		// now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
+		err = addresses.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    addressPrefix + ":Mainstreet",
+				"props": map[string]interface{}{"name": "Mainstreet-changed"},
+				"refs":  map[string]interface{}{},
+			}),
 		})
+		Expect(err).To(BeNil())
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Bob"))
+	})
 
-		// initial incremental will be much slower, as it traverses all main entities and processes all dependency changes without watermarks
-		g.It("should emit main entity if direct dependency was changed after initial incremental run", func() {
-			addresses, addressPrefix := createTestDataset(
-				"address",
-				[]string{"Mainstreet", "Sidealley"},
-				nil,
-				dsm,
-				g,
-				store,
-			)
-			peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
-			createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
-				"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
-				"Alice": {peoplePrefix + ":address": addressPrefix + ":Sidealley"},
-			}, dsm, g, store)
+	// initial incremental will be much slower, as it traverses all main entities and processes all dependency changes without watermarks
+	It("should emit main entity if direct dependency was changed after initial incremental run", func() {
+		addresses, addressPrefix := createTestDataset(
+			"address",
+			[]string{"Mainstreet", "Sidealley"},
+			nil,
+			dsm,
+			store,
+		)
+		peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
+		createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
+			"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
+			"Alice": {peoplePrefix + ":address": addressPrefix + ":Sidealley"},
+		}, dsm, store)
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "address",
 							"joins": [ { "dataset": "people", "predicate": "http://people/address", "inverse": true } ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			err := json.Unmarshal([]byte(srcJSON), &srcConfig)
-			g.Assert(err).IsNil()
-			err = testSource.ParseDependencies(srcConfig["Dependencies"])
-			g.Assert(err).IsNil()
+		srcConfig := map[string]interface{}{}
+		err := json.Unmarshal([]byte(srcJSON), &srcConfig)
+		Expect(err).To(BeNil())
+		err = testSource.ParseDependencies(srcConfig["Dependencies"])
+		Expect(err).To(BeNil())
 
-			// initial incremental run.
-			// Since the fullsync flag is not set, the run will traverse all dependencies in addition to all main entities
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			err = testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
+		// initial incremental run.
+		// Since the fullsync flag is not set, the run will traverse all dependencies in addition to all main entities
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		err = testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
 
-			// now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
-			err = addresses.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    addressPrefix + ":Mainstreet",
-					"props": map[string]interface{}{"name": "Mainstreet-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
+		// now, modify Mainstreet address and verify that we get Bob emitted in next read (mainstreet is direct dependency to bob)
+		err = addresses.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    addressPrefix + ":Mainstreet",
+				"props": map[string]interface{}{"name": "Mainstreet-changed"},
+				"refs":  map[string]interface{}{},
+			}),
 		})
+		Expect(err).To(BeNil())
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Bob"))
+	})
 
-		g.It("should emit main entity if inverse dependency was changed after fullsync", func() {
-			_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			employments, employmentPrefix := createTestDataset("employment",
-				[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
-					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
-					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale": {
-						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
-					},
-				}, dsm, g, store)
+	It("should emit main entity if inverse dependency was changed after fullsync", func() {
+		_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		employments, employmentPrefix := createTestDataset("employment",
+			[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
+				"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
+				"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
+				"YardSale": {
+					peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+				},
+			}, dsm, store)
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "employment",
 							"joins": [ { "dataset": "people", "predicate": "http://people/employment", "inverse": false } ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// now, modify MediumCorp employment and verify that we get Bob emitted in next read (MediumCorp is inverse dependency to bob)
-			err = employments.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    employmentPrefix + ":MediumCorp",
-					"props": map[string]interface{}{"name": "MediumCorp-changed"},
-					"refs":  map[string]interface{}{peoplePrefix + ":employment": peoplePrefix + ":Bob"},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
-
-			// also, modify YardSale employment and verify that both Bob and Alice emitted in next read
-			err = employments.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    employmentPrefix + ":YardSale",
-					"props": map[string]interface{}{"name": "YardSale-changed"},
-					"refs": map[string]interface{}{
-						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
-					},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			// expect both referred-to people to be emitted
-			g.Assert(len(recordedEntities)).Eql(2)
+		// now, modify MediumCorp employment and verify that we get Bob emitted in next read (MediumCorp is inverse dependency to bob)
+		err = employments.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    employmentPrefix + ":MediumCorp",
+				"props": map[string]interface{}{"name": "MediumCorp-changed"},
+				"refs":  map[string]interface{}{peoplePrefix + ":employment": peoplePrefix + ":Bob"},
+			}),
 		})
+		Expect(err).To(BeNil())
 
-		g.It("should emit main entity if multi hop dependency was changed after fullsync", func() {
-			cities, cityPrefix := createTestDataset("city", []string{"Oslo", "Bergen"}, nil, dsm, g, store)
-			addressPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://address/")
-			addresses, _ := createTestDataset("address", []string{"Mainstreet", "Sidealley"},
-				map[string]map[string]interface{}{
-					"Mainstreet": {},
-					"Sidealley":  {addressPrefix + ":city": cityPrefix + ":Bergen"},
-				}, dsm, g, store)
-			peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
-			createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
-				"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
-				"Alice": {peoplePrefix + ":address": addressPrefix + ":Sidealley"},
-			}, dsm, g, store)
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Bob"))
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+		// also, modify YardSale employment and verify that both Bob and Alice emitted in next read
+		err = employments.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    employmentPrefix + ":YardSale",
+				"props": map[string]interface{}{"name": "YardSale-changed"},
+				"refs": map[string]interface{}{
+					peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+				},
+			}),
+		})
+		Expect(err).To(BeNil())
+
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		// expect both referred-to people to be emitted
+		Expect(len(recordedEntities)).To(Equal(2))
+	})
+
+	It("should emit main entity if multi hop dependency was changed after fullsync", func() {
+		cities, cityPrefix := createTestDataset("city", []string{"Oslo", "Bergen"}, nil, dsm, store)
+		addressPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://address/")
+		addresses, _ := createTestDataset("address", []string{"Mainstreet", "Sidealley"},
+			map[string]map[string]interface{}{
+				"Mainstreet": {},
+				"Sidealley":  {addressPrefix + ":city": cityPrefix + ":Bergen"},
+			}, dsm, store)
+		peoplePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://people/")
+		createTestDataset("people", []string{"Bob", "Alice"}, map[string]map[string]interface{}{
+			"Bob":   {peoplePrefix + ":address": addressPrefix + ":Mainstreet"},
+			"Alice": {peoplePrefix + ":address": addressPrefix + ":Sidealley"},
+		}, dsm, store)
+
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "city",
 							"joins": [
                               { "dataset": "address", "predicate": "http://address/city", "inverse": true },
                               { "dataset": "people", "predicate": "http://people/address", "inverse": true }
                             ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			err := json.Unmarshal([]byte(srcJSON), &srcConfig)
-			g.Assert(err).IsNil()
-			err = testSource.ParseDependencies(srcConfig["Dependencies"])
-			g.Assert(err).IsNil()
+		srcConfig := map[string]interface{}{}
+		err := json.Unmarshal([]byte(srcJSON), &srcConfig)
+		Expect(err).To(BeNil())
+		err = testSource.ParseDependencies(srcConfig["Dependencies"])
+		Expect(err).To(BeNil())
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err = testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err = testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// modify Mainstreet address and verify that nothing changed (address is not a dependency, just a join)
-			err = addresses.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    addressPrefix + ":Mainstreet",
-					"props": map[string]interface{}{"name": "Mainstreet-changed"},
-					"refs":  map[string]interface{}{addressPrefix + ":city": cityPrefix + ":Oslo"},
-				}),
-			})
-			g.Assert(err).IsNil()
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(0)
-
-			// now, modify Oslo city and verify that bob is found via Mainstreet address
-			err = cities.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    cityPrefix + ":Oslo",
-					"props": map[string]interface{}{"name": "Oslo-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
+		// modify Mainstreet address and verify that nothing changed (address is not a dependency, just a join)
+		err = addresses.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    addressPrefix + ":Mainstreet",
+				"props": map[string]interface{}{"name": "Mainstreet-changed"},
+				"refs":  map[string]interface{}{addressPrefix + ":city": cityPrefix + ":Oslo"},
+			}),
 		})
+		Expect(err).To(BeNil())
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(0))
 
-		g.It("Should emit main entity if inverse multi hop dependency is changed", func() {
-			// people <- employment <- salary
-			_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			_, employmentPrefix := createTestDataset("employment",
-				[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
-					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
-					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale": {
-						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
-					},
-				}, dsm, g, store)
-			incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
-				[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
-					"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
-					"Low": {
-						employmentPrefix + ":employment": []string{
-							employmentPrefix + ":MediumCorp",
-							employmentPrefix + "YardSale",
-						},
-					},
-				}, dsm, g, store)
+		// now, modify Oslo city and verify that bob is found via Mainstreet address
+		err = cities.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    cityPrefix + ":Oslo",
+				"props": map[string]interface{}{"name": "Oslo-changed"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		Expect(err).To(BeNil())
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+	})
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+	It("Should emit main entity if inverse multi hop dependency is changed", func() {
+		// people <- employment <- salary
+		_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		_, employmentPrefix := createTestDataset("employment",
+			[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
+				"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
+				"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
+				"YardSale": {
+					peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+				},
+			}, dsm, store)
+		incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
+			[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
+				"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
+				"Low": {
+					employmentPrefix + ":employment": []string{
+						employmentPrefix + ":MediumCorp",
+						employmentPrefix + "YardSale",
+					},
+				},
+			}, dsm, store)
+
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "incomeRange",
 							"joins": [ { "dataset": "employment", "predicate": "http://employment/employment", "inverse": false },
 									   { "dataset": "people", "predicate": "http://people/employment", "inverse": false }
                                      ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// now, modify High incomeRange and verify that we get Bob emitted in next read (MediumCorp is inverse dependency to bob via employment MediumCorp)
-			err = incomeRanges.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    incomeRangePrefix + ":High",
-					"props": map[string]interface{}{"name": "High-changed"},
-					"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
+		// now, modify High incomeRange and verify that we get Bob emitted in next read (MediumCorp is inverse dependency to bob via employment MediumCorp)
+		err = incomeRanges.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    incomeRangePrefix + ":High",
+				"props": map[string]interface{}{"name": "High-changed"},
+				"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
+			}),
 		})
+		Expect(err).To(BeNil())
 
-		g.It("should emit main entity if inverse dependency ref is removed", func() {
-			_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			employments, employmentPrefix := createTestDataset("employment",
-				[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
-					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
-					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale": {
-						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
-					},
-				}, dsm, g, store)
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Bob"))
+	})
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+	It("should emit main entity if inverse dependency ref is removed", func() {
+		_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		employments, employmentPrefix := createTestDataset("employment",
+			[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
+				"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
+				"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
+				"YardSale": {
+					peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+				},
+			}, dsm, store)
+
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "employment",
 							"joins": [ { "dataset": "people", "predicate": "http://people/employment", "inverse": false } ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// now, remove all refs  from MediumCorp.  this should emit bob because the dependency was changed
-			err = employments.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    employmentPrefix + ":MediumCorp",
-					"props": map[string]interface{}{"name": "MediumCorp-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
+		// now, remove all refs  from MediumCorp.  this should emit bob because the dependency was changed
+		err = employments.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    employmentPrefix + ":MediumCorp",
+				"props": map[string]interface{}{"name": "MediumCorp-changed"},
+				"refs":  map[string]interface{}{},
+			}),
 		})
-		g.It("should support empty dependency dastasets", func() {
-			_, _ = createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			_, _ = createTestDataset("employment", nil, nil, dsm, g, store)
+		Expect(err).To(BeNil())
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		// Bob was emitted enchanged. up to transform to do something with bob and dependency that triggered bob's emission
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Bob"))
+	})
+	It("should support empty dependency dastasets", func() {
+		_, _ = createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		_, _ = createTestDataset("employment", nil, nil, dsm, store)
+
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "employment",
 							"joins": [ { "dataset": "people", "predicate": "http://people/employment", "inverse": false } ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+
+		Expect(len(recordedEntities)).To(Equal(2))
+
+		// run inc
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(0))
+	})
+
+	It("should emit main enitity if inverse multi hop dependency is removed", func() {
+		// people <- employment <- salary
+		_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice", "Hank"}, nil, dsm, store)
+		_, employmentPrefix := createTestDataset("employment",
+			[]string{"MediumCorp", "LittleSweatshop", "YardSale", "BigCorp"}, map[string]map[string]interface{}{
+				"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
+				"BigCorp":         {peoplePrefix + ":employment": peoplePrefix + ":Hank"},
+				"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
+				"YardSale": {
+					peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
 				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-
-			g.Assert(len(recordedEntities)).Eql(2)
-
-			// run inc
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
+			}, dsm, store)
+		incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
+			[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
+				"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
+				"Low": {
+					employmentPrefix + ":employment": []string{
+						employmentPrefix + ":MediumCorp",
+						employmentPrefix + "YardSale",
+					},
 				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(0)
-		})
+			}, dsm, store)
 
-		g.It("should emit main enitity if inverse multi hop dependency is removed", func() {
-			// people <- employment <- salary
-			_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice", "Hank"}, nil, dsm, g, store)
-			_, employmentPrefix := createTestDataset("employment",
-				[]string{"MediumCorp", "LittleSweatshop", "YardSale", "BigCorp"}, map[string]map[string]interface{}{
-					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
-					"BigCorp":         {peoplePrefix + ":employment": peoplePrefix + ":Hank"},
-					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale": {
-						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
-					},
-				}, dsm, g, store)
-			incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
-				[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
-					"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
-					"Low": {
-						employmentPrefix + ":employment": []string{
-							employmentPrefix + ":MediumCorp",
-							employmentPrefix + "YardSale",
-						},
-					},
-				}, dsm, g, store)
-
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "incomeRange",
 							"joins": [ { "dataset": "employment", "predicate": "http://employment/employment", "inverse": false },
 									   { "dataset": "people", "predicate": "http://people/employment", "inverse": false }
                                      ] } ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// now, point High incomeRange from MediumCorp to BigCorp.
-			// Hank and Bob should be emitted (Hank, because he gained High incomeRange. Bob, because he lost it).
-			err = incomeRanges.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    incomeRangePrefix + ":High",
-					"props": map[string]interface{}{"name": "High"},
-					"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":BigCorp"},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			batchCnt := 0
-			err = testSource.ReadEntities(
-				lastToken,
-				1,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					batchCnt++
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(batchCnt).Eql(3, "2 batches of 1, and final main dataset batch is empty")
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(2)
-			var seenBob, seenHank bool
-			for _, re := range recordedEntities {
-				seenBob = seenBob || re.ID == peoplePrefix+":Bob"
-				seenHank = seenHank || re.ID == peoplePrefix+":Hank"
-			}
-			g.Assert(seenBob).IsTrue("expected to find Bob in emitted entities")
-			g.Assert(seenHank).IsTrue("expected to find Hank in emitted entities")
+		// now, point High incomeRange from MediumCorp to BigCorp.
+		// Hank and Bob should be emitted (Hank, because he gained High incomeRange. Bob, because he lost it).
+		err = incomeRanges.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    incomeRangePrefix + ":High",
+				"props": map[string]interface{}{"name": "High"},
+				"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":BigCorp"},
+			}),
 		})
+		Expect(err).To(BeNil())
 
-		g.It("should support same dataset as dependency multiple times", func() {
-			// people <- employment <- salary
-			// people <- demographic -> salary
-			_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice", "Hank"}, nil, dsm, g, store)
-			_, employmentPrefix := createTestDataset("employment",
-				[]string{"MediumCorp", "LittleSweatshop", "YardSale", "BigCorp"}, map[string]map[string]interface{}{
-					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
-					"BigCorp":         {peoplePrefix + ":employment": peoplePrefix + ":Hank"},
-					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-					"YardSale": {
-						peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
-					},
-				}, dsm, g, store)
-			incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
-				[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
-					"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
-					"Low": {
-						employmentPrefix + ":employment": []string{
-							employmentPrefix + ":MediumCorp",
-							employmentPrefix + "YardSale",
-						},
-					},
-				}, dsm, g, store)
-			_, _ = createTestDataset("demographic", []string{"young", "middle-aged", "senior"},
-				map[string]map[string]interface{}{
-					"young": {
-						peoplePrefix + ":people":           peoplePrefix + ":Alice",
-						incomeRangePrefix + ":incomeRange": incomeRangePrefix + ":High",
-					},
-				}, dsm, g, store)
+		recordedEntities = []server.Entity{}
+		batchCnt := 0
+		err = testSource.ReadEntities(
+			lastToken,
+			1,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				batchCnt++
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(batchCnt).To(Equal(3), "2 batches of 1, and final main dataset batch is empty")
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(2))
+		var seenBob, seenHank bool
+		for _, re := range recordedEntities {
+			seenBob = seenBob || re.ID == peoplePrefix+":Bob"
+			seenHank = seenHank || re.ID == peoplePrefix+":Hank"
+		}
+		Expect(seenBob).To(BeTrue(), "expected to find Bob in emitted entities")
+		Expect(seenHank).To(BeTrue(), "expected to find Hank in emitted entities")
+	})
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
+	It("should support same dataset as dependency multiple times", func() {
+		// people <- employment <- salary
+		// people <- demographic -> salary
+		_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice", "Hank"}, nil, dsm, store)
+		_, employmentPrefix := createTestDataset("employment",
+			[]string{"MediumCorp", "LittleSweatshop", "YardSale", "BigCorp"}, map[string]map[string]interface{}{
+				"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
+				"BigCorp":         {peoplePrefix + ":employment": peoplePrefix + ":Hank"},
+				"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
+				"YardSale": {
+					peoplePrefix + ":employment": []string{peoplePrefix + ":Bob", peoplePrefix + ":Alice"},
+				},
+			}, dsm, store)
+		incomeRanges, incomeRangePrefix := createTestDataset("incomeRange",
+			[]string{"High", "Medium", "Low"}, map[string]map[string]interface{}{
+				"High": {employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
+				"Low": {
+					employmentPrefix + ":employment": []string{
+						employmentPrefix + ":MediumCorp",
+						employmentPrefix + "YardSale",
+					},
+				},
+			}, dsm, store)
+		_, _ = createTestDataset("demographic", []string{"young", "middle-aged", "senior"},
+			map[string]map[string]interface{}{
+				"young": {
+					peoplePrefix + ":people":           peoplePrefix + ":Alice",
+					incomeRangePrefix + ":incomeRange": incomeRangePrefix + ":High",
+				},
+			}, dsm, store)
+
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
                           {
 							"dataset": "incomeRange",
 							"joins": [ { "dataset": "employment", "predicate": "http://employment/employment", "inverse": false },
@@ -896,92 +891,91 @@ func TestMultiSource(t *testing.T) {
                           }
                         ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// Now, change name of "High" incomeRange. expected Bob emitted through first dependency via employment.
-			// Expect also Alice through 2nd dependency via demographic
-			err = incomeRanges.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    incomeRangePrefix + ":High",
-					"props": map[string]interface{}{"name": "High-changed"},
-					"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(2)
-			var seenBob, seenAlice bool
-			for _, re := range recordedEntities {
-				seenBob = seenBob || re.ID == peoplePrefix+":Bob"
-				seenAlice = seenAlice || re.ID == peoplePrefix+":Alice"
-			}
-			g.Assert(seenBob).IsTrue("expected to find Bob in emitted entities via 1st dep")
-			g.Assert(seenAlice).IsTrue("expected to find Alice in emitted entities via 2nd dep")
+		// Now, change name of "High" incomeRange. expected Bob emitted through first dependency via employment.
+		// Expect also Alice through 2nd dependency via demographic
+		err = incomeRanges.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    incomeRangePrefix + ":High",
+				"props": map[string]interface{}{"name": "High-changed"},
+				"refs":  map[string]interface{}{employmentPrefix + ":employment": employmentPrefix + ":MediumCorp"},
+			}),
 		})
+		Expect(err).To(BeNil())
 
-		g.It("should support multiple link predicates per join", func() {
-			// people <- band -> people
-			people, peoplePrefix := createTestDataset(
-				"people",
-				[]string{"Bob", "Rob", "Mary", "Alice", "Hank", "Lisa"},
-				nil,
-				dsm,
-				g,
-				store,
-			)
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(2))
+		var seenBob, seenAlice bool
+		for _, re := range recordedEntities {
+			seenBob = seenBob || re.ID == peoplePrefix+":Bob"
+			seenAlice = seenAlice || re.ID == peoplePrefix+":Alice"
+		}
+		Expect(seenBob).To(BeTrue(), "expected to find Bob in emitted entities via 1st dep")
+		Expect(seenAlice).To(BeTrue(), "expected to find Alice in emitted entities via 2nd dep")
+	})
 
-			_, _ = createTestDataset("band", []string{"Rockbuds", "SideshowBand"},
-				map[string]map[string]interface{}{
-					"Rockbuds": {
-						peoplePrefix + ":singer": []string{
-							peoplePrefix + ":Rob",
-							peoplePrefix + ":Mary",
-							peoplePrefix + ":Lisa",
-						},
-						peoplePrefix + ":drummer": []string{peoplePrefix + ":Alice"},
+	It("should support multiple link predicates per join", func() {
+		// people <- band -> people
+		people, peoplePrefix := createTestDataset(
+			"people",
+			[]string{"Bob", "Rob", "Mary", "Alice", "Hank", "Lisa"},
+			nil,
+			dsm,
+			store,
+		)
+
+		_, _ = createTestDataset("band", []string{"Rockbuds", "SideshowBand"},
+			map[string]map[string]interface{}{
+				"Rockbuds": {
+					peoplePrefix + ":singer": []string{
+						peoplePrefix + ":Rob",
+						peoplePrefix + ":Mary",
+						peoplePrefix + ":Lisa",
 					},
-					"SideshowBand": {
-						peoplePrefix + ":singer":  peoplePrefix + ":Bob",
-						peoplePrefix + ":drummer": []string{peoplePrefix + ":Hank"},
-					},
-				}, dsm, g, store)
+					peoplePrefix + ":drummer": []string{peoplePrefix + ":Alice"},
+				},
+				"SideshowBand": {
+					peoplePrefix + ":singer":  peoplePrefix + ":Bob",
+					peoplePrefix + ":drummer": []string{peoplePrefix + ":Hank"},
+				},
+			}, dsm, store)
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
                           {
 							"dataset": "people",
 							"joins": [ { "dataset": "band", "predicate": "http://people/drummer", "inverse": true },
@@ -999,148 +993,148 @@ func TestMultiSource(t *testing.T) {
                           }
                         ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-
-			// Rename Hank, expect Hank himself (main dataset change) and Bob, who is singer in Hank's band "Sideshow", to be emitted
-			err = people.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Hank",
-					"props": map[string]interface{}{"name": "Hank-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(2)
-			var seenBob, seenHank bool
-			for _, re := range recordedEntities {
-				seenBob = seenBob || re.ID == peoplePrefix+":Bob"
-				seenHank = seenHank || re.ID == peoplePrefix+":Hank"
-			}
-			g.Assert(seenBob).IsTrue("expected to find Bob in emitted entities via 1st dep")
-			g.Assert(seenHank).IsTrue("expected to find Hank because Hank was changed in main dataset")
-
-			// Rename Lisa. expect Lisa herself. and all her bandmates (singers Rob+Mary and drummer Alice)
-			// Lisa will currently be emitted twice. once from main dataset, and once because lisa is her own singer-singer relation aswell
-			err = people.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Lisa",
-					"props": map[string]interface{}{"name": "Lisa-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(5)
-			var lisaSeen, robSeen, marySeen, aliceSeen bool
-			lisaCnt := 0
-			for _, re := range recordedEntities {
-				lisaSeen = lisaSeen || re.ID == peoplePrefix+":Lisa"
-				robSeen = robSeen || re.ID == peoplePrefix+":Rob"
-				marySeen = marySeen || re.ID == peoplePrefix+":Mary"
-				aliceSeen = aliceSeen || re.ID == peoplePrefix+":Alice"
-				if re.ID == peoplePrefix+":Lisa" {
-					lisaCnt++
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
 				}
-			}
-			g.Assert(lisaSeen).IsTrue()
-			g.Assert(robSeen).IsTrue()
-			g.Assert(marySeen).IsTrue()
-			g.Assert(aliceSeen).IsTrue()
-			g.Assert(lisaCnt).Eql(2)
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+
+		// Rename Hank, expect Hank himself (main dataset change) and Bob, who is singer in Hank's band "Sideshow", to be emitted
+		err = people.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Hank",
+				"props": map[string]interface{}{"name": "Hank-changed"},
+				"refs":  map[string]interface{}{},
+			}),
 		})
+		Expect(err).To(BeNil())
 
-		g.It("should support deep join paths", func() {
-			// people <------ team -----------> people <------------- office -------> address
-			//         member      team-lead            contact-person        address
-			_, peoplePrefix := createTestDataset("people",
-				[]string{"Bob", "Rob", "Mary", "Alice", "Hank", "Lisa"}, nil, dsm, g, store)
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(2))
+		var seenBob, seenHank bool
+		for _, re := range recordedEntities {
+			seenBob = seenBob || re.ID == peoplePrefix+":Bob"
+			seenHank = seenHank || re.ID == peoplePrefix+":Hank"
+		}
+		Expect(seenBob).To(BeTrue(), "expected to find Bob in emitted entities via 1st dep")
+		Expect(seenHank).To(BeTrue(), "expected to find Hank because Hank was changed in main dataset")
 
-			teamPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://team/")
-			_, _ = createTestDataset("team", []string{"product", "development"},
-				map[string]map[string]interface{}{
-					"product": {
-						teamPrefix + ":lead": peoplePrefix + ":Bob",
-						teamPrefix + ":member": []string{
-							peoplePrefix + ":Bob",
-							peoplePrefix + ":Rob",
-							peoplePrefix + ":Mary",
-						},
+		// Rename Lisa. expect Lisa herself. and all her bandmates (singers Rob+Mary and drummer Alice)
+		// Lisa will currently be emitted twice. once from main dataset, and once because lisa is her own singer-singer relation aswell
+		err = people.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Lisa",
+				"props": map[string]interface{}{"name": "Lisa-changed"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		Expect(err).To(BeNil())
+
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(5))
+		var lisaSeen, robSeen, marySeen, aliceSeen bool
+		lisaCnt := 0
+		for _, re := range recordedEntities {
+			lisaSeen = lisaSeen || re.ID == peoplePrefix+":Lisa"
+			robSeen = robSeen || re.ID == peoplePrefix+":Rob"
+			marySeen = marySeen || re.ID == peoplePrefix+":Mary"
+			aliceSeen = aliceSeen || re.ID == peoplePrefix+":Alice"
+			if re.ID == peoplePrefix+":Lisa" {
+				lisaCnt++
+			}
+		}
+		Expect(lisaSeen).To(BeTrue())
+		Expect(robSeen).To(BeTrue())
+		Expect(marySeen).To(BeTrue())
+		Expect(aliceSeen).To(BeTrue())
+		Expect(lisaCnt).To(Equal(2))
+	})
+
+	It("should support deep join paths", func() {
+		// people <------ team -----------> people <------------- office -------> address
+		//         member      team-lead            contact-person        address
+		_, peoplePrefix := createTestDataset("people",
+			[]string{"Bob", "Rob", "Mary", "Alice", "Hank", "Lisa"}, nil, dsm, store)
+
+		teamPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://team/")
+		_, _ = createTestDataset("team", []string{"product", "development"},
+			map[string]map[string]interface{}{
+				"product": {
+					teamPrefix + ":lead": peoplePrefix + ":Bob",
+					teamPrefix + ":member": []string{
+						peoplePrefix + ":Bob",
+						peoplePrefix + ":Rob",
+						peoplePrefix + ":Mary",
 					},
-					"development": {
-						teamPrefix + ":lead": peoplePrefix + ":Alice",
-						teamPrefix + ":member": []string{
-							peoplePrefix + ":Alice",
-							peoplePrefix + ":Hank",
-							peoplePrefix + ":Lisa",
-						},
+				},
+				"development": {
+					teamPrefix + ":lead": peoplePrefix + ":Alice",
+					teamPrefix + ":member": []string{
+						peoplePrefix + ":Alice",
+						peoplePrefix + ":Hank",
+						peoplePrefix + ":Lisa",
 					},
-				}, dsm, g, store)
-
-			addresses, addressPrefix := createTestDataset("address", []string{"BigSquare 1", "Lillevegen 9"},
-				nil, dsm, g, store)
-
-			officePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://office/")
-			createTestDataset("office", []string{"Brisbane", "Stavanger"}, map[string]map[string]interface{}{
-				"Brisbane": {
-					officePrefix + ":contact":  peoplePrefix + ":Bob",
-					officePrefix + ":location": addressPrefix + ":BigSquare 1",
 				},
-				"Stavanger": {
-					officePrefix + ":contact":  peoplePrefix + ":Alice",
-					officePrefix + ":location": addressPrefix + ":Lillevegen 9",
-				},
-			}, dsm, g, store)
+			}, dsm, store)
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
+		addresses, addressPrefix := createTestDataset("address", []string{"BigSquare 1", "Lillevegen 9"},
+			nil, dsm, store)
+
+		officePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://office/")
+		createTestDataset("office", []string{"Brisbane", "Stavanger"}, map[string]map[string]interface{}{
+			"Brisbane": {
+				officePrefix + ":contact":  peoplePrefix + ":Bob",
+				officePrefix + ":location": addressPrefix + ":BigSquare 1",
+			},
+			"Stavanger": {
+				officePrefix + ":contact":  peoplePrefix + ":Alice",
+				officePrefix + ":location": addressPrefix + ":Lillevegen 9",
+			},
+		}, dsm, store)
+
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
                           {
 							"dataset": "address",
 							"joins": [
@@ -1152,148 +1146,148 @@ func TestMultiSource(t *testing.T) {
                           }
                         ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
 
-			// delete Lillevegen 9, verify that all 3 team members at that address are emitted (Alice, Hank, Lisa)
-			fromMap := server.NewEntityFromMap(map[string]interface{}{
-				"id":    addressPrefix + ":Lillevegen 9",
-				"props": map[string]interface{}{"name": "Lillevegen 9"},
-				"refs":  map[string]interface{}{},
-			})
-			fromMap.References = nil
-			fromMap.IsDeleted = true
-			err = addresses.StoreEntities([]*server.Entity{fromMap})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(3)
-
-			m := make(map[string]bool)
-			for _, re := range recordedEntities {
-				m["Alice"] = m["Alice"] || re.ID == peoplePrefix+":Alice"
-				m["Hank"] = m["Hank"] || re.ID == peoplePrefix+":Hank"
-				m["Lisa"] = m["Lisa"] || re.ID == peoplePrefix+":Lisa"
-			}
-			g.Assert(m["Alice"]).IsTrue()
-			g.Assert(m["Hank"]).IsTrue()
-			g.Assert(m["Lisa"]).IsTrue()
+		// delete Lillevegen 9, verify that all 3 team members at that address are emitted (Alice, Hank, Lisa)
+		fromMap := server.NewEntityFromMap(map[string]interface{}{
+			"id":    addressPrefix + ":Lillevegen 9",
+			"props": map[string]interface{}{"name": "Lillevegen 9"},
+			"refs":  map[string]interface{}{},
 		})
-		g.It("Should only emit main entities that exist in main dataset", func() {
-			// people <- employment
-			_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			copyDs, _ := dsm.CreateDataset("peopleTwo", nil)
-			copyDs.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    peoplePrefix + ":Bob",
-					"props": map[string]interface{}{"name": "Bob"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			employmentDs, employmentPrefix := createTestDataset("employment",
-				[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
-					"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
-					"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
-				}, dsm, g, store)
+		fromMap.References = nil
+		fromMap.IsDeleted = true
+		err = addresses.StoreEntities([]*server.Entity{fromMap})
+		Expect(err).To(BeNil())
 
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(3))
+
+		m := make(map[string]bool)
+		for _, re := range recordedEntities {
+			m["Alice"] = m["Alice"] || re.ID == peoplePrefix+":Alice"
+			m["Hank"] = m["Hank"] || re.ID == peoplePrefix+":Hank"
+			m["Lisa"] = m["Lisa"] || re.ID == peoplePrefix+":Lisa"
+		}
+		Expect(m["Alice"]).To(BeTrue())
+		Expect(m["Hank"]).To(BeTrue())
+		Expect(m["Lisa"]).To(BeTrue())
+	})
+	It("Should only emit main entities that exist in main dataset", func() {
+		// people <- employment
+		_, peoplePrefix := createTestDataset("people", []string{"Bob", "Alice"}, nil, dsm, store)
+		copyDs, _ := dsm.CreateDataset("peopleTwo", nil)
+		copyDs.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    peoplePrefix + ":Bob",
+				"props": map[string]interface{}{"name": "Bob"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		employmentDs, employmentPrefix := createTestDataset("employment",
+			[]string{"MediumCorp", "LittleSweatshop", "YardSale"}, map[string]map[string]interface{}{
+				"MediumCorp":      {peoplePrefix + ":employment": peoplePrefix + ":Bob"},
+				"LittleSweatshop": {peoplePrefix + ":employment": peoplePrefix + ":Alice"},
+			}, dsm, store)
+
+		testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+		srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [ {
 							"dataset": "employment",
 							"joins": [ { "dataset": "people", "predicate": "http://people/employment", "inverse": false } ]
 						} ] }`
 
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		srcConfig := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
 
-			// fullsync
-			var recordedEntities []server.Entity
-			token := &source.MultiDatasetContinuation{}
-			var lastToken source.DatasetContinuation
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
+		// fullsync
+		var recordedEntities []server.Entity
+		token := &source.MultiDatasetContinuation{}
+		var lastToken source.DatasetContinuation
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+
+		// now, add new Employment with refs to Bob (exists) and Franz (non-exists)
+		err = employmentDs.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    employmentPrefix + ":YardSale",
+				"props": map[string]interface{}{"name": "YardSale"},
+				"refs": map[string]interface{}{
+					peoplePrefix + ":employment": []string{peoplePrefix + ":Franz", peoplePrefix + ":Bob"},
 				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-
-			// now, add new Employment with refs to Bob (exists) and Franz (non-exists)
-			err = employmentDs.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    employmentPrefix + ":YardSale",
-					"props": map[string]interface{}{"name": "YardSale"},
-					"refs": map[string]interface{}{
-						peoplePrefix + ":employment": []string{peoplePrefix + ":Franz", peoplePrefix + ":Bob"},
-					},
-				}),
-			})
-			g.Assert(err).IsNil()
-
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				lastToken,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					lastToken = token
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).
-				Eql(1, "YardSale change points to non-existing entity 'Franz' in people, therefore only Bob should be emitted")
-			g.Assert(recordedEntities[0].ID).Eql(peoplePrefix + ":Bob")
-			g.Assert(recordedEntities[0].Properties["name"]).
-				Eql("Bob", "Bob exists in two datasets. making sure we dont get a merged result")
+			}),
 		})
+		Expect(err).To(BeNil())
 
-		g.Describe("parseDependencies", func() {
-			g.It("should translate json to config", func() {
-				s := source.MultiSource{DatasetName: "person", Store: store, DatasetManager: dsm}
-				srcJSON := `{
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			lastToken,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				lastToken = token
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).
+			To(Equal(1), "YardSale change points to non-existing entity 'Franz' in people, therefore only Bob should be emitted")
+		Expect(recordedEntities[0].ID).To(Equal(peoplePrefix + ":Bob"))
+		Expect(recordedEntities[0].Properties["name"]).
+			To(Equal("Bob"), "Bob exists in two datasets. making sure we dont get a merged result")
+	})
+
+	Describe("parseDependencies", func() {
+		It("should translate json to config", func() {
+			s := source.MultiSource{DatasetName: "person", Store: store, DatasetManager: dsm}
+			srcJSON := `{
 				"Type" : "MultiSource",
 				"Name" : "person",
 				"Dependencies": [
@@ -1325,49 +1319,49 @@ func TestMultiSource(t *testing.T) {
 				]
 			}`
 
-				srcConfig := map[string]interface{}{}
-				err := json.Unmarshal([]byte(srcJSON), &srcConfig)
-				g.Assert(err).IsNil()
-				err = s.ParseDependencies(srcConfig["Dependencies"])
-				g.Assert(err).IsNil()
+			srcConfig := map[string]interface{}{}
+			err := json.Unmarshal([]byte(srcJSON), &srcConfig)
+			Expect(err).To(BeNil())
+			err = s.ParseDependencies(srcConfig["Dependencies"])
+			Expect(err).To(BeNil())
 
-				g.Assert(s.Dependencies).IsNotZero()
-				g.Assert(len(s.Dependencies)).Eql(2)
+			Expect(s.Dependencies).NotTo(BeZero())
+			Expect(len(s.Dependencies)).To(Equal(2))
 
-				dep := s.Dependencies[0]
-				g.Assert(dep.Dataset).Eql("product")
-				g.Assert(dep.Joins).IsNotZero()
-				g.Assert(len(dep.Joins)).Eql(2)
-				j := dep.Joins[0]
-				g.Assert(j.Dataset).Eql("order")
-				g.Assert(j.Predicate).Eql("product-ordered")
-				g.Assert(j.Inverse).IsTrue()
-				j = dep.Joins[1]
-				g.Assert(j.Dataset).Eql("person")
-				g.Assert(j.Predicate).Eql("ordering-customer")
-				g.Assert(j.Inverse).IsFalse()
+			dep := s.Dependencies[0]
+			Expect(dep.Dataset).To(Equal("product"))
+			Expect(dep.Joins).NotTo(BeZero())
+			Expect(len(dep.Joins)).To(Equal(2))
+			j := dep.Joins[0]
+			Expect(j.Dataset).To(Equal("order"))
+			Expect(j.Predicate).To(Equal("product-ordered"))
+			Expect(j.Inverse).To(BeTrue())
+			j = dep.Joins[1]
+			Expect(j.Dataset).To(Equal("person"))
+			Expect(j.Predicate).To(Equal("ordering-customer"))
+			Expect(j.Inverse).To(BeFalse())
 
-				dep = s.Dependencies[1]
-				g.Assert(dep.Dataset).Eql("order")
-				g.Assert(dep.Joins).IsNotZero()
-				g.Assert(len(dep.Joins)).Eql(1)
-				j = dep.Joins[0]
-				g.Assert(j.Dataset).Eql("person")
-				g.Assert(j.Predicate).Eql("ordering-customer")
-				g.Assert(j.Inverse).IsFalse()
+			dep = s.Dependencies[1]
+			Expect(dep.Dataset).To(Equal("order"))
+			Expect(dep.Joins).NotTo(BeZero())
+			Expect(len(dep.Joins)).To(Equal(1))
+			j = dep.Joins[0]
+			Expect(j.Dataset).To(Equal("person"))
+			Expect(j.Predicate).To(Equal("ordering-customer"))
+			Expect(j.Inverse).To(BeFalse())
+		})
+		It("Should fail if main dataset is proxy dataset", func() {
+			// create main dataset as proxy dataset
+			_, err := dsm.CreateDataset("people", &server.CreateDatasetConfig{
+				ProxyDatasetConfig: &server.ProxyDatasetConfig{
+					RemoteURL: "http://localhost:7777/datasets/people",
+				},
 			})
-			g.It("Should fail if main dataset is proxy dataset", func() {
-				// create main dataset as proxy dataset
-				_, err := dsm.CreateDataset("people", &server.CreateDatasetConfig{
-					ProxyDatasetConfig: &server.ProxyDatasetConfig{
-						RemoteURL: "http://localhost:7777/datasets/people",
-					},
-				})
-				g.Assert(err).IsNil()
+			Expect(err).To(BeNil())
 
-				// now instantiate (simulating job start)
-				testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-				srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
+			// now instantiate (simulating job start)
+			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
                           {
 							"dataset": "address",
 							"joins": [
@@ -1379,24 +1373,24 @@ func TestMultiSource(t *testing.T) {
                           }
                         ] }`
 
-				srcConfig := map[string]interface{}{}
-				_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-				err = testSource.ParseDependencies(srcConfig["Dependencies"])
-				// t.Log(err)
-				g.Assert(err).IsNotNil()
+			srcConfig := map[string]interface{}{}
+			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+			err = testSource.ParseDependencies(srcConfig["Dependencies"])
+			// t.Log(err)
+			Expect(err).NotTo(BeNil())
+		})
+		It("Should fail if a dependency is a proxy dataset", func() {
+			// create dependency dataset as proxy dataset
+			_, err := dsm.CreateDataset("address", &server.CreateDatasetConfig{
+				ProxyDatasetConfig: &server.ProxyDatasetConfig{
+					RemoteURL: "http://localhost:7777/datasets/address",
+				},
 			})
-			g.It("Should fail if a dependency is a proxy dataset", func() {
-				// create dependency dataset as proxy dataset
-				_, err := dsm.CreateDataset("address", &server.CreateDatasetConfig{
-					ProxyDatasetConfig: &server.ProxyDatasetConfig{
-						RemoteURL: "http://localhost:7777/datasets/address",
-					},
-				})
-				g.Assert(err).IsNil()
+			Expect(err).To(BeNil())
 
-				// now instantiate (simulating job start)
-				testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-				srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
+			// now instantiate (simulating job start)
+			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
+			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
                           {
 							"dataset": "address",
 							"joins": [
@@ -1408,23 +1402,23 @@ func TestMultiSource(t *testing.T) {
                           }
                         ] }`
 
-				srcConfig := map[string]interface{}{}
-				_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-				err = testSource.ParseDependencies(srcConfig["Dependencies"])
-				// t.Log(err)
-				g.Assert(err).IsNotNil()
-			})
+			srcConfig := map[string]interface{}{}
+			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
+			err = testSource.ParseDependencies(srcConfig["Dependencies"])
+			// t.Log(err)
+			Expect(err).NotTo(BeNil())
 		})
 	})
-}
+})
 
 func createTestDataset(dsName string, entityNames []string, refMap map[string]map[string]interface{},
-	dsm *server.DsManager, g *goblin.G, store *server.Store,
+	dsm *server.DsManager, store *server.Store,
 ) (*server.Dataset, string) {
+	GinkgoHelper()
 	dataset, err := dsm.CreateDataset(dsName, nil)
-	g.Assert(err).IsNil()
+	Expect(err).To(BeNil())
 	peoplePrefix, err := store.NamespaceManager.AssertPrefixMappingForExpansion("http://" + dsName + "/")
-	g.Assert(err).IsNil()
+	Expect(err).To(BeNil())
 	var entities []*server.Entity
 
 	for _, entityName := range entityNames {
@@ -1436,7 +1430,7 @@ func createTestDataset(dsName string, entityNames []string, refMap map[string]ma
 	}
 
 	err = dataset.StoreEntities(entities)
-	g.Assert(err).IsNil()
+	Expect(err).To(BeNil())
 
 	return dataset, peoplePrefix
 }

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -18,17 +18,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
-	"os"
 
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/mimiro-io/datahub/internal/jobs/source"
 	"github.com/mimiro-io/datahub/internal/server"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("dependency tracking", func() {

--- a/internal/jobs/source/union_source_test.go
+++ b/internal/jobs/source/union_source_test.go
@@ -65,8 +65,8 @@ func TestUnionDatasetSource(t *testing.T) {
 		})
 
 		g.It("should emit changes if not in fullsync mode", func() {
-			adults, adultsPrefix := createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			children, childrenPrefix := createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, g, store)
+			adults, adultsPrefix := createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
+			children, childrenPrefix := createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
 			// add one change to each entity -> 4 changes
 			addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
 			addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
@@ -149,8 +149,8 @@ func TestUnionDatasetSource(t *testing.T) {
 			g.Assert(recordedEntities[0].Properties["name"]).Eql("Grace-changed")
 		})
 		g.It("should support fullsync", func() {
-			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, g, store)
+			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
+			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
 			// add one change to each entity -> 4 changes
 			addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
 			addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
@@ -181,8 +181,8 @@ func TestUnionDatasetSource(t *testing.T) {
 			g.Assert(len(recordedEntities)).Eql(4, "two entities per dataset in latest state")
 		})
 		g.It("should respect latestOnly", func() {
-			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, g, store)
+			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
+			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
 			// add one change to each entity -> 4 changes
 			addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
 			addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
@@ -212,13 +212,12 @@ func TestUnionDatasetSource(t *testing.T) {
 		})
 
 		g.It("should respect batch sizes", func() {
-			createTestDataset("adults", []string{"Bob", "Alice", "a", "b", "c"}, nil, dsm, g, store)
+			createTestDataset("adults", []string{"Bob", "Alice", "a", "b", "c"}, nil, dsm, store)
 			createTestDataset(
 				"children",
 				[]string{"Jimmy", "Grace", "1", "2", "3", "4", "5", "6", "7", "8"},
 				nil,
 				dsm,
-				g,
 				store,
 			)
 
@@ -250,8 +249,8 @@ func TestUnionDatasetSource(t *testing.T) {
 		})
 
 		g.It("should recognize it's tokens", func() {
-			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, g, store)
-			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, g, store)
+			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
+			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
 
 			testSource := source.UnionDatasetSource{
 				[]*source.DatasetSource{

--- a/internal/jobs/source/union_source_test.go
+++ b/internal/jobs/source/union_source_test.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
@@ -31,327 +31,323 @@ import (
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
-func TestUnionDatasetSource(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("A UnionDatasetSource", func() {
-		testCnt := 0
-		var dsm *server.DsManager
-		var store *server.Store
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_dataset_union_source_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
+var _ = Describe("A UnionDatasetSource", func() {
+	testCnt := 0
+	var dsm *server.DsManager
+	var store *server.Store
+	var storeLocation string
+	BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_dataset_union_source_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
 
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(t, false))
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(GinkgoT(), false))
 
-			store = server.NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
+		store = server.NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = server.NewDsManager(lc, e, store, server.NoOpBus())
 
-			err = lc.Start(context.Background())
-			if err != nil {
-				fmt.Println(err.Error())
-				t.FailNow()
-			}
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-
-		g.It("should emit changes if not in fullsync mode", func() {
-			adults, adultsPrefix := createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
-			children, childrenPrefix := createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
-			// add one change to each entity -> 4 changes
-			addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
-			addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
-
-			testSource := source.UnionDatasetSource{
-				[]*source.DatasetSource{
-					{DatasetName: "adults", Store: store, DatasetManager: dsm},
-					{DatasetName: "children", Store: store, DatasetManager: dsm},
-				},
-			}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.UnionDatasetContinuation{}
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(8, "two entities per dataset with 2 changes each expected")
-
-			// now, modify alice and verify that we get alice emitted in next read
-			err = adults.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    adultsPrefix + ":Alice",
-					"props": map[string]interface{}{"name": "Alice-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			since := tokens[len(tokens)-1]
-			tokens = []source.DatasetContinuation{}
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				since,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Alice-changed")
-
-			// now, modify Grace and verify that we get Grace emitted in next read
-			err = children.StoreEntities([]*server.Entity{
-				server.NewEntityFromMap(map[string]interface{}{
-					"id":    childrenPrefix + ":Grace",
-					"props": map[string]interface{}{"name": "Grace-changed"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			g.Assert(err).IsNil()
-			since = tokens[len(tokens)-1]
-			tokens = []source.DatasetContinuation{}
-			recordedEntities = []server.Entity{}
-			err = testSource.ReadEntities(
-				since,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Grace-changed")
-		})
-		g.It("should support fullsync", func() {
-			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
-			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
-			// add one change to each entity -> 4 changes
-			addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
-			addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
-
-			testSource := source.UnionDatasetSource{
-				[]*source.DatasetSource{
-					{DatasetName: "adults", Store: store, DatasetManager: dsm, LatestOnly: true},
-					{DatasetName: "children", Store: store, DatasetManager: dsm},
-				},
-			}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.UnionDatasetContinuation{}
-			testSource.StartFullSync()
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			testSource.EndFullSync()
-			g.Assert(len(recordedEntities)).Eql(4, "two entities per dataset in latest state")
-		})
-		g.It("should respect latestOnly", func() {
-			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
-			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
-			// add one change to each entity -> 4 changes
-			addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
-			addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
-
-			testSource := source.UnionDatasetSource{
-				[]*source.DatasetSource{
-					{DatasetName: "adults", Store: store, DatasetManager: dsm, LatestOnly: true},
-					{DatasetName: "children", Store: store, DatasetManager: dsm},
-				},
-			}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.UnionDatasetContinuation{}
-			err := testSource.ReadEntities(
-				token,
-				1000,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(6, "two entities per dataset, incl 2 changes in children")
-		})
-
-		g.It("should respect batch sizes", func() {
-			createTestDataset("adults", []string{"Bob", "Alice", "a", "b", "c"}, nil, dsm, store)
-			createTestDataset(
-				"children",
-				[]string{"Jimmy", "Grace", "1", "2", "3", "4", "5", "6", "7", "8"},
-				nil,
-				dsm,
-				store,
-			)
-
-			testSource := source.UnionDatasetSource{
-				[]*source.DatasetSource{
-					{DatasetName: "adults", Store: store, DatasetManager: dsm},
-					{DatasetName: "children", Store: store, DatasetManager: dsm},
-				},
-			}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			token := &source.UnionDatasetContinuation{}
-			batchCount := 0
-			err := testSource.ReadEntities(
-				token,
-				3,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					batchCount = batchCount + 1
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(15)
-			g.Assert(batchCount).Eql(7, "2 batches from adults, 4 from children, plus final empty batch.")
-		})
-
-		g.It("should recognize it's tokens", func() {
-			createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
-			createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
-
-			testSource := source.UnionDatasetSource{
-				[]*source.DatasetSource{
-					{DatasetName: "adults", Store: store, DatasetManager: dsm},
-					{DatasetName: "children", Store: store, DatasetManager: dsm},
-				},
-			}
-			var tokens []source.DatasetContinuation
-			var recordedEntities []server.Entity
-			startToken := source.UnionDatasetContinuation{}
-			err := testSource.ReadEntities(
-				&startToken,
-				3,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(4)
-
-			// run with last returned token and no changes
-			startToken = *tokens[len(tokens)-1].(*source.UnionDatasetContinuation)
-			recordedEntities = make([]server.Entity, 0)
-			err = testSource.ReadEntities(
-				&startToken,
-				3,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(0)
-			g.Assert(startToken).Eql(*(tokens[len(tokens)-1].(*source.UnionDatasetContinuation)))
-
-			// add a change to adults
-			addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
-			startToken = *tokens[len(tokens)-1].(*source.UnionDatasetContinuation)
-			recordedEntities = make([]server.Entity, 0)
-			err = testSource.ReadEntities(
-				&startToken,
-				3,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(2)
-			g.Assert(recordedEntities[0].Properties["name"]).Eql("Bob")
-			g.Assert(recordedEntities[1].Properties["name"]).Eql("Alice")
-
-			// add a change to 2nd ds
-			addChanges("children", []string{"Jimmy"}, dsm, store)
-			startToken = *tokens[len(tokens)-1].(*source.UnionDatasetContinuation)
-			recordedEntities = make([]server.Entity, 0)
-			err = testSource.ReadEntities(
-				&startToken,
-				3,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(recordedEntities)).Eql(1)
-
-			cont, _ := (tokens[len(tokens)-1].(*source.UnionDatasetContinuation)).Encode()
-			g.Assert(cont).
-				Eql("{\"Tokens\":[{\"Token\":\"4\"},{\"Token\":\"3\"}],\"DatasetNames\":[\"adults\",\"children\"]}")
-
-			// simulate order change in source config
-			startToken = *tokens[len(tokens)-1].(*source.UnionDatasetContinuation)
-			startToken.DatasetNames = []string{"children", "adults"}
-			recordedEntities = make([]server.Entity, 0)
-			err = testSource.ReadEntities(
-				&startToken,
-				3,
-				func(entities []*server.Entity, token source.DatasetContinuation) error {
-					tokens = append(tokens, token)
-					for _, e := range entities {
-						recordedEntities = append(recordedEntities, *e)
-					}
-					return nil
-				},
-			)
-			g.Assert(err).IsNotZero("should fail due to changed order of datasets")
-			g.Assert(len(recordedEntities)).Eql(0)
-		})
+		err = lc.Start(context.Background())
+		if err != nil {
+			Fail(err.Error())
+		}
 	})
-}
+	AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+
+	It("should emit changes if not in fullsync mode", func() {
+		adults, adultsPrefix := createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
+		children, childrenPrefix := createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
+		// add one change to each entity -> 4 changes
+		addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
+		addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
+
+		testSource := source.UnionDatasetSource{
+			[]*source.DatasetSource{
+				{DatasetName: "adults", Store: store, DatasetManager: dsm},
+				{DatasetName: "children", Store: store, DatasetManager: dsm},
+			},
+		}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.UnionDatasetContinuation{}
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(8), "two entities per dataset with 2 changes each expected")
+
+		// now, modify alice and verify that we get alice emitted in next read
+		err = adults.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    adultsPrefix + ":Alice",
+				"props": map[string]interface{}{"name": "Alice-changed"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		Expect(err).To(BeNil())
+		since := tokens[len(tokens)-1]
+		tokens = []source.DatasetContinuation{}
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			since,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Alice-changed"))
+
+		// now, modify Grace and verify that we get Grace emitted in next read
+		err = children.StoreEntities([]*server.Entity{
+			server.NewEntityFromMap(map[string]interface{}{
+				"id":    childrenPrefix + ":Grace",
+				"props": map[string]interface{}{"name": "Grace-changed"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		Expect(err).To(BeNil())
+		since = tokens[len(tokens)-1]
+		tokens = []source.DatasetContinuation{}
+		recordedEntities = []server.Entity{}
+		err = testSource.ReadEntities(
+			since,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Grace-changed"))
+	})
+	It("should support fullsync", func() {
+		createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
+		createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
+		// add one change to each entity -> 4 changes
+		addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
+		addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
+
+		testSource := source.UnionDatasetSource{
+			[]*source.DatasetSource{
+				{DatasetName: "adults", Store: store, DatasetManager: dsm, LatestOnly: true},
+				{DatasetName: "children", Store: store, DatasetManager: dsm},
+			},
+		}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.UnionDatasetContinuation{}
+		testSource.StartFullSync()
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		testSource.EndFullSync()
+		Expect(len(recordedEntities)).To(Equal(4), "two entities per dataset in latest state")
+	})
+	It("should respect latestOnly", func() {
+		createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
+		createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
+		// add one change to each entity -> 4 changes
+		addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
+		addChanges("children", []string{"Jimmy", "Grace"}, dsm, store)
+
+		testSource := source.UnionDatasetSource{
+			[]*source.DatasetSource{
+				{DatasetName: "adults", Store: store, DatasetManager: dsm, LatestOnly: true},
+				{DatasetName: "children", Store: store, DatasetManager: dsm},
+			},
+		}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.UnionDatasetContinuation{}
+		err := testSource.ReadEntities(
+			token,
+			1000,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(6), "two entities per dataset, incl 2 changes in children")
+	})
+
+	It("should respect batch sizes", func() {
+		createTestDataset("adults", []string{"Bob", "Alice", "a", "b", "c"}, nil, dsm, store)
+		createTestDataset(
+			"children",
+			[]string{"Jimmy", "Grace", "1", "2", "3", "4", "5", "6", "7", "8"},
+			nil,
+			dsm,
+			store,
+		)
+
+		testSource := source.UnionDatasetSource{
+			[]*source.DatasetSource{
+				{DatasetName: "adults", Store: store, DatasetManager: dsm},
+				{DatasetName: "children", Store: store, DatasetManager: dsm},
+			},
+		}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		token := &source.UnionDatasetContinuation{}
+		batchCount := 0
+		err := testSource.ReadEntities(
+			token,
+			3,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				batchCount = batchCount + 1
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(15))
+		Expect(batchCount).To(Equal(7), "2 batches from adults, 4 from children, plus final empty batch.")
+	})
+
+	It("should recognize it's tokens", func() {
+		createTestDataset("adults", []string{"Bob", "Alice"}, nil, dsm, store)
+		createTestDataset("children", []string{"Jimmy", "Grace"}, nil, dsm, store)
+
+		testSource := source.UnionDatasetSource{
+			[]*source.DatasetSource{
+				{DatasetName: "adults", Store: store, DatasetManager: dsm},
+				{DatasetName: "children", Store: store, DatasetManager: dsm},
+			},
+		}
+		var tokens []source.DatasetContinuation
+		var recordedEntities []server.Entity
+		startToken := source.UnionDatasetContinuation{}
+		err := testSource.ReadEntities(
+			&startToken,
+			3,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(4))
+
+		// run with last returned token and no changes
+		startToken = *tokens[len(tokens)-1].(*source.UnionDatasetContinuation)
+		recordedEntities = make([]server.Entity, 0)
+		err = testSource.ReadEntities(
+			&startToken,
+			3,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(0))
+		Expect(startToken).To(Equal(*(tokens[len(tokens)-1].(*source.UnionDatasetContinuation))))
+
+		// add a change to adults
+		addChanges("adults", []string{"Bob", "Alice"}, dsm, store)
+		startToken = *tokens[len(tokens)-1].(*source.UnionDatasetContinuation)
+		recordedEntities = make([]server.Entity, 0)
+		err = testSource.ReadEntities(
+			&startToken,
+			3,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(2))
+		Expect(recordedEntities[0].Properties["name"]).To(Equal("Bob"))
+		Expect(recordedEntities[1].Properties["name"]).To(Equal("Alice"))
+
+		// add a change to 2nd ds
+		addChanges("children", []string{"Jimmy"}, dsm, store)
+		startToken = *tokens[len(tokens)-1].(*source.UnionDatasetContinuation)
+		recordedEntities = make([]server.Entity, 0)
+		err = testSource.ReadEntities(
+			&startToken,
+			3,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(recordedEntities)).To(Equal(1))
+
+		cont, _ := (tokens[len(tokens)-1].(*source.UnionDatasetContinuation)).Encode()
+		Expect(cont).
+			To(Equal("{\"Tokens\":[{\"Token\":\"4\"},{\"Token\":\"3\"}],\"DatasetNames\":[\"adults\",\"children\"]}"))
+
+		// simulate order change in source config
+		startToken = *tokens[len(tokens)-1].(*source.UnionDatasetContinuation)
+		startToken.DatasetNames = []string{"children", "adults"}
+		recordedEntities = make([]server.Entity, 0)
+		err = testSource.ReadEntities(
+			&startToken,
+			3,
+			func(entities []*server.Entity, token source.DatasetContinuation) error {
+				tokens = append(tokens, token)
+				for _, e := range entities {
+					recordedEntities = append(recordedEntities, *e)
+				}
+				return nil
+			},
+		)
+		Expect(err).NotTo(BeZero(), "should fail due to changed order of datasets")
+		Expect(len(recordedEntities)).To(Equal(0))
+	})
+})

--- a/internal/jobs/transform_test.go
+++ b/internal/jobs/transform_test.go
@@ -17,21 +17,19 @@ package jobs
 import (
 	"encoding/base64"
 	"strings"
-	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
-func TestTransform(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("A Javascript transformation", func() {
-		g.It("Should return a go error when the script fails", func() {
-			// a failing function
-			js := ` // fail.js
+var _ = Describe("A Javascript transformation", func() {
+	It("Should return a go error when the script fails", func() {
+		// a failing function
+		js := ` // fail.js
 					function transform_entities(entities) {
 						for (e of entities) {
 							var bodyEvent = GetProperty(e, prefix, "failField");
@@ -39,68 +37,67 @@ func TestTransform(t *testing.T) {
 					  	}
 						return entities;
 					}`
-			f := base64.StdEncoding.EncodeToString([]byte(js))
+		f := base64.StdEncoding.EncodeToString([]byte(js))
 
-			transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
-			g.Assert(err).IsNil("Expected transform runner to be created without error")
+		transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
+		Expect(err).To(BeNil(), "Expected transform runner to be created without error")
 
-			entities := make([]*server.Entity, 0)
-			entities = append(entities, server.NewEntity("1", 1))
+		entities := make([]*server.Entity, 0)
+		entities = append(entities, server.NewEntity("1", 1))
 
-			_, err = transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
-			g.Assert(err).IsNotNil("transform should fail")
-			g.Assert(strings.Split(err.Error(), " (")[0]).
-				Eql("ReferenceError: prefix is not defined at transform_entities")
-		})
-		g.It("Should return a go error when the script emits non-entities", func() {
-			// a failing function
-			js := ` function transform_entities(entities) {
+		_, err = transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
+		Expect(err).NotTo(BeNil(), "transform should fail")
+		Expect(strings.Split(err.Error(), " (")[0]).
+			To(Equal("ReferenceError: prefix is not defined at transform_entities"))
+	})
+	It("Should return a go error when the script emits non-entities", func() {
+		// a failing function
+		js := ` function transform_entities(entities) {
 						return ["hello"];
 					}`
-			f := base64.StdEncoding.EncodeToString([]byte(js))
+		f := base64.StdEncoding.EncodeToString([]byte(js))
 
-			transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
-			g.Assert(err).IsNil("Expected transform runner to be created without error")
+		transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
+		Expect(err).To(BeNil(), "Expected transform runner to be created without error")
 
-			entities := make([]*server.Entity, 0)
-			entities = append(entities, server.NewEntity("1", 1))
+		entities := make([]*server.Entity, 0)
+		entities = append(entities, server.NewEntity("1", 1))
 
-			_, err = transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
-			g.Assert(err).IsNotNil("transform should fail")
-			g.Assert(strings.Split(err.Error(), " (")[0]).
-				Eql("transform emitted invalid entity: hello")
-		})
-		g.It("Should produce type compatible number properties", func() {
-			// goja stores numbers without decimals as int64, we need float64 to be type-compatible with
-			// json deserialized entities
-			js := ` function transform_entities(entities) {
+		_, err = transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
+		Expect(err).NotTo(BeNil(), "transform should fail")
+		Expect(strings.Split(err.Error(), " (")[0]).To(Equal("transform emitted invalid entity: hello"))
+	})
+	It("Should produce type compatible number properties", func() {
+		// goja stores numbers without decimals as int64, we need float64 to be type-compatible with
+		// json deserialized entities
+		js := ` function transform_entities(entities) {
 
 						for (e of entities) {
 							SetProperty(e, "b", "output", GetProperty(e, "a", "input"))
 						}
 						return entities;
 					}`
-			f := base64.StdEncoding.EncodeToString([]byte(js))
+		f := base64.StdEncoding.EncodeToString([]byte(js))
 
-			transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
-			g.Assert(err).IsNil("Expected transform runner to be created without error")
+		transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
+		Expect(err).To(BeNil(), "Expected transform runner to be created without error")
 
-			entities := make([]*server.Entity, 0)
-			entities = append(entities, server.NewEntityFromMap(map[string]any{
-				"id": "1",
-				"props": map[string]any{
-					"a:input": float64(6708238),
-				},
-				"refs": map[string]any{},
-			}))
+		entities := make([]*server.Entity, 0)
+		entities = append(entities, server.NewEntityFromMap(map[string]any{
+			"id": "1",
+			"props": map[string]any{
+				"a:input": float64(6708238),
+			},
+			"refs": map[string]any{},
+		}))
 
-			r, err := transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
-			g.Assert(err).IsNil()
-			g.Assert(len(r)).Eql(1)
-			g.Assert(r[0].Properties["b:output"]).Eql(entities[0].Properties["a:input"])
-		})
-		g.It("Should produce type compatible numbers in nested entities", func() {
-			js := ` function transform_entities(entities) {
+		r, err := transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
+		Expect(err).To(BeNil())
+		Expect(len(r)).To(Equal(1))
+		Expect(r[0].Properties["b:output"]).To(Equal(entities[0].Properties["a:input"]))
+	})
+	It("Should produce type compatible numbers in nested entities", func() {
+		js := ` function transform_entities(entities) {
 						for (e of entities) {
 							const n = NewEntity();
 							SetProperty(n, "b", "num", GetProperty(e, "a", "input"));
@@ -108,132 +105,125 @@ func TestTransform(t *testing.T) {
 						}
 						return entities;
 					}`
-			f := base64.StdEncoding.EncodeToString([]byte(js))
+		f := base64.StdEncoding.EncodeToString([]byte(js))
 
-			transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
-			g.Assert(err).IsNil("Expected transform runner to be created without error")
+		transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
+		Expect(err).To(BeNil(), "Expected transform runner to be created without error")
 
-			entities := make([]*server.Entity, 0)
-			entities = append(entities, server.NewEntityFromMap(map[string]any{
-				"id": "1",
-				"props": map[string]any{
-					"a:input": float64(6708238),
-				},
-				"refs": map[string]any{},
-			}))
+		entities := make([]*server.Entity, 0)
+		entities = append(entities, server.NewEntityFromMap(map[string]any{
+			"id": "1",
+			"props": map[string]any{
+				"a:input": float64(6708238),
+			},
+			"refs": map[string]any{},
+		}))
 
-			r, _ := transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
-			g.Assert(len(r)).Eql(1)
-			// t.Logf("%+v", r[0])
-			g.Assert(r[0].Properties["b:output"].(*server.Entity).
-				Properties["b:num"]).Eql(entities[0].Properties["a:input"])
-		})
-		g.It("Should produce type compatible numbers in value array properties", func() {
-			js := ` function transform_entities(entities) {
+		r, _ := transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
+		Expect(len(r)).To(Equal(1))
+		// t.Logf("%+v", r[0])
+		Expect(r[0].Properties["b:output"].(*server.Entity).
+			Properties["b:num"]).To(Equal(entities[0].Properties["a:input"]))
+	})
+	It("Should produce type compatible numbers in value array properties", func() {
+		js := ` function transform_entities(entities) {
 						for (e of entities) {
 							const val = GetProperty(e, "a", "input");
 							SetProperty(e, "b", "output", [val, val]);
 						}
 						return entities;
 					}`
-			f := base64.StdEncoding.EncodeToString([]byte(js))
+		f := base64.StdEncoding.EncodeToString([]byte(js))
 
-			transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
-			g.Assert(err).IsNil("Expected transform runner to be created without error")
+		transform, err := NewJavascriptTransform(zap.NewNop().Sugar(), f, nil, nil)
+		Expect(err).To(BeNil(), "Expected transform runner to be created without error")
 
-			entities := make([]*server.Entity, 0)
-			entities = append(entities, server.NewEntityFromMap(map[string]any{
-				"id": "1",
-				"props": map[string]any{
-					"a:input": float64(6708238),
-				},
-				"refs": map[string]any{},
-			}))
+		entities := make([]*server.Entity, 0)
+		entities = append(entities, server.NewEntityFromMap(map[string]any{
+			"id": "1",
+			"props": map[string]any{
+				"a:input": float64(6708238),
+			},
+			"refs": map[string]any{},
+		}))
 
-			r, err := transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
-			g.Assert(err).IsNil()
-			g.Assert(len(r)).Eql(1)
-			// t.Logf("%+v", r[0])
-			g.Assert(r[0].Properties["b:output"]).Eql([]interface{}{
-				entities[0].Properties["a:input"],
-				entities[0].Properties["a:input"],
-			})
-		})
+		r, err := transform.transformEntities(&Runner{statsdClient: &statsd.NoOpClient{}}, entities, "")
+		Expect(err).To(BeNil())
+		Expect(len(r)).To(Equal(1))
+		// t.Logf("%+v", r[0])
+		Expect(r[0].Properties["b:output"]).To(Equal([]interface{}{
+			entities[0].Properties["a:input"],
+			entities[0].Properties["a:input"],
+		}))
 	})
-}
+})
 
-func TestJavascriptTransform_ToString(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("Calling ToString from a transform", func() {
-		g.It("should return null when nil", func() {
-			transform := &JavascriptTransform{}
-			ret := transform.ToString(nil)
+var _ = Describe("Calling ToString from a transform", func() {
+	It("should return null when nil", func() {
+		transform := &JavascriptTransform{}
+		ret := transform.ToString(nil)
 
-			g.Assert(ret).Equal("undefined")
-		})
-		g.It("number should be formatted as a number", func() {
-			transform := &JavascriptTransform{}
-			ret := transform.ToString(30)
-			g.Assert(ret).Equal("30")
-
-			ret = transform.ToString(2.1)
-			g.Assert(ret).Equal("2.1")
-		})
-		g.It("bool should be formatted with true or false", func() {
-			transform := &JavascriptTransform{}
-			ret := transform.ToString(true)
-			g.Assert(ret).Equal("true")
-		})
-		g.It("a map should correctly formatted", func() {
-			transform := &JavascriptTransform{}
-
-			lemap := map[string]interface{}{
-				"field1": 1,
-				"field2": "2",
-			}
-
-			ret := transform.ToString(lemap)
-			g.Assert(ret).Equal("map[field1:1 field2:2]")
-		})
-		g.It("an entity should be formatted correctly", func() {
-			transform := &JavascriptTransform{}
-
-			e := transform.NewEntity()
-			e.ID = "ns1:1"
-			e.InternalID = 1
-			e.Recorded = 2
-			e.Properties = map[string]interface{}{
-				"field1": "hello",
-			}
-			ret := transform.ToString(e)
-
-			g.Assert(ret).Equal("&{ns1:1 1 2 false map[] map[field1:hello]}")
-		})
+		Expect(ret).To(Equal("undefined"))
 	})
-}
+	It("number should be formatted as a number", func() {
+		transform := &JavascriptTransform{}
+		ret := transform.ToString(30)
+		Expect(ret).To(Equal("30"))
 
-func TestHttpTransformConfig(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("Test that httpTransform picks up timeout from config", func() {
-		g.It("Should return correct httpTransform", func() {
-			c := &JobConfiguration{
-				ID:          "oes3fjudqn",
-				Title:       "my-test-title",
-				Description: "my-description",
-				Source:      map[string]interface{}{"Type": "DatasetSource", "Name": "test-dataset"},
-				Sink:        map[string]interface{}{"Type": "DatasetSink", "Name": "test-transformed"},
-				Transform: map[string]interface{}{
-					"TimeOut": 70.00,
-					"Type":    "HttpTransform",
-					"Url":     "https://very-external",
-				},
-			}
-			transform := &HTTPTransform{TimeOut: 70.00, URL: "https://very-external"}
-			scheduler := Scheduler{}
-			test, err := scheduler.parseTransform(c)
-			g.Assert(err).IsNil("should not error here")
-
-			g.Assert(transform).Equal(test, "Bare minimum transform")
-		})
+		ret = transform.ToString(2.1)
+		Expect(ret).To(Equal("2.1"))
 	})
-}
+	It("bool should be formatted with true or false", func() {
+		transform := &JavascriptTransform{}
+		ret := transform.ToString(true)
+		Expect(ret).To(Equal("true"))
+	})
+	It("a map should correctly formatted", func() {
+		transform := &JavascriptTransform{}
+
+		lemap := map[string]interface{}{
+			"field1": 1,
+			"field2": "2",
+		}
+
+		ret := transform.ToString(lemap)
+		Expect(ret).To(Equal("map[field1:1 field2:2]"))
+	})
+	It("an entity should be formatted correctly", func() {
+		transform := &JavascriptTransform{}
+
+		e := transform.NewEntity()
+		e.ID = "ns1:1"
+		e.InternalID = 1
+		e.Recorded = 2
+		e.Properties = map[string]interface{}{
+			"field1": "hello",
+		}
+		ret := transform.ToString(e)
+
+		Expect(ret).To(Equal("&{ns1:1 1 2 false map[] map[field1:hello]}"))
+	})
+})
+
+var _ = Describe("Test that httpTransform picks up timeout from config", func() {
+	It("Should return correct httpTransform", func() {
+		c := &JobConfiguration{
+			ID:          "oes3fjudqn",
+			Title:       "my-test-title",
+			Description: "my-description",
+			Source:      map[string]interface{}{"Type": "DatasetSource", "Name": "test-dataset"},
+			Sink:        map[string]interface{}{"Type": "DatasetSink", "Name": "test-transformed"},
+			Transform: map[string]interface{}{
+				"TimeOut": 70.00,
+				"Type":    "HttpTransform",
+				"Url":     "https://very-external",
+			},
+		}
+		transform := &HTTPTransform{TimeOut: 70.00, URL: "https://very-external"}
+		scheduler := Scheduler{}
+		test, err := scheduler.parseTransform(c)
+		Expect(err).To(BeNil(), "should not error here")
+
+		Expect(transform).To(Equal(test), "Bare minimum transform")
+	})
+})

--- a/internal/security/login_provider_test.go
+++ b/internal/security/login_provider_test.go
@@ -17,10 +17,10 @@ package security
 import (
 	"os"
 	"strconv"
-	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
@@ -29,98 +29,94 @@ import (
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
-func TestCrud(t *testing.T) {
-	g := goblin.Goblin(t)
+var _ = Describe("Login Provider Crud operations", func() {
+	var store *server.Store
+	var e *conf.Env
+	var pm *ProviderManager
+	testCnt := 0
 
-	g.Describe("Login Provider Crud operations", func() {
-		var store *server.Store
-		var e *conf.Env
-		var pm *ProviderManager
-		testCnt := 0
-
-		g.BeforeEach(func() {
-			testCnt = testCnt + 1
-			e = &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: "./test_login_provider_" + strconv.Itoa(testCnt),
-			}
-			err := os.RemoveAll(e.StoreLocation)
-			g.Assert(err).IsNil("should be allowed to clean test files in " + e.StoreLocation)
-			lc := fxtest.NewLifecycle(internal.FxTestLog(t, false))
-			sc := &statsd.NoOpClient{}
-			store = server.NewStore(lc, e, sc)
-			lc.RequireStart()
-			pm = NewProviderManager(lc, e, store, zap.NewNop().Sugar())
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(e.StoreLocation)
-		})
-		g.It("should add a config", func() {
-			p := createConfig("test-jwt")
-			err := pm.AddProvider(p)
-			g.Assert(err).IsNil()
-		})
-		g.It("should be able to get a config by name", func() {
-			p := createConfig("test-jwt-2")
-			err := pm.AddProvider(p)
-			g.Assert(err).IsNil()
-
-			p2, err := pm.FindByName("test-jwt-2")
-			g.Assert(err).IsNil()
-			g.Assert(p2).IsNotNil()
-
-			g.Assert(p2.Name).Equal("test-jwt-2")
-		})
-		g.It("should be able to update a config", func() {
-			p := createConfig("test-jwt-3")
-			err := pm.AddProvider(p)
-			g.Assert(err).IsNil()
-
-			p.Endpoint = &ValueReader{
-				Type:  "text",
-				Value: "http://localhost/hello",
-			}
-			err = pm.AddProvider(p)
-			g.Assert(err).IsNil()
-
-			// load it back
-			p2, err := pm.FindByName("test-jwt-3")
-			g.Assert(err).IsNil()
-			g.Assert(p2).IsNotNil()
-			g.Assert(pm.LoadValue(p2.Endpoint)).Equal("http://localhost/hello")
-
-			_, err = pm.FindByName("test-jwt-4")
-			g.Assert(err).Eql(ErrLoginProviderNotFound)
-		})
-		g.It("should be able to delete a config", func() {
-			p := createConfig("test-jwt-5")
-			err := pm.AddProvider(p)
-			g.Assert(err).IsNil()
-
-			p2, err := pm.FindByName("test-jwt-5")
-			g.Assert(err).IsNil()
-			g.Assert(p2).IsNotNil()
-
-			err = pm.DeleteProvider("test-jwt-5")
-			g.Assert(err).IsNil()
-
-			p3, err := pm.FindByName("test-jwt-5")
-			g.Assert(err).Eql(ErrLoginProviderNotFound)
-			g.Assert(p3).IsZero()
-		})
-		g.It("should list all configs", func() {
-			p := createConfig("test-jwt-6")
-			_ = pm.AddProvider(p)
-			p2 := createConfig("test-jwt-7")
-			_ = pm.AddProvider(p2)
-
-			items, err := pm.ListProviders()
-			g.Assert(err).IsNil()
-			g.Assert(len(items)).Equal(2)
-		})
+	BeforeEach(func() {
+		testCnt = testCnt + 1
+		e = &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: "./test_login_provider_" + strconv.Itoa(testCnt),
+		}
+		err := os.RemoveAll(e.StoreLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean test files in "+e.StoreLocation)
+		lc := fxtest.NewLifecycle(internal.FxTestLog(GinkgoT(), false))
+		sc := &statsd.NoOpClient{}
+		store = server.NewStore(lc, e, sc)
+		lc.RequireStart()
+		pm = NewProviderManager(lc, e, store, zap.NewNop().Sugar())
 	})
-}
+	AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(e.StoreLocation)
+	})
+	It("should add a config", func() {
+		p := createConfig("test-jwt")
+		err := pm.AddProvider(p)
+		Expect(err).To(BeNil())
+	})
+	It("should be able to get a config by name", func() {
+		p := createConfig("test-jwt-2")
+		err := pm.AddProvider(p)
+		Expect(err).To(BeNil())
+
+		p2, err := pm.FindByName("test-jwt-2")
+		Expect(err).To(BeNil())
+		Expect(p2).NotTo(BeNil())
+
+		Expect(p2.Name).To(Equal("test-jwt-2"))
+	})
+	It("should be able to update a config", func() {
+		p := createConfig("test-jwt-3")
+		err := pm.AddProvider(p)
+		Expect(err).To(BeNil())
+
+		p.Endpoint = &ValueReader{
+			Type:  "text",
+			Value: "http://localhost/hello",
+		}
+		err = pm.AddProvider(p)
+		Expect(err).To(BeNil())
+
+		// load it back
+		p2, err := pm.FindByName("test-jwt-3")
+		Expect(err).To(BeNil())
+		Expect(p2).NotTo(BeNil())
+		Expect(pm.LoadValue(p2.Endpoint)).To(Equal("http://localhost/hello"))
+
+		_, err = pm.FindByName("test-jwt-4")
+		Expect(err).To(Equal(ErrLoginProviderNotFound))
+	})
+	It("should be able to delete a config", func() {
+		p := createConfig("test-jwt-5")
+		err := pm.AddProvider(p)
+		Expect(err).To(BeNil())
+
+		p2, err := pm.FindByName("test-jwt-5")
+		Expect(err).To(BeNil())
+		Expect(p2).NotTo(BeNil())
+
+		err = pm.DeleteProvider("test-jwt-5")
+		Expect(err).To(BeNil())
+
+		p3, err := pm.FindByName("test-jwt-5")
+		Expect(err).To(Equal(ErrLoginProviderNotFound))
+		Expect(p3).To(BeZero())
+	})
+	It("should list all configs", func() {
+		p := createConfig("test-jwt-6")
+		_ = pm.AddProvider(p)
+		p2 := createConfig("test-jwt-7")
+		_ = pm.AddProvider(p2)
+
+		items, err := pm.ListProviders()
+		Expect(err).To(BeNil())
+		Expect(len(items)).To(Equal(2))
+	})
+})
 
 func createConfig(name string) ProviderConfig {
 	return ProviderConfig{

--- a/internal/server/dataset_test.go
+++ b/internal/server/dataset_test.go
@@ -20,15 +20,14 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
-
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
 )
 
 type testEnv struct {
@@ -40,179 +39,176 @@ type testEnv struct {
 	storeLocation          string
 }
 
-func TestDataset(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("A Dataset", func() {
-		testCnt := 0
-		var storeLocation string
-		var env *testEnv
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_dataset_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
+var _ = ginkgo.Describe("A Dataset", func() {
+	testCnt := 0
+	var storeLocation string
+	var env *testEnv
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_dataset_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
 
-			// create store
-			e := &conf.Env{Logger: zap.NewNop().Sugar(), StoreLocation: storeLocation}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(t, false))
-			s := NewStore(lc, e, &statsd.NoOpClient{})
-			dsm := NewDsManager(lc, e, s, NoOpBus())
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
+		// create store
+		e := &conf.Env{Logger: zap.NewNop().Sugar(), StoreLocation: storeLocation}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(ginkgo.GinkgoT(), false))
+		s := NewStore(lc, e, &statsd.NoOpClient{})
+		dsm := NewDsManager(lc, e, s, NoOpBus())
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
 
-			// namespaces
-			peopleNamespacePrefix, _ := s.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			companyNamespacePrefix, _ := s.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/company/",
-			)
+		// namespaces
+		peopleNamespacePrefix, _ := s.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		companyNamespacePrefix, _ := s.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/company/",
+		)
 
-			// create dataset
-			peopleDataset, _ := dsm.CreateDataset("people", nil)
-			env = &testEnv{
-				s,
-				peopleNamespacePrefix,
-				companyNamespacePrefix,
-				peopleDataset,
-				dsm,
-				storeLocation,
-			}
-		})
-		g.AfterEach(func() {
-			_ = env.store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-		g.It("XXX Should accept both single strings and string arrays as refs values", func() {
-			// add a first person with all new refs
-			person := NewEntity(env.peopleNamespacePrefix+":person-1", 1)
-			person.Properties[env.peopleNamespacePrefix+":Name"] = "person 1"
-			person.References[env.peopleNamespacePrefix+":worksfor"] = env.companyNamespacePrefix + ":company-3"
-			person.References[env.peopleNamespacePrefix+":workedfor"] = []string{
-				env.companyNamespacePrefix + ":company-2",
-				env.companyNamespacePrefix + ":company-1",
-			}
-			err := env.ds.StoreEntities([]*Entity{person})
-			g.Assert(err).IsNil("Expected entity to be stored without error")
-			// query
-			queryIds := []string{"http://data.mimiro.io/people/person-1"}
-			result, err := env.store.GetManyRelatedEntities(queryIds, "*", false, []string{})
-			g.Assert(err).IsNil("Expected query to succeed")
-
-			var company2Seen, company1Seen bool
-			for _, r := range result {
-				refEntityID := r[2].(*Entity).ID
-				relation := r[1].(string)
-				if strings.Contains(relation, "worksfor") {
-					g.Assert(refEntityID == "ns4:company-3").IsTrue("worksfor should be company-3")
-				}
-				if strings.Contains(relation, "workedfor") {
-					company1Seen = company1Seen || strings.Contains(refEntityID, "company-1")
-					company2Seen = company2Seen || strings.Contains(refEntityID, "company-2")
-				}
-			}
-			g.Assert(company1Seen).IsTrue("company-1 was not observed in relations")
-			g.Assert(company2Seen).IsTrue("company-2 was not observed in relations")
-
-			// add the same person with updated working relations, thus covering the "not new" branch of code
-			person = NewEntity(env.peopleNamespacePrefix+":person-"+strconv.Itoa(1), 0)
-			person.Properties[env.peopleNamespacePrefix+":Name"] = "person " + strconv.Itoa(2)
-			person.References[env.peopleNamespacePrefix+":worksfor"] = env.companyNamespacePrefix + ":company-4"
-			person.References[env.peopleNamespacePrefix+":workedfor"] = []string{
-				env.companyNamespacePrefix + ":company-3",
-				env.companyNamespacePrefix + ":company-2",
-				env.companyNamespacePrefix + ":company-1",
-			}
-
-			err = env.ds.StoreEntities([]*Entity{person})
-			g.Assert(err).IsNil("Expected entity to be stored without error")
-
-			// query
-			result, err = env.store.GetManyRelatedEntities(queryIds, "*", false, []string{})
-			g.Assert(err).IsNil("Expected query to succeed")
-
-			company3Seen := false
-			company2Seen = false
-			company1Seen = false
-			for _, r := range result {
-				refEntityID := r[2].(*Entity).ID
-				relation := r[1].(string)
-				if strings.Contains(relation, "worksfor") {
-					g.Assert(refEntityID == "ns4:company-4").IsTrue("worksfor should be company-4")
-				}
-				if strings.Contains(relation, "workedfor") {
-					company1Seen = company1Seen || strings.Contains(refEntityID, "company-1")
-					company2Seen = company2Seen || strings.Contains(refEntityID, "company-2")
-					company3Seen = company3Seen || strings.Contains(refEntityID, "company-3")
-				}
-			}
-			g.Assert(company1Seen).IsTrue("company-1 was not observed in relations")
-			g.Assert(company2Seen).IsTrue("company-2 was not observed in relations")
-			g.Assert(company3Seen).IsTrue("company-3 was not observed in relations")
-		})
-
-		g.It("Should use it's publicNamespaces property for context", func() {
-			// first part: test that we get global namespace if nothing is overridden
-			_, _ = env.store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/internal/secret/finance",
-			)
-			_, _ = env.store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/people/profile/")
-			context := env.ds.GetContext()
-			g.Assert(len(context.Namespaces)).Eql(7, "There should have been 7 namespaces in the context "+
-				"since the dataset does not have publicNamespaces declared.")
-
-			// second part: inject publicNamespaces setting for people ds,
-			// and test that it is applied when retrieving context
-			coreDsInterface, _ := env.store.datasets.Load("core.Dataset")
-			coreDs := coreDsInterface.(*Dataset)
-			res, _ := coreDs.GetEntities("", 10)
-			for _, e := range res.Entities {
-				if e.ID == "ns0:people" {
-					nsi, _ := env.store.NamespaceManager.GetDatasetNamespaceInfo()
-					e.Properties[nsi.PublicNamespacesKey] = []interface{}{
-						"http://data.mimiro.io/people/",
-						"http://data.mimiro.io/company/",
-					}
-					g.Assert(e.Properties[nsi.ItemsKey]).Eql(0.0, "item count should be 0 in core.Dataset")
-					err := coreDs.StoreEntities([]*Entity{e})
-					g.Assert(err).IsNil()
-				}
-			}
-			context = env.ds.GetContext()
-			g.Assert(len(context.Namespaces)).Eql(2, "Expected only 2 namespaces now, since we have"+
-				" added a publicNamespaces override")
-
-			// make sure we did not remove the items property when updating publicNamespaces
-			res, _ = coreDs.GetEntities("", 10)
-			for _, e := range res.Entities {
-				if e.ID == "ns0:people" {
-					nsi, _ := env.store.NamespaceManager.GetDatasetNamespaceInfo()
-					g.Assert(e.Properties[nsi.ItemsKey]).Eql(0.0, "Expected itemscount to be unchanged")
-				}
-			}
-
-			// add an entity to people, so that the itemcount is updated
-			_ = env.ds.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    env.peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{env.peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs":  map[string]interface{}{},
-				}),
-			})
-			res, _ = coreDs.GetEntities("", 10)
-
-			// verify that the itemcount is updated
-			for _, e := range res.Entities {
-				if e.ID == "ns0:people" {
-					nsi, _ := env.store.NamespaceManager.GetDatasetNamespaceInfo()
-					g.Assert(e.Properties[nsi.ItemsKey]).Eql(1.0, "Expected itemscount to be updated")
-				}
-			}
-
-			// and verify that the context is still correct.
-			context = env.ds.GetContext()
-			g.Assert(len(context.Namespaces)).Eql(2, "Expected still only 2 namespaces, since we have"+
-				" added a publicNamespaces override")
-		})
+		// create dataset
+		peopleDataset, _ := dsm.CreateDataset("people", nil)
+		env = &testEnv{
+			s,
+			peopleNamespacePrefix,
+			companyNamespacePrefix,
+			peopleDataset,
+			dsm,
+			storeLocation,
+		}
 	})
-}
+	ginkgo.AfterEach(func() {
+		_ = env.store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+	ginkgo.It("XXX Should accept both single strings and string arrays as refs values", func() {
+		// add a first person with all new refs
+		person := NewEntity(env.peopleNamespacePrefix+":person-1", 1)
+		person.Properties[env.peopleNamespacePrefix+":Name"] = "person 1"
+		person.References[env.peopleNamespacePrefix+":worksfor"] = env.companyNamespacePrefix + ":company-3"
+		person.References[env.peopleNamespacePrefix+":workedfor"] = []string{
+			env.companyNamespacePrefix + ":company-2",
+			env.companyNamespacePrefix + ":company-1",
+		}
+		err := env.ds.StoreEntities([]*Entity{person})
+		Expect(err).To(BeNil(), "Expected entity to be stored without error")
+		// query
+		queryIds := []string{"http://data.mimiro.io/people/person-1"}
+		result, err := env.store.GetManyRelatedEntities(queryIds, "*", false, []string{})
+		Expect(err).To(BeNil(), "Expected query to succeed")
+
+		var company2Seen, company1Seen bool
+		for _, r := range result {
+			refEntityID := r[2].(*Entity).ID
+			relation := r[1].(string)
+			if strings.Contains(relation, "worksfor") {
+				Expect(refEntityID == "ns4:company-3").To(BeTrue(), "worksfor should be company-3")
+			}
+			if strings.Contains(relation, "workedfor") {
+				company1Seen = company1Seen || strings.Contains(refEntityID, "company-1")
+				company2Seen = company2Seen || strings.Contains(refEntityID, "company-2")
+			}
+		}
+		Expect(company1Seen).To(BeTrue(), "company-1 was not observed in relations")
+		Expect(company2Seen).To(BeTrue(), "company-2 was not observed in relations")
+
+		// add the same person with updated working relations, thus covering the "not new" branch of code
+		person = NewEntity(env.peopleNamespacePrefix+":person-"+strconv.Itoa(1), 0)
+		person.Properties[env.peopleNamespacePrefix+":Name"] = "person " + strconv.Itoa(2)
+		person.References[env.peopleNamespacePrefix+":worksfor"] = env.companyNamespacePrefix + ":company-4"
+		person.References[env.peopleNamespacePrefix+":workedfor"] = []string{
+			env.companyNamespacePrefix + ":company-3",
+			env.companyNamespacePrefix + ":company-2",
+			env.companyNamespacePrefix + ":company-1",
+		}
+
+		err = env.ds.StoreEntities([]*Entity{person})
+		Expect(err).To(BeNil(), "Expected entity to be stored without error")
+
+		// query
+		result, err = env.store.GetManyRelatedEntities(queryIds, "*", false, []string{})
+		Expect(err).To(BeNil(), "Expected query to succeed")
+
+		company3Seen := false
+		company2Seen = false
+		company1Seen = false
+		for _, r := range result {
+			refEntityID := r[2].(*Entity).ID
+			relation := r[1].(string)
+			if strings.Contains(relation, "worksfor") {
+				Expect(refEntityID == "ns4:company-4").To(BeTrue(), "worksfor should be company-4")
+			}
+			if strings.Contains(relation, "workedfor") {
+				company1Seen = company1Seen || strings.Contains(refEntityID, "company-1")
+				company2Seen = company2Seen || strings.Contains(refEntityID, "company-2")
+				company3Seen = company3Seen || strings.Contains(refEntityID, "company-3")
+			}
+		}
+		Expect(company1Seen).To(BeTrue(), "company-1 was not observed in relations")
+		Expect(company2Seen).To(BeTrue(), "company-2 was not observed in relations")
+		Expect(company3Seen).To(BeTrue(), "company-3 was not observed in relations")
+	})
+
+	ginkgo.It("Should use it's publicNamespaces property for context", func() {
+		// first part: test that we get global namespace if nothing is overridden
+		_, _ = env.store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/internal/secret/finance",
+		)
+		_, _ = env.store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/people/profile/")
+		context := env.ds.GetContext()
+		Expect(len(context.Namespaces)).To(Equal(7), "There should have been 7 namespaces in the context "+
+			"since the dataset does not have publicNamespaces declared.")
+
+		// second part: inject publicNamespaces setting for people ds,
+		// and test that it is applied when retrieving context
+		coreDsInterface, _ := env.store.datasets.Load("core.Dataset")
+		coreDs := coreDsInterface.(*Dataset)
+		res, _ := coreDs.GetEntities("", 10)
+		for _, e := range res.Entities {
+			if e.ID == "ns0:people" {
+				nsi, _ := env.store.NamespaceManager.GetDatasetNamespaceInfo()
+				e.Properties[nsi.PublicNamespacesKey] = []interface{}{
+					"http://data.mimiro.io/people/",
+					"http://data.mimiro.io/company/",
+				}
+				Expect(e.Properties[nsi.ItemsKey]).To(Equal(0.0), "item count should be 0 in core.Dataset")
+				err := coreDs.StoreEntities([]*Entity{e})
+				Expect(err).To(BeNil())
+			}
+		}
+		context = env.ds.GetContext()
+		Expect(len(context.Namespaces)).To(Equal(2), "Expected only 2 namespaces now, since we have"+
+			" added a publicNamespaces override")
+
+		// make sure we did not remove the items property when updating publicNamespaces
+		res, _ = coreDs.GetEntities("", 10)
+		for _, e := range res.Entities {
+			if e.ID == "ns0:people" {
+				nsi, _ := env.store.NamespaceManager.GetDatasetNamespaceInfo()
+				Expect(e.Properties[nsi.ItemsKey]).To(Equal(0.0), "Expected itemscount to be unchanged")
+			}
+		}
+
+		// add an entity to people, so that the itemcount is updated
+		_ = env.ds.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    env.peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{env.peopleNamespacePrefix + ":Name": "Lisa"},
+				"refs":  map[string]interface{}{},
+			}),
+		})
+		res, _ = coreDs.GetEntities("", 10)
+
+		// verify that the itemcount is updated
+		for _, e := range res.Entities {
+			if e.ID == "ns0:people" {
+				nsi, _ := env.store.NamespaceManager.GetDatasetNamespaceInfo()
+				Expect(e.Properties[nsi.ItemsKey]).To(Equal(1.0), "Expected itemscount to be updated")
+			}
+		}
+
+		// and verify that the context is still correct.
+		context = env.ds.GetContext()
+		Expect(len(context.Namespaces)).To(Equal(2), "Expected still only 2 namespaces, since we have"+
+			" added a publicNamespaces override")
+	})
+})

--- a/internal/server/dataset_test.go
+++ b/internal/server/dataset_test.go
@@ -22,12 +22,13 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 type testEnv struct {

--- a/internal/server/dsmanager_test.go
+++ b/internal/server/dsmanager_test.go
@@ -21,11 +21,11 @@ import (
 	"math"
 	"os"
 	"reflect"
-	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
@@ -33,296 +33,293 @@ import (
 	"github.com/mimiro-io/datahub/internal/conf"
 )
 
-func TestDatasetManager(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("The dataset manager", func() {
-		testCnt := 0
-		var dsm *DsManager
-		var store *Store
-		var gc *GarbageCollector
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_dataset_manager_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
+var _ = ginkgo.Describe("The dataset manager", func() {
+	testCnt := 0
+	var dsm *DsManager
+	var store *Store
+	var gc *GarbageCollector
+	var storeLocation string
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_dataset_manager_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(ginkgo.GinkgoT(), false))
+		store = NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = NewDsManager(lc, e, store, NoOpBus())
+		gc = NewGarbageCollector(lc, store, e)
+
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
+	})
+	ginkgo.AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+
+	ginkgo.It("Should give correct dataset details after storage", func() {
+		ds, err := dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+		Expect(ds).NotTo(BeZero())
+
+		details, found, err := dsm.GetDatasetDetails("people")
+		Expect(err).To(BeNil())
+		Expect(found).To(BeTrue())
+		Expect(details).NotTo(BeZero())
+		Expect(details.ID).To(Equal("ns0:people"))
+		Expect(details.Properties).To(Equal(map[string]interface{}{"ns0:items": float64(0), "ns0:name": "people"}))
+
+		ds, err = dsm.CreateDataset("more.people", nil)
+		Expect(err).To(BeNil())
+		Expect(ds).NotTo(BeZero())
+
+		err = ds.StoreEntities([]*Entity{{ID: "hei"}})
+		Expect(err).To(BeNil())
+
+		details, _, _ = dsm.GetDatasetDetails("people")
+		Expect(details.Properties).To(Equal(map[string]interface{}{"ns0:items": float64(0), "ns0:name": "people"}),
+			"people dataset was not unchanged")
+
+		details, _, _ = dsm.GetDatasetDetails("more.people")
+		Expect(details.Properties).To(Equal(map[string]interface{}{"ns0:items": float64(1), "ns0:name": "more.people"}))
+	})
+
+	ginkgo.It("Should persist internal IDs of deleted datasets, so that they are not given out again", func() {
+		ds, err := dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+		Expect(ds).NotTo(BeZero())
+
+		err = dsm.DeleteDataset("people")
+		Expect(err).To(BeNil())
+
+		err = store.Close()
+		Expect(err).To(BeNil())
+
+		err = store.Open()
+		Expect(err).To(BeNil())
+
+		Expect(len(store.deletedDatasets)).To(Equal(1), "Deleted datasets should have surviced restart of store")
+		_, ok := store.deletedDatasets[ds.InternalID]
+		Expect(ok).To(BeTrue(), "our ds should still be deleted")
+	})
+
+	ginkgo.It("Should assign a new internal id to re-created datasets", func() {
+		ds, _ := dsm.CreateDataset("people", nil)
+		Expect(ds).NotTo(BeZero())
+
+		_ = dsm.DeleteDataset("people")
+
+		ds1, _ := dsm.CreateDataset("people", nil)
+		Expect(ds1).NotTo(BeZero())
+
+		Expect(ds1.InternalID == ds.InternalID).
+			To(BeFalse(), "re-creating the same dataset after deletin should result in new internal id")
+		Expect(ds1.ID).To(Equal(ds.ID), "the re-created dataset's ID should be equal to previously deleted ID")
+	})
+
+	ginkgo.It("Should persist internal IDs correctly across restarts", func() {
+		ds, _ := dsm.CreateDataset("people", nil)
+		Expect(ds).NotTo(BeZero())
+		Expect(ds.InternalID).To(Equal(uint32(2)))
+
+		_ = store.Close()
+		_ = store.Open()
+
+		ds = dsm.GetDataset("people")
+		Expect(ds).NotTo(BeZero())
+		Expect(ds.InternalID).To(Equal(uint32(2)))
+
+		ds2, _ := dsm.CreateDataset("animals", nil)
+		Expect(ds2).NotTo(BeZero())
+		Expect(ds2.InternalID).To(Equal(uint32(3)))
+	})
+
+	ginkgo.It("Should store and overwrite and restore datasets at same pace", func() {
+		// create datasets
+		ds, _ := dsm.CreateDataset("people0", nil)
+
+		batchSize := 100
+		iterationSize := 10
+		totalcnt := 0
+		uniq := 0
+		var avgs []int64
+		// we write the same batches to a new dataset 3 times:
+		//  - first iteration to an empty store
+		//  - second iteration after a dataset delete + dataset create, followed by GC
+		//  - third iteration after a dataset delete + dataset create, no GC
+		// all three write processes should be in the same performance range
+		for deletes := 0; deletes < 3; deletes++ {
+			// t.Log("restored dataset times: ", deletes)
+			var times []time.Duration
+			for rewrites := 0; rewrites < 2; rewrites++ {
+				prefix := "http://data.mimiro.io/people/p1-"
+				idcounter := uint64(0)
+				// write 5 batches
+				for j := 0; j < iterationSize; j++ {
+					entities := make([]*Entity, batchSize)
+					// of 10000 entities each
+					for i := 0; i < batchSize; i++ {
+						uniq++
+						entity := NewEntity(fmt.Sprint(idcounter), idcounter)
+						entity.Properties[prefix+":Name"] = "homer"
+						entity.Properties[prefix+":uniqueness"] = fmt.Sprint(uniq)
+						entity.References[prefix+":type"] = prefix + "/Person"
+						entity.References[prefix+":f1"] = prefix + "/Person-1"
+						entity.References[prefix+":f2"] = prefix + "/Person-2"
+						entity.References[prefix+":f3"] = prefix + "/Person-3"
+						entity.References[prefix+":f4"] = prefix + "/Person-4"
+						entity.References[prefix+":f5"] = prefix + "/Person-5"
+						entity.References[prefix+":f6"] = prefix + "/Person-6"
+						entity.References[prefix+":f7"] = prefix + "/Person-7"
+						entity.References[prefix+":f8"] = prefix + "/Person-8"
+						entity.References[prefix+":f9"] = prefix + "/Person-9"
+
+						entities[i] = entity
+						idcounter++
+					}
+					ts := time.Now()
+					totalcnt += len(entities)
+					_ = ds.StoreEntities(entities)
+					// t.Log("StoreEntities of batch took ", time.Now().Sub(ts))
+					times = append(times, time.Since(ts))
+				}
 			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(t, false))
-			store = NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = NewDsManager(lc, e, store, NoOpBus())
-			gc = NewGarbageCollector(lc, store, e)
+			totalDur := time.Duration(0)
+			for _, d := range times {
+				totalDur = d + totalDur
+			}
+			avgs = append(avgs, totalDur.Nanoseconds()/int64(len(times)))
+			_ = dsm.DeleteDataset("people0")
+			ds, _ = dsm.CreateDataset("people0", nil)
+			if deletes == 0 {
+				_ = gc.Cleandeleted()
+				_ = gc.GC()
+			}
+		}
+		Expect(math.Abs(float64(avgs[1])-float64(avgs[0])) < float64(avgs[0])).To(BeTrue(),
+			"Average batch time after first delete with gc should not exceed twice average of first batch-loop")
+		Expect(math.Abs(float64(avgs[2])-float64(avgs[0])) < float64(avgs[0])).To(BeTrue(),
+			"Average batch time after 2nd delete should not exceed twice average of first batch-loop")
+	})
 
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
+	ginkgo.Describe("rename dataset", func() {
+		ginkgo.It("should fail but not panic for non existing src", func() {
+			_, err := dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
+			Expect(err).NotTo(BeZero())
 		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
+		ginkgo.It("should fail but not panic for existing rename target", func() {
+			_, _ = dsm.CreateDataset("people0", nil)
+			_, _ = dsm.CreateDataset("people1", nil)
+			_, err := dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
+			Expect(err).NotTo(BeZero())
 		})
+		ginkgo.It("should replace entry in system collection", func() {
+			_, _ = dsm.CreateDataset("people0", nil)
+			prefix := make([]byte, 2)
+			binary.BigEndian.PutUint16(prefix, SysDatasetsID)
+			storedDatasets := map[string]*Dataset{}
+			dsm.store.iterateObjects(prefix, reflect.TypeOf(Dataset{}), func(i interface{}) error {
+				ds := i.(*Dataset)
+				storedDatasets[ds.ID] = ds
+				return nil
+			})
+			Expect(len(storedDatasets)).To(Equal(2))
+			Expect(storedDatasets["people0"]).NotTo(BeNil())
+			Expect(storedDatasets["people0"].InternalID).To(Equal(uint32(2)))
+			Expect(storedDatasets["people0"].SubjectIdentifier).To(Equal("http://data.mimiro.io/datasets/people0"))
 
-		g.It("Should give correct dataset details after storage", func() {
-			ds, err := dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
-			g.Assert(ds).IsNotZero()
+			// do the rename
+			_, err := dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
+			Expect(err).To(BeNil())
 
-			details, found, err := dsm.GetDatasetDetails("people")
-			g.Assert(err).IsNil()
-			g.Assert(found).IsTrue()
-			g.Assert(details).IsNotZero()
-			g.Assert(details.ID).Eql("ns0:people")
-			g.Assert(details.Properties).Eql(map[string]interface{}{"ns0:items": 0, "ns0:name": "people"})
-
-			ds, err = dsm.CreateDataset("more.people", nil)
-			g.Assert(err).IsNil()
-			g.Assert(ds).IsNotZero()
-
-			err = ds.StoreEntities([]*Entity{{ID: "hei"}})
-			g.Assert(err).IsNil()
-
-			details, _, _ = dsm.GetDatasetDetails("people")
-			g.Assert(details.Properties).Eql(map[string]interface{}{"ns0:items": 0, "ns0:name": "people"},
-				"people dataset was not unchanged")
-
-			details, _, _ = dsm.GetDatasetDetails("more.people")
-			g.Assert(details.Properties).Eql(map[string]interface{}{"ns0:items": 1, "ns0:name": "more.people"})
+			storedDatasets = map[string]*Dataset{}
+			dsm.store.iterateObjects(prefix, reflect.TypeOf(Dataset{}), func(i interface{}) error {
+				ds := i.(*Dataset)
+				storedDatasets[ds.ID] = ds
+				return nil
+			})
+			Expect(len(storedDatasets)).To(Equal(2))
+			Expect(storedDatasets["people1"]).NotTo(BeNil())
+			Expect(storedDatasets["people1"].InternalID).To(Equal(uint32(2)))
+			Expect(storedDatasets["people1"].SubjectIdentifier).To(Equal("http://data.mimiro.io/datasets/people1"))
 		})
+		ginkgo.It("should replace entry in cached dataset list", func() {
+			_, _ = dsm.CreateDataset("people0", nil)
+			Expect(len(dsm.GetDatasetNames())).To(Equal(2))
+			seen := false
+			for _, n := range dsm.GetDatasetNames() {
+				if n.Name == "people0" {
+					seen = true
+				}
+			}
+			Expect(seen).To(BeTrue())
+			Expect(dsm.GetDataset("people0").InternalID).To(Equal(uint32(2)))
 
-		g.It("Should persist internal IDs of deleted datasets, so that they are not given out again", func() {
-			ds, err := dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
-			g.Assert(ds).IsNotZero()
+			// do the rename
+			_, err := dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
+			Expect(err).To(BeNil())
 
-			err = dsm.DeleteDataset("people")
-			g.Assert(err).IsNil()
-
-			err = store.Close()
-			g.Assert(err).IsNil()
-
-			err = store.Open()
-			g.Assert(err).IsNil()
-
-			g.Assert(len(store.deletedDatasets)).Eql(1, "Deleted datasets should have surviced restart of store")
-			_, ok := store.deletedDatasets[ds.InternalID]
-			g.Assert(ok).IsTrue("our ds should still be deleted")
-		})
-
-		g.It("Should assign a new internal id to re-created datasets", func() {
-			ds, _ := dsm.CreateDataset("people", nil)
-			g.Assert(ds).IsNotZero()
-
-			_ = dsm.DeleteDataset("people")
-
-			ds1, _ := dsm.CreateDataset("people", nil)
-			g.Assert(ds1).IsNotZero()
-
-			g.Assert(ds1.InternalID == ds.InternalID).
-				IsFalse("re-creating the same dataset after deletin should result in new internal id")
-			g.Assert(ds1.ID).Eql(ds.ID, "the re-created dataset's ID should be equal to previously deleted ID")
-		})
-
-		g.It("Should persist internal IDs correctly across restarts", func() {
-			ds, _ := dsm.CreateDataset("people", nil)
-			g.Assert(ds).IsNotZero()
-			g.Assert(ds.InternalID).Eql(uint32(2))
-
-			_ = store.Close()
-			_ = store.Open()
-
-			ds = dsm.GetDataset("people")
-			g.Assert(ds).IsNotZero()
-			g.Assert(ds.InternalID).Eql(uint32(2))
-
-			ds2, _ := dsm.CreateDataset("animals", nil)
-			g.Assert(ds2).IsNotZero()
-			g.Assert(ds2.InternalID).Eql(uint32(3))
+			Expect(len(dsm.GetDatasetNames())).To(Equal(2))
+			seen = false
+			for _, n := range dsm.GetDatasetNames() {
+				if n.Name == "people1" {
+					seen = true
+				}
+			}
+			Expect(seen).To(BeTrue())
+			Expect(dsm.GetDataset("people1").InternalID).To(Equal(uint32(2)))
+			Expect(dsm.GetDataset("people0")).To(BeNil())
 		})
 
-		g.It("Should store and overwrite and restore datasets at same pace", func() {
-			// create datasets
+		ginkgo.It("should replace entry in core.Dataset, and dataset content", func() {
+			coreDs := dsm.GetDataset("core.Dataset")
 			ds, _ := dsm.CreateDataset("people0", nil)
-
-			batchSize := 100
-			iterationSize := 10
-			totalcnt := 0
-			uniq := 0
-			var avgs []int64
-			// we write the same batches to a new dataset 3 times:
-			//  - first iteration to an empty store
-			//  - second iteration after a dataset delete + dataset create, followed by GC
-			//  - third iteration after a dataset delete + dataset create, no GC
-			// all three write processes should be in the same performance range
-			for deletes := 0; deletes < 3; deletes++ {
-				// t.Log("restored dataset times: ", deletes)
-				var times []time.Duration
-				for rewrites := 0; rewrites < 2; rewrites++ {
-					prefix := "http://data.mimiro.io/people/p1-"
-					idcounter := uint64(0)
-					// write 5 batches
-					for j := 0; j < iterationSize; j++ {
-						entities := make([]*Entity, batchSize)
-						// of 10000 entities each
-						for i := 0; i < batchSize; i++ {
-							uniq++
-							entity := NewEntity(fmt.Sprint(idcounter), idcounter)
-							entity.Properties[prefix+":Name"] = "homer"
-							entity.Properties[prefix+":uniqueness"] = fmt.Sprint(uniq)
-							entity.References[prefix+":type"] = prefix + "/Person"
-							entity.References[prefix+":f1"] = prefix + "/Person-1"
-							entity.References[prefix+":f2"] = prefix + "/Person-2"
-							entity.References[prefix+":f3"] = prefix + "/Person-3"
-							entity.References[prefix+":f4"] = prefix + "/Person-4"
-							entity.References[prefix+":f5"] = prefix + "/Person-5"
-							entity.References[prefix+":f6"] = prefix + "/Person-6"
-							entity.References[prefix+":f7"] = prefix + "/Person-7"
-							entity.References[prefix+":f8"] = prefix + "/Person-8"
-							entity.References[prefix+":f9"] = prefix + "/Person-9"
-
-							entities[i] = entity
-							idcounter++
-						}
-						ts := time.Now()
-						totalcnt += len(entities)
-						_ = ds.StoreEntities(entities)
-						// t.Log("StoreEntities of batch took ", time.Now().Sub(ts))
-						times = append(times, time.Since(ts))
-					}
-				}
-				totalDur := time.Duration(0)
-				for _, d := range times {
-					totalDur = d + totalDur
-				}
-				avgs = append(avgs, totalDur.Nanoseconds()/int64(len(times)))
-				_ = dsm.DeleteDataset("people0")
-				ds, _ = dsm.CreateDataset("people0", nil)
-				if deletes == 0 {
-					_ = gc.Cleandeleted()
-					_ = gc.GC()
+			_ = ds.StoreEntities([]*Entity{NewEntity("item0", 0), NewEntity("item1", 0), NewEntity("item2", 0)})
+			dsContent, err := ds.GetChanges(0, 100, false)
+			Expect(err).To(BeNil())
+			coreChanges, _ := coreDs.GetChanges(0, 100, true)
+			Expect(coreChanges).NotTo(BeNil())
+			Expect(len(coreChanges.Entities)).To(Equal(2))
+			seen := false
+			for _, e := range coreChanges.Entities {
+				if e.ID == "ns0:people0" {
+					seen = true
+					Expect(e.IsDeleted).To(BeFalse())
+					Expect(e.Properties["ns0:name"]).To(Equal("people0"))
+					Expect(e.Properties["ns0:items"]).To(Equal(3.0))
 				}
 			}
-			g.Assert(math.Abs(float64(avgs[1])-float64(avgs[0])) < float64(avgs[0])).IsTrue(
-				"Average batch time after first delete with gc should not exceed twice average of first batch-loop")
-			g.Assert(math.Abs(float64(avgs[2])-float64(avgs[0])) < float64(avgs[0])).IsTrue(
-				"Average batch time after 2nd delete should not exceed twice average of first batch-loop")
-		})
+			Expect(seen).To(BeTrue())
 
-		g.Describe("rename dataset", func() {
-			g.It("should fail but not panic for non existing src", func() {
-				_, err := dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
-				g.Assert(err).IsNotZero()
-			})
-			g.It("should fail but not panic for existing rename target", func() {
-				_, _ = dsm.CreateDataset("people0", nil)
-				_, _ = dsm.CreateDataset("people1", nil)
-				_, err := dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
-				g.Assert(err).IsNotZero()
-			})
-			g.It("should replace entry in system collection", func() {
-				_, _ = dsm.CreateDataset("people0", nil)
-				prefix := make([]byte, 2)
-				binary.BigEndian.PutUint16(prefix, SysDatasetsID)
-				storedDatasets := map[string]*Dataset{}
-				dsm.store.iterateObjects(prefix, reflect.TypeOf(Dataset{}), func(i interface{}) error {
-					ds := i.(*Dataset)
-					storedDatasets[ds.ID] = ds
-					return nil
-				})
-				g.Assert(len(storedDatasets)).Eql(2)
-				g.Assert(storedDatasets["people0"]).IsNotNil()
-				g.Assert(storedDatasets["people0"].InternalID).Eql(uint32(2))
-				g.Assert(storedDatasets["people0"].SubjectIdentifier).Eql("http://data.mimiro.io/datasets/people0")
-
-				// do the rename
-				_, err := dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
-				g.Assert(err).IsNil()
-
-				storedDatasets = map[string]*Dataset{}
-				dsm.store.iterateObjects(prefix, reflect.TypeOf(Dataset{}), func(i interface{}) error {
-					ds := i.(*Dataset)
-					storedDatasets[ds.ID] = ds
-					return nil
-				})
-				g.Assert(len(storedDatasets)).Eql(2)
-				g.Assert(storedDatasets["people1"]).IsNotNil()
-				g.Assert(storedDatasets["people1"].InternalID).Eql(uint32(2))
-				g.Assert(storedDatasets["people1"].SubjectIdentifier).Eql("http://data.mimiro.io/datasets/people1")
-			})
-			g.It("should replace entry in cached dataset list", func() {
-				_, _ = dsm.CreateDataset("people0", nil)
-				g.Assert(len(dsm.GetDatasetNames())).Eql(2)
-				seen := false
-				for _, n := range dsm.GetDatasetNames() {
-					if n.Name == "people0" {
-						seen = true
-					}
+			// do the rename
+			_, err = dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
+			Expect(err).To(BeNil())
+			coreChanges, _ = coreDs.GetChanges(0, 100, true)
+			Expect(coreChanges).NotTo(BeNil())
+			Expect(len(coreChanges.Entities)).To(Equal(3))
+			seen0 := false
+			seen1 := false
+			for _, e := range coreChanges.Entities {
+				if e.ID == "ns0:people0" {
+					seen0 = true
+					Expect(e.IsDeleted).To(BeTrue())
 				}
-				g.Assert(seen).IsTrue()
-				g.Assert(dsm.GetDataset("people0").InternalID).Eql(uint32(2))
-
-				// do the rename
-				_, err := dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
-				g.Assert(err).IsNil()
-
-				g.Assert(len(dsm.GetDatasetNames())).Eql(2)
-				seen = false
-				for _, n := range dsm.GetDatasetNames() {
-					if n.Name == "people1" {
-						seen = true
-					}
+				if e.ID == "ns0:people1" {
+					seen1 = true
+					Expect(e.IsDeleted).To(BeFalse())
+					Expect(e.Properties["ns0:name"]).To(Equal("people1"))
+					Expect(e.Properties["ns0:items"]).To(Equal(3.0))
 				}
-				g.Assert(seen).IsTrue()
-				g.Assert(dsm.GetDataset("people1").InternalID).Eql(uint32(2))
-				g.Assert(dsm.GetDataset("people0")).IsNil()
-			})
-
-			g.It("should replace entry in core.Dataset, and dataset content", func() {
-				coreDs := dsm.GetDataset("core.Dataset")
-				ds, _ := dsm.CreateDataset("people0", nil)
-				_ = ds.StoreEntities([]*Entity{NewEntity("item0", 0), NewEntity("item1", 0), NewEntity("item2", 0)})
-				dsContent, err := ds.GetChanges(0, 100, false)
-				g.Assert(err).IsNil()
-				coreChanges, _ := coreDs.GetChanges(0, 100, true)
-				g.Assert(coreChanges).IsNotNil()
-				g.Assert(len(coreChanges.Entities)).Eql(2)
-				seen := false
-				for _, e := range coreChanges.Entities {
-					if e.ID == "ns0:people0" {
-						seen = true
-						g.Assert(e.IsDeleted).IsFalse()
-						g.Assert(e.Properties["ns0:name"]).Eql("people0")
-						g.Assert(e.Properties["ns0:items"]).Eql(3.0)
-					}
-				}
-				g.Assert(seen).IsTrue()
-
-				// do the rename
-				_, err = dsm.UpdateDataset("people0", &UpdateDatasetConfig{ID: "people1"})
-				g.Assert(err).IsNil()
-				coreChanges, _ = coreDs.GetChanges(0, 100, true)
-				g.Assert(coreChanges).IsNotNil()
-				g.Assert(len(coreChanges.Entities)).Eql(3)
-				seen0 := false
-				seen1 := false
-				for _, e := range coreChanges.Entities {
-					if e.ID == "ns0:people0" {
-						seen0 = true
-						g.Assert(e.IsDeleted).IsTrue()
-					}
-					if e.ID == "ns0:people1" {
-						seen1 = true
-						g.Assert(e.IsDeleted).IsFalse()
-						g.Assert(e.Properties["ns0:name"]).Eql("people1")
-						g.Assert(e.Properties["ns0:items"]).Eql(3.0)
-					}
-				}
-				g.Assert(seen0).IsTrue()
-				g.Assert(seen1).IsTrue()
-				dsContentNew, err := ds.GetChanges(0, 100, false)
-				g.Assert(err).IsNil()
-				g.Assert(dsContentNew).Eql(dsContent)
-			})
+			}
+			Expect(seen0).To(BeTrue())
+			Expect(seen1).To(BeTrue())
+			dsContentNew, err := ds.GetChanges(0, 100, false)
+			Expect(err).To(BeNil())
+			Expect(dsContentNew).To(Equal(dsContent))
 		})
 	})
-}
+})

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -22,13 +22,13 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
 	"github.com/labstack/echo/v4"
 	"github.com/mustafaturan/bus"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
@@ -39,122 +39,119 @@ import (
 	"github.com/mimiro-io/datahub/internal/web"
 )
 
-func TestEvents(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("The Eventbus", func() {
-		testCnt := 0
-		var storeLocation string
-		var eventBus *server.MEventBus
-		var store *server.Store
-		var dsm *server.DsManager
-		var scheduler *jobs.Scheduler
-		var runner *jobs.Runner
-		var mockServer *echo.Echo
-		var peopleDs *server.Dataset
-		g.BeforeEach(func() {
-			testCnt += 1
-			// since we wire up our actual web server, we need to provide a file matching 'views/*html' to avoid errors
-			_ = os.MkdirAll("./views", os.ModePerm)
-			_, _ = os.Create("./views/x.html")
+var _ = Describe("The Eventbus", func() {
+	testCnt := 0
+	var storeLocation string
+	var eventBus *server.MEventBus
+	var store *server.Store
+	var dsm *server.DsManager
+	var scheduler *jobs.Scheduler
+	var runner *jobs.Runner
+	var mockServer *echo.Echo
+	var peopleDs *server.Dataset
+	BeforeEach(func() {
+		testCnt += 1
+		// since we wire up our actual web server, we need to provide a file matching 'views/*html' to avoid errors
+		_ = os.MkdirAll("./views", os.ModePerm)
+		_, _ = os.Create("./views/x.html")
 
-			storeLocation = fmt.Sprintf("./test_events_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
+		storeLocation = fmt.Sprintf("./test_events_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
 
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-				Port:          "5555",
-				Auth:          &conf.AuthConfig{Middleware: "noop"},
-				RunnerConfig:  &conf.RunnerConfig{PoolIncremental: 10, PoolFull: 5},
-			}
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+			Port:          "5555",
+			Auth:          &conf.AuthConfig{Middleware: "noop"},
+			RunnerConfig:  &conf.RunnerConfig{PoolIncremental: 10, PoolFull: 5},
+		}
 
-			devNull, _ := os.Open("/dev/null")
-			oldOut := os.Stdout
-			os.Stdout = devNull
+		devNull, _ := os.Open("/dev/null")
+		oldOut := os.Stdout
+		os.Stdout = devNull
 
-			lc := fxtest.NewLifecycle(internal.FxTestLog(t, false))
-			store = server.NewStore(lc, e, &statsd.NoOpClient{})
-			newBus, _ := server.NewBus(&conf.Env{Logger: zap.NewNop().Sugar()})
-			eventBus = newBus.(*server.MEventBus)
-			dsm = server.NewDsManager(lc, e, store, newBus)
+		lc := fxtest.NewLifecycle(internal.FxTestLog(GinkgoT(), false))
+		store = server.NewStore(lc, e, &statsd.NoOpClient{})
+		newBus, _ := server.NewBus(&conf.Env{Logger: zap.NewNop().Sugar()})
+		eventBus = newBus.(*server.MEventBus)
+		dsm = server.NewDsManager(lc, e, store, newBus)
 
-			runner = jobs.NewRunner(
-				e, store, nil, eventBus, &statsd.NoOpClient{})
-			scheduler = jobs.NewScheduler(lc, e, store, dsm, runner)
+		runner = jobs.NewRunner(
+			e, store, nil, eventBus, &statsd.NoOpClient{})
+		scheduler = jobs.NewScheduler(lc, e, store, dsm, runner)
 
-			var webHander *web.WebHandler
-			webHander, mockServer = web.NewWebServer(lc, e, e.Logger, &statsd.NoOpClient{})
-			mw := web.NewMiddleware(lc, e, webHander, mockServer, web.NewAuthorizer(e, e.Logger, nil), nil)
-			web.NewDatasetHandler(lc, mockServer, e.Logger, mw, dsm, store, newBus, nil)
+		var webHander *web.WebHandler
+		webHander, mockServer = web.NewWebServer(lc, e, e.Logger, &statsd.NoOpClient{})
+		mw := web.NewMiddleware(lc, e, webHander, mockServer, web.NewAuthorizer(e, e.Logger, nil), nil)
+		web.NewDatasetHandler(lc, mockServer, e.Logger, mw, dsm, store, newBus, nil)
 
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
 
-			os.Stdout = oldOut
+		os.Stdout = oldOut
 
-			peopleDs, err = dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
-		})
-		g.AfterEach(func() {
-			runner.Stop()
-			_ = mockServer.Close()
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-			_ = os.RemoveAll("./views")
-		})
+		peopleDs, err = dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+	})
+	AfterEach(func() {
+		runner.Stop()
+		_ = mockServer.Close()
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+		_ = os.RemoveAll("./views")
+	})
 
-		g.It("Should be an MEventBus", func() {
-			busType := reflect.TypeOf(eventBus)
-			g.Assert(busType.String()).Eql("*server.MEventBus")
-		})
+	It("Should be an MEventBus", func() {
+		busType := reflect.TypeOf(eventBus)
+		Expect(busType.String()).To(Equal("*server.MEventBus"))
+	})
 
-		g.It("Should have a topic for each existing dataset", func() {
-			allTopics := eventBus.Bus.Topics()
-			for _, dsn := range dsm.GetDatasetNames() {
-				seen := false
-				for _, registeredTopic := range allTopics {
-					if registeredTopic == "dataset."+dsn.Name {
-						seen = true
-					}
+	It("Should have a topic for each existing dataset", func() {
+		allTopics := eventBus.Bus.Topics()
+		for _, dsn := range dsm.GetDatasetNames() {
+			seen := false
+			for _, registeredTopic := range allTopics {
+				if registeredTopic == "dataset."+dsn.Name {
+					seen = true
 				}
-				g.Assert(seen).IsTrue()
+			}
+			Expect(seen).To(BeTrue())
+		}
+	})
+
+	It("Should emit an event if entities are posted to /entitites", func(_ SpecContext) {
+		var eventReceived bool
+		var wg sync.WaitGroup
+		wg.Add(1)
+		eventBus.SubscribeToDataset("people", "*", func(e *bus.Event) {
+			if e.Topic == "dataset.people" {
+				eventReceived = true
+				wg.Done()
 			}
 		})
-
-		g.It("Should emit an event if entities are posted to /entitites", func() {
-			g.Timeout(1 * time.Minute)
-			var eventReceived bool
-			var wg sync.WaitGroup
-			wg.Add(1)
-			eventBus.SubscribeToDataset("people", "*", func(e *bus.Event) {
-				if e.Topic == "dataset.people" {
-					eventReceived = true
-					wg.Done()
-				}
-			})
-			reader := strings.NewReader(`[
+		reader := strings.NewReader(`[
 				{ "id" : "@context", "namespaces" : { "_" : "http://data.mimiro.io/core/" } },
 				{ "id" : "homer" }
             ]`)
 
-			_, err := http.Post("http://localhost:5555/datasets/people/entities", "application/json", reader)
-			g.Assert(err).IsNil()
-			wg.Wait()
-			g.Assert(eventReceived).IsTrue()
-		})
+		_, err := http.Post("http://localhost:5555/datasets/people/entities", "application/json", reader)
+		Expect(err).To(BeNil())
+		wg.Wait()
+		Expect(eventReceived).To(BeTrue())
+	}, SpecTimeout(1*time.Minute))
 
-		g.It("Should emit event on sink's topic when a job with datasetSink is done", func() {
-			var eventReceived bool
-			var wg sync.WaitGroup
-			wg.Add(2)
-			eventBus.SubscribeToDataset("people", "*", func(e *bus.Event) {
-				if e.Topic == "dataset.people" {
-					eventReceived = true
-				}
-				wg.Done()
-			})
-			sj, err := scheduler.Parse([]byte((`{
+	It("Should emit event on sink's topic when a job with datasetSink is done", func() {
+		var eventReceived bool
+		var wg sync.WaitGroup
+		wg.Add(2)
+		eventBus.SubscribeToDataset("people", "*", func(e *bus.Event) {
+			if e.Topic == "dataset.people" {
+				eventReceived = true
+			}
+			wg.Done()
+		})
+		sj, err := scheduler.Parse([]byte((`{
 				"id" : "job1",
 				"title" : "job1",
 				"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -168,34 +165,34 @@ func TestEvents(t *testing.T) {
 					"Name": "people"
 				}
 			}`)))
-			g.Assert(err).IsNil()
-			err = scheduler.AddJob(sj)
-			g.Assert(err).IsNil()
+		Expect(err).To(BeNil())
+		err = scheduler.AddJob(sj)
+		Expect(err).To(BeNil())
 
-			_, err = scheduler.RunJob(sj.ID, jobs.JobTypeIncremental)
-			g.Assert(err).IsNil()
-			wg.Wait()
-			g.Assert(eventReceived).IsTrue("Should have observed event for people dataset")
+		_, err = scheduler.RunJob(sj.ID, jobs.JobTypeIncremental)
+		Expect(err).To(BeNil())
+		wg.Wait()
+		Expect(eventReceived).To(BeTrue(), "Should have observed event for people dataset")
+	})
+
+	It("Should trigger jobs that listen on the dataset's topic", func() {
+		// add a extra listener for this test to know when the job is done
+		var wg sync.WaitGroup
+		wg.Add(1)
+		eventBus.SubscribeToDataset("people", "*", func(e *bus.Event) {
+			if e.Topic == "dataset.peoplecopy" {
+				wg.Done()
+			}
 		})
 
-		g.It("Should trigger jobs that listen on the dataset's topic", func() {
-			// add a extra listener for this test to know when the job is done
-			var wg sync.WaitGroup
-			wg.Add(1)
-			eventBus.SubscribeToDataset("people", "*", func(e *bus.Event) {
-				if e.Topic == "dataset.peoplecopy" {
-					wg.Done()
-				}
-			})
+		// add data to people dataset
+		err := peopleDs.StoreEntities([]*server.Entity{server.NewEntity("homer", 0)})
+		Expect(err).To(BeNil())
+		target, err := dsm.CreateDataset("peoplecopy", nil)
+		Expect(err).To(BeNil())
 
-			// add data to people dataset
-			err := peopleDs.StoreEntities([]*server.Entity{server.NewEntity("homer", 0)})
-			g.Assert(err).IsNil()
-			target, err := dsm.CreateDataset("peoplecopy", nil)
-			g.Assert(err).IsNil()
-
-			// setup job
-			sj, err := scheduler.Parse([]byte((`{
+		// setup job
+		sj, err := scheduler.Parse([]byte((`{
 				"id" : "job1",
 				"title" : "job1",
 				"triggers": [{"triggerType": "onchange", "jobType": "incremental", "monitoredDataset": "people"}],
@@ -208,28 +205,28 @@ func TestEvents(t *testing.T) {
 					"Name": "peoplecopy"
 				}
 			}`)))
-			g.Assert(err).IsNil()
-			err = scheduler.AddJob(sj)
-			g.Assert(err).IsNil()
+		Expect(err).To(BeNil())
+		err = scheduler.AddJob(sj)
+		Expect(err).To(BeNil())
 
-			// verify that target is empty before event
-			res, err := target.GetEntities("", 1)
-			g.Assert(err).IsNil()
-			g.Assert(len(res.Entities)).Eql(0, "target dataset should be empty")
+		// verify that target is empty before event
+		res, err := target.GetEntities("", 1)
+		Expect(err).To(BeNil())
+		Expect(len(res.Entities)).To(Equal(0), "target dataset should be empty")
 
-			// emit event on people dataset
-			eventBus.Emit(context.Background(), "dataset.people", nil)
+		// emit event on people dataset
+		eventBus.Emit(context.Background(), "dataset.people", nil)
 
-			wg.Wait()
+		wg.Wait()
 
-			// verify that the job is done
-			res, err = target.GetEntities("", 1)
-			g.Assert(err).IsNil()
-			g.Assert(len(res.Entities)).Eql(1, "Job should have copied entity to target dataset")
-		})
+		// verify that the job is done
+		res, err = target.GetEntities("", 1)
+		Expect(err).To(BeNil())
+		Expect(len(res.Entities)).To(Equal(1), "Job should have copied entity to target dataset")
+	})
 
-		g.It("Should deregister an onChange job when it's triggerType is changed", func() {
-			sj, err := scheduler.Parse([]byte((`{
+	It("Should deregister an onChange job when it's triggerType is changed", func() {
+		sj, err := scheduler.Parse([]byte((`{
 				"id" : "job1",
 				"title" : "job1",
 				"triggers": [{"triggerType": "onchange", "jobType": "incremental", "monitoredDataset": "people"}],
@@ -237,26 +234,25 @@ func TestEvents(t *testing.T) {
 				"sink" : { "Type" : "ConsoleSink" }
 			}`)))
 
-			g.Assert(err).IsNil()
-			err = scheduler.AddJob(sj)
-			g.Assert(err).IsNil()
+		Expect(err).To(BeNil())
+		err = scheduler.AddJob(sj)
+		Expect(err).To(BeNil())
 
-			g.Assert(eventBus.Bus.HandlerKeys()).Eql([]string{"job1"}, "job1 should have a subscription now")
-			g.Assert(len(scheduler.GetScheduleEntries().Entries)).IsZero("there should not be any cron jobs")
+		Expect(eventBus.Bus.HandlerKeys()).To(Equal([]string{"job1"}), "job1 should have a subscription now")
+		Expect(len(scheduler.GetScheduleEntries().Entries)).To(BeZero(), "there should not be any cron jobs")
 
-			sj, err = scheduler.Parse([]byte((`{
+		sj, err = scheduler.Parse([]byte((`{
 				"id" : "job1",
 				"title" : "job1",
 				"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 24h"}],
 				"source" : { "Type" : "SampleSource" },
 				"sink" : { "Type" : "ConsoleSink" }
 			}`)))
-			g.Assert(err).IsNil()
-			err = scheduler.AddJob(sj)
-			g.Assert(err).IsNil()
+		Expect(err).To(BeNil())
+		err = scheduler.AddJob(sj)
+		Expect(err).To(BeNil())
 
-			g.Assert(len(eventBus.Bus.HandlerKeys())).IsZero("job1 should be deregistered")
-			g.Assert(len(scheduler.GetScheduleEntries().Entries)).IsNotZero("there should be a cron job now")
-		})
+		Expect(len(eventBus.Bus.HandlerKeys())).To(BeZero(), "job1 should be deregistered")
+		Expect(len(scheduler.GetScheduleEntries().Entries)).NotTo(BeZero(), "there should be a cron job now")
 	})
-}
+})

--- a/internal/server/garbagecollector_test.go
+++ b/internal/server/garbagecollector_test.go
@@ -18,224 +18,220 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
-
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
 )
 
-func TestGC(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("The GarbageCollector", func() {
-		testCnt := 0
-		var dsm *DsManager
-		var store *Store
-		var storeLocation string
-		var gc *GarbageCollector
+var _ = ginkgo.Describe("The GarbageCollector", func() {
+	testCnt := 0
+	var dsm *DsManager
+	var store *Store
+	var storeLocation string
+	var gc *GarbageCollector
 
-		var lc *fxtest.Lifecycle
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_gc_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
+	var lc *fxtest.Lifecycle
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_gc_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
 
-			devNull, _ := os.Open("/dev/null")
-			oldErr := os.Stderr
-			os.Stderr = devNull
-			lc = fxtest.NewLifecycle(internal.FxTestLog(t, false))
-			store = NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = NewDsManager(lc, e, store, NoOpBus())
-			gc = NewGarbageCollector(lc, store, e)
-			g.Assert(err).IsNil()
+		devNull, _ := os.Open("/dev/null")
+		oldErr := os.Stderr
+		os.Stderr = devNull
+		lc = fxtest.NewLifecycle(internal.FxTestLog(ginkgo.GinkgoT(), false))
+		store = NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = NewDsManager(lc, e, store, NoOpBus())
+		gc = NewGarbageCollector(lc, store, e)
+		Expect(err).To(BeNil())
 
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
-			os.Stderr = oldErr
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-		g.It("Should not delete used data", func() {
-			b := gc.store.database
-			g.Assert(count(b)).Eql(16)
-
-			ds, _ := dsm.CreateDataset("test", nil)
-			g.Assert(count(b)).Eql(24)
-
-			_ = ds.StoreEntities([]*Entity{NewEntity("hei", 0)})
-			g.Assert(count(b)).Eql(34)
-
-			gc.GC()
-			g.Assert(count(b)).Eql(34)
-
-			gc.Cleandeleted()
-			g.Assert(count(b)).Eql(34)
-		})
-
-		g.It("Should remove entities and indexes from deleted datasets", func() {
-			b := store.database
-			g.Assert(count(b)).Eql(16)
-
-			ds, _ := dsm.CreateDataset("test", nil)
-			g.Assert(count(b)).Eql(24)
-
-			ds2, _ := dsm.CreateDataset("delete.me", nil)
-			g.Assert(count(b)).Eql(32)
-
-			_ = ds.StoreEntities([]*Entity{NewEntity("p1", 0)})
-			g.Assert(count(b)).Eql(42)
-
-			_ = ds2.StoreEntities([]*Entity{NewEntity("p1", 0)})
-			g.Assert(count(b)).Eql(50)
-
-			_ = dsm.DeleteDataset("delete.me")
-			g.Assert(count(b)).Eql(54, "before cleanup, 4 new keys are expected (deleted dataset state)")
-
-			err := gc.Cleandeleted()
-			g.Assert(err).IsNil()
-			g.Assert(count(b)).Eql(51, "3 keys should be gone now for the one referenced entity in "+
-				"'delete.me': main index, latest and changes")
-		})
-
-		g.It("Should delete the correct incoming and outgoing references", func() {
-			b := store.database
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			workPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/work/")
-			g.Assert(count(b)).Eql(16)
-
-			friendsDS, _ := dsm.CreateDataset("friends", nil)
-			g.Assert(count(b)).Eql(24)
-
-			workDS, _ := dsm.CreateDataset("work", nil)
-			g.Assert(count(b)).Eql(32)
-
-			_ = friendsDS.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
-					},
-				}),
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-2",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Bob"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
-					},
-				}),
-			})
-			g.Assert(count(b)).Eql(55)
-
-			// check that we can query outgoing
-			result, err := store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
-
-			// check that we can query incoming
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
-
-			_ = workDS.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{workPrefix + ":Wage": "110"},
-					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-2"},
-				}),
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-2",
-					"props": map[string]interface{}{workPrefix + ":Wage": "100"},
-					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-3"},
-				}),
-			})
-			g.Assert(count(b)).Eql(72)
-
-			// check that we can still query outgoing
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1, "Expected still to find person-3 as a friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
-
-			// and incoming
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1, "Expected still to find person-2 as reverse friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
-
-			_ = dsm.DeleteDataset("work")
-			g.Assert(count(b)).Eql(76, "before cleanup, 4 new keys are expected (deleted dataset state)")
-
-			err = gc.Cleandeleted()
-			g.Assert(err).IsNil()
-			g.Assert(count(b)).Eql(66, "two entities with 5 keys each should be removed now")
-
-			// make sure we still can query
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				"*",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
-
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-2"},
-				"*",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-1")
-		})
-
-		g.It("Should stop when asked to", func() {
-			go func() { gc.quit <- true }()
-			err := gc.Cleandeleted()
-			g.Assert(err).IsNotZero()
-			g.Assert(err.Error()).Eql("gc cancelled")
-		})
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
+		os.Stderr = oldErr
 	})
-}
+	ginkgo.AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+	ginkgo.It("Should not delete used data", func() {
+		b := gc.store.database
+		Expect(count(b)).To(Equal(16))
+
+		ds, _ := dsm.CreateDataset("test", nil)
+		Expect(count(b)).To(Equal(24))
+
+		_ = ds.StoreEntities([]*Entity{NewEntity("hei", 0)})
+		Expect(count(b)).To(Equal(34))
+
+		gc.GC()
+		Expect(count(b)).To(Equal(34))
+
+		gc.Cleandeleted()
+		Expect(count(b)).To(Equal(34))
+	})
+
+	ginkgo.It("Should remove entities and indexes from deleted datasets", func() {
+		b := store.database
+		Expect(count(b)).To(Equal(16))
+
+		ds, _ := dsm.CreateDataset("test", nil)
+		Expect(count(b)).To(Equal(24))
+
+		ds2, _ := dsm.CreateDataset("delete.me", nil)
+		Expect(count(b)).To(Equal(32))
+
+		_ = ds.StoreEntities([]*Entity{NewEntity("p1", 0)})
+		Expect(count(b)).To(Equal(42))
+
+		_ = ds2.StoreEntities([]*Entity{NewEntity("p1", 0)})
+		Expect(count(b)).To(Equal(50))
+
+		_ = dsm.DeleteDataset("delete.me")
+		Expect(count(b)).To(Equal(54), "before cleanup, 4 new keys are expected (deleted dataset state)")
+
+		err := gc.Cleandeleted()
+		Expect(err).To(BeNil())
+		Expect(count(b)).To(Equal(51), "3 keys should be gone now for the one referenced entity in "+
+			"'delete.me': main index, latest and changes")
+	})
+
+	ginkgo.It("Should delete the correct incoming and outgoing references", func() {
+		b := store.database
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		workPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/work/")
+		Expect(count(b)).To(Equal(16))
+
+		friendsDS, _ := dsm.CreateDataset("friends", nil)
+		Expect(count(b)).To(Equal(24))
+
+		workDS, _ := dsm.CreateDataset("work", nil)
+		Expect(count(b)).To(Equal(32))
+
+		_ = friendsDS.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
+				},
+			}),
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-2",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Bob"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
+				},
+			}),
+		})
+		Expect(count(b)).To(Equal(55))
+
+		// check that we can query outgoing
+		result, err := store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-3"))
+
+		// check that we can query incoming
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-2"))
+
+		_ = workDS.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{workPrefix + ":Wage": "110"},
+				"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-2"},
+			}),
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-2",
+				"props": map[string]interface{}{workPrefix + ":Wage": "100"},
+				"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-3"},
+			}),
+		})
+		Expect(count(b)).To(Equal(72))
+
+		// check that we can still query outgoing
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1), "Expected still to find person-3 as a friend")
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-3"))
+
+		// and incoming
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1), "Expected still to find person-2 as reverse friend")
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-2"))
+
+		_ = dsm.DeleteDataset("work")
+		Expect(count(b)).To(Equal(76), "before cleanup, 4 new keys are expected (deleted dataset state)")
+
+		err = gc.Cleandeleted()
+		Expect(err).To(BeNil())
+		Expect(count(b)).To(Equal(66), "two entities with 5 keys each should be removed now")
+
+		// make sure we still can query
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			"*",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-3"))
+
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-2"},
+			"*",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-1"))
+	})
+
+	ginkgo.It("Should stop when asked to", func() {
+		go func() { gc.quit <- true }()
+		err := gc.Cleandeleted()
+		Expect(err).NotTo(BeZero())
+		Expect(err.Error()).To(Equal("gc cancelled"))
+	})
+})

--- a/internal/server/garbagecollector_test.go
+++ b/internal/server/garbagecollector_test.go
@@ -20,12 +20,13 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 var _ = ginkgo.Describe("The GarbageCollector", func() {

--- a/internal/server/get_related_test.go
+++ b/internal/server/get_related_test.go
@@ -4,203 +4,201 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
-func TestGetRelated(test *testing.T) {
-	g := goblin.Goblin(test)
-	g.Describe("The GetManyRelatedEntitiesBatch functions", func() {
-		testCnt := 0
-		var dsm *DsManager
-		var store *Store
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_get_relations_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(test, false))
-			store = NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = NewDsManager(lc, e, store, NoOpBus())
+var _ = ginkgo.Describe("The GetManyRelatedEntitiesBatch functions", func() {
+	testCnt := 0
+	var dsm *DsManager
+	var store *Store
+	var storeLocation string
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_get_relations_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(ginkgo.GinkgoT(), false))
+		store = NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = NewDsManager(lc, e, store, NoOpBus())
 
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-
-		g.It("Should respect limit for single start uri", func() {
-			peopleNamespacePrefix := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
-				{id: 1, friends: []int{0}},
-				{id: 2, friends: []int{1, 4}},
-				{id: 3, deleted: true, friends: []int{2}},
-				{id: 0, friends: []int{1, 2, 3, 4}},
-				{id: 3, friends: []int{2}},
-				{id: 0, deleted: true, friends: []int{1, 2, 3, 4}},
-				{id: 1, friends: []int{3, 2, 4}},
-			}))
-			start := []string{peopleNamespacePrefix + ":person-1"}
-			result, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(len(result[0].Relations)).Eql(3, "person-1 points to p2, p3 and (empty) p4")
-			g.Assert(result[0].Relations[0].RelatedEntity.ID).Eql(peopleNamespacePrefix + ":person-3")
-			g.Assert(result[0].Relations[1].RelatedEntity.ID).Eql(peopleNamespacePrefix + ":person-4")
-			g.Assert(result[0].Relations[2].RelatedEntity.ID).Eql(peopleNamespacePrefix + ":person-2")
-
-			seenCnt := 0
-			for _, r := range result[0].Relations {
-				if r.RelatedEntity.ID == peopleNamespacePrefix+":person-2" ||
-					r.RelatedEntity.ID == peopleNamespacePrefix+":person-3" {
-					seenCnt++
-					g.Assert(r.RelatedEntity.Recorded > 0).IsTrue("make sure person-2 is an actual entity")
-				}
-				if r.RelatedEntity.ID == peopleNamespacePrefix+":person-4" {
-					seenCnt++
-					g.Assert(r.RelatedEntity.Recorded).Eql(uint64(0), "make sure person-4 is an open ref")
-				}
-			}
-			g.Assert(seenCnt).Eql(3)
-
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 1)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(len(result[0].Relations)).Eql(1)
-
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 2)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(len(result[0].Relations)).Eql(2)
-		})
-		g.It("Should respect limit for many start uris", func() {
-			peopleNamespacePrefix := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
-				{id: 1, friends: []int{0}},
-				{id: 2, friends: []int{1, 4}},
-				{id: 3, deleted: true, friends: []int{2}},
-				{id: 0, friends: []int{1, 2, 3, 4}},
-				{id: 3, friends: []int{2}},
-				{id: 0, deleted: true, friends: []int{1, 2, 3, 4}},
-				{id: 1, friends: []int{3, 2, 4}},
-			}))
-			// get everything
-			start := []string{peopleNamespacePrefix + ":person-1", peopleNamespacePrefix + ":person-2"}
-			result, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(2)
-			g.Assert(len(result[0].Relations)).Eql(3)
-			g.Assert(len(result[1].Relations)).Eql(2)
-
-			// limit 1, should return first hit of first startUri
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 1)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(len(result[0].Relations)).Eql(1)
-
-			// limit 4, room for all 3 relations of first startUri plus 1 from other startUri
-			result, err = store.GetManyRelatedEntitiesBatch(
-				start,
-				"*",
-				false,
-				nil,
-				4,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(2)
-			g.Assert(len(result[0].Relations)).Eql(3)
-			g.Assert(len(result[1].Relations)).Eql(1)
-		})
-		g.It("Should respect limit in inverse queries", func() {
-			peopleNamespacePrefix := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
-				{id: 1, friends: []int{0}},
-				{id: 2, friends: []int{1, 4}},
-				{id: 3, deleted: true, friends: []int{2}},
-				{id: 0, friends: []int{1, 2, 3, 4}},
-				{id: 3, friends: []int{2}},
-				{id: 0, deleted: true, friends: []int{1, 2, 3, 4}},
-				{id: 1, friends: []int{3, 2, 4}},
-			}))
-			// get everything
-			start := []string{peopleNamespacePrefix + ":person-1", peopleNamespacePrefix + ":person-2"}
-			result, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(2)
-			g.Assert(len(result[0].Relations)).Eql(1)
-			g.Assert(len(result[1].Relations)).Eql(2)
-			// limit 1, should return first hit of first startUri
-			result, err = store.GetManyRelatedEntitiesBatch(
-				start,
-				"*",
-				true,
-				nil,
-				1,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(len(result[0].Relations)).Eql(1)
-
-			// limit 2, room for all 1 relations of first startUri plus 1 from other startUri
-			result, err = store.GetManyRelatedEntitiesBatch(
-				start,
-				"*",
-				true,
-				nil,
-				2,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(2)
-			g.Assert(len(result[0].Relations)).Eql(1)
-			g.Assert(len(result[1].Relations)).Eql(1)
-		})
-		g.It("Should return a working continuation token", func() {
-			pref := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
-				{id: 1, friends: []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}},
-			}))
-			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
-			g.Assert(err).IsNil()
-			g.Assert(len(queryResult)).Eql(1)
-			g.Assert(len(queryResult[0].Relations)).Eql(19)
-
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 2)
-			g.Assert(err).IsNil()
-			g.Assert(len(queryResult)).Eql(1)
-			g.Assert(len(queryResult[0].Relations)).Eql(2)
-			g.Assert(queryResult[0].Relations[0].RelatedEntity.ID).Eql(pref + ":person-20")
-			g.Assert(queryResult[0].Relations[1].RelatedEntity.ID).Eql(pref + ":person-19")
-			g.Assert(queryResult[0].Continuation.RelationIndexFromKey).IsNotNil()
-			startFromCont := queryResult.Cont()
-			queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 3)
-			g.Assert(err).IsNil()
-			g.Assert(len(queryResult)).Eql(1)
-			g.Assert(len(queryResult[0].Relations)).Eql(3)
-			g.Assert(queryResult[0].Relations[0].RelatedEntity.ID).Eql(pref + ":person-18")
-			g.Assert(queryResult[0].Relations[1].RelatedEntity.ID).Eql(pref + ":person-17")
-			g.Assert(queryResult[0].Relations[2].RelatedEntity.ID).Eql(pref + ":person-16")
-			g.Assert(queryResult[0].Continuation.RelationIndexFromKey).IsNotNil()
-			startFromCont = queryResult.Cont()
-			queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 25)
-			g.Assert(err).IsNil()
-			g.Assert(len(queryResult)).Eql(1)
-			g.Assert(len(queryResult[0].Relations)).Eql(14)
-			g.Assert(queryResult[0].Relations[0].RelatedEntity.ID).Eql(pref + ":person-15")
-			g.Assert(queryResult[0].Relations[13].RelatedEntity.ID).Eql(pref + ":person-2")
-			g.Assert(queryResult[0].Continuation.RelationIndexFromKey).IsNil()
-		})
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
 	})
-}
+	ginkgo.AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+
+	ginkgo.It("Should respect limit for single start uri", func() {
+		peopleNamespacePrefix := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
+			{id: 1, friends: []int{0}},
+			{id: 2, friends: []int{1, 4}},
+			{id: 3, deleted: true, friends: []int{2}},
+			{id: 0, friends: []int{1, 2, 3, 4}},
+			{id: 3, friends: []int{2}},
+			{id: 0, deleted: true, friends: []int{1, 2, 3, 4}},
+			{id: 1, friends: []int{3, 2, 4}},
+		}))
+		start := []string{peopleNamespacePrefix + ":person-1"}
+		result, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(len(result[0].Relations)).To(Equal(3), "person-1 points to p2, p3 and (empty) p4")
+		Expect(result[0].Relations[0].RelatedEntity.ID).To(Equal(peopleNamespacePrefix + ":person-3"))
+		Expect(result[0].Relations[1].RelatedEntity.ID).To(Equal(peopleNamespacePrefix + ":person-4"))
+		Expect(result[0].Relations[2].RelatedEntity.ID).To(Equal(peopleNamespacePrefix + ":person-2"))
+
+		seenCnt := 0
+		for _, r := range result[0].Relations {
+			if r.RelatedEntity.ID == peopleNamespacePrefix+":person-2" ||
+				r.RelatedEntity.ID == peopleNamespacePrefix+":person-3" {
+				seenCnt++
+				Expect(r.RelatedEntity.Recorded > 0).To(BeTrue(), "make sure person-2 is an actual entity")
+			}
+			if r.RelatedEntity.ID == peopleNamespacePrefix+":person-4" {
+				seenCnt++
+				Expect(r.RelatedEntity.Recorded).To(Equal(uint64(0)), "make sure person-4 is an open ref")
+			}
+		}
+		Expect(seenCnt).To(Equal(3))
+
+		result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 1)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(len(result[0].Relations)).To(Equal(1))
+
+		result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 2)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(len(result[0].Relations)).To(Equal(2))
+	})
+	ginkgo.It("Should respect limit for many start uris", func() {
+		peopleNamespacePrefix := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
+			{id: 1, friends: []int{0}},
+			{id: 2, friends: []int{1, 4}},
+			{id: 3, deleted: true, friends: []int{2}},
+			{id: 0, friends: []int{1, 2, 3, 4}},
+			{id: 3, friends: []int{2}},
+			{id: 0, deleted: true, friends: []int{1, 2, 3, 4}},
+			{id: 1, friends: []int{3, 2, 4}},
+		}))
+		// get everything
+		start := []string{peopleNamespacePrefix + ":person-1", peopleNamespacePrefix + ":person-2"}
+		result, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(2))
+		Expect(len(result[0].Relations)).To(Equal(3))
+		Expect(len(result[1].Relations)).To(Equal(2))
+
+		// limit 1, should return first hit of first startUri
+		result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 1)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(len(result[0].Relations)).To(Equal(1))
+
+		// limit 4, room for all 3 relations of first startUri plus 1 from other startUri
+		result, err = store.GetManyRelatedEntitiesBatch(
+			start,
+			"*",
+			false,
+			nil,
+			4,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(2))
+		Expect(len(result[0].Relations)).To(Equal(3))
+		Expect(len(result[1].Relations)).To(Equal(1))
+	})
+	ginkgo.It("Should respect limit in inverse queries", func() {
+		peopleNamespacePrefix := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
+			{id: 1, friends: []int{0}},
+			{id: 2, friends: []int{1, 4}},
+			{id: 3, deleted: true, friends: []int{2}},
+			{id: 0, friends: []int{1, 2, 3, 4}},
+			{id: 3, friends: []int{2}},
+			{id: 0, deleted: true, friends: []int{1, 2, 3, 4}},
+			{id: 1, friends: []int{3, 2, 4}},
+		}))
+		// get everything
+		start := []string{peopleNamespacePrefix + ":person-1", peopleNamespacePrefix + ":person-2"}
+		result, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(2))
+		Expect(len(result[0].Relations)).To(Equal(1))
+		Expect(len(result[1].Relations)).To(Equal(2))
+		// limit 1, should return first hit of first startUri
+		result, err = store.GetManyRelatedEntitiesBatch(
+			start,
+			"*",
+			true,
+			nil,
+			1,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(len(result[0].Relations)).To(Equal(1))
+
+		// limit 2, room for all 1 relations of first startUri plus 1 from other startUri
+		result, err = store.GetManyRelatedEntitiesBatch(
+			start,
+			"*",
+			true,
+			nil,
+			2,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(2))
+		Expect(len(result[0].Relations)).To(Equal(1))
+		Expect(len(result[1].Relations)).To(Equal(1))
+	})
+	ginkgo.It("Should return a working continuation token", func() {
+		pref := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
+			{id: 1, friends: []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}},
+		}))
+		start := []string{pref + ":person-1"}
+		queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+		Expect(err).To(BeNil())
+		Expect(len(queryResult)).To(Equal(1))
+		Expect(len(queryResult[0].Relations)).To(Equal(19))
+
+		queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 2)
+		Expect(err).To(BeNil())
+		Expect(len(queryResult)).To(Equal(1))
+		Expect(len(queryResult[0].Relations)).To(Equal(2))
+		Expect(queryResult[0].Relations[0].RelatedEntity.ID).To(Equal(pref + ":person-20"))
+		Expect(queryResult[0].Relations[1].RelatedEntity.ID).To(Equal(pref + ":person-19"))
+		Expect(queryResult[0].Continuation.RelationIndexFromKey).NotTo(BeNil())
+		startFromCont := queryResult.Cont()
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 3)
+		Expect(err).To(BeNil())
+		Expect(len(queryResult)).To(Equal(1))
+		Expect(len(queryResult[0].Relations)).To(Equal(3))
+		Expect(queryResult[0].Relations[0].RelatedEntity.ID).To(Equal(pref + ":person-18"))
+		Expect(queryResult[0].Relations[1].RelatedEntity.ID).To(Equal(pref + ":person-17"))
+		Expect(queryResult[0].Relations[2].RelatedEntity.ID).To(Equal(pref + ":person-16"))
+		Expect(queryResult[0].Continuation.RelationIndexFromKey).NotTo(BeNil())
+		startFromCont = queryResult.Cont()
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 25)
+		Expect(err).To(BeNil())
+		Expect(len(queryResult)).To(Equal(1))
+		Expect(len(queryResult[0].Relations)).To(Equal(14))
+		Expect(queryResult[0].Relations[0].RelatedEntity.ID).To(Equal(pref + ":person-15"))
+		Expect(queryResult[0].Relations[13].RelatedEntity.ID).To(Equal(pref + ":person-2"))
+		Expect(queryResult[0].Continuation.RelationIndexFromKey).To(BeNil())
+	})
+})
 
 func persist(dsName string, store *Store, dsm *DsManager, b []*Entity) string {
 	friendsDS, _ := dsm.CreateDataset(dsName, nil)

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -21,12 +21,12 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/dgraph-io/badger/v3"
-	"github.com/franela/goblin"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
@@ -34,1818 +34,1814 @@ import (
 	"github.com/mimiro-io/datahub/internal/conf"
 )
 
-func TestStoreRelations(test *testing.T) {
-	g := goblin.Goblin(test)
-	g.Describe("The dataset storage", func() {
-		testCnt := 0
-		var dsm *DsManager
-		var store *Store
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_store_relations_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(test, false))
-			store = NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = NewDsManager(lc, e, store, NoOpBus())
+var _ = ginkgo.Describe("The dataset storage", func() {
+	testCnt := 0
+	var dsm *DsManager
+	var store *Store
+	var storeLocation string
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_store_relations_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(ginkgo.GinkgoT(), false))
+		store = NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = NewDsManager(lc, e, store, NoOpBus())
 
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-
-		g.It("Should delete the correct old outgoing references in array after entity modified", func() {
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			friendsDS, _ := dsm.CreateDataset("friends", nil)
-
-			_ = friendsDS.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": []string{
-							peopleNamespacePrefix + ":person-3",
-							peopleNamespacePrefix + ":person-2",
-						},
-					},
-				}),
-			})
-
-			// check that we can query outgoing
-			result, err := store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(2)
-
-			// check that we can query incoming
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-2"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-
-			// update lisa
-			e := NewEntityFromMap(map[string]interface{}{
-				"id":    peopleNamespacePrefix + ":person-1",
-				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-				"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"},
-			})
-
-			_ = friendsDS.StoreEntities([]*Entity{
-				e,
-			})
-			// check that outgoing related entities is 0
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-3"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-2"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(0)
-		})
-
-		g.It("Should delete the correct old outgoing references after entity modified", func() {
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			friendsDS, _ := dsm.CreateDataset("friends", nil)
-
-			_ = friendsDS.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
-					},
-				}),
-			})
-
-			// check that we can query outgoing
-			result, err := store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
-
-			// delete lisa
-			e := NewEntityFromMap(map[string]interface{}{
-				"id":    peopleNamespacePrefix + ":person-1",
-				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-				"refs":  map[string]interface{}{},
-			})
-
-			_ = friendsDS.StoreEntities([]*Entity{
-				e,
-			})
-
-			// check that outgoing related entities is 0
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(0)
-		})
-
-		g.It("Should delete the correct incoming and outgoing references after entity deleted", func() {
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			friendsDS, _ := dsm.CreateDataset("friends", nil)
-
-			_ = friendsDS.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
-					},
-				}),
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-2",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Homer"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
-					},
-				}),
-			})
-
-			// check that we can query outgoing
-			result, err := store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
-
-			// check that we can query incoming
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
-
-			// delete lisa
-			e := NewEntityFromMap(map[string]interface{}{
-				"id":    peopleNamespacePrefix + ":person-1",
-				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-				"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"},
-			})
-			e.IsDeleted = true
-
-			_ = friendsDS.StoreEntities([]*Entity{
-				e,
-			})
-
-			// check that outgoing related entities is 0
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(0)
-
-			// check that we can query incoming count to person-3 is 0
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-3"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(0)
-
-			// check that we can query incoming count to person-1 is still 1
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-		})
-
-		g.It("Should delete the correct incoming and outgoing references", func() {
-			b := store.database
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			workPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/work/")
-			g.Assert(count(b)).Eql(16)
-
-			friendsDS, _ := dsm.CreateDataset("friends", nil)
-			g.Assert(count(b)).Eql(24)
-
-			workDS, _ := dsm.CreateDataset("work", nil)
-			g.Assert(count(b)).Eql(32)
-
-			_ = friendsDS.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
-					},
-				}),
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-2",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
-					},
-				}),
-			})
-			g.Assert(count(b)).Eql(55)
-
-			// check that we can query outgoing
-			result, err := store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
-
-			// check that we can query incoming
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
-
-			_ = workDS.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{workPrefix + ":Wage": "110"},
-					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-2"},
-				}),
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-2",
-					"props": map[string]interface{}{workPrefix + ":Wage": "100"},
-					"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-3"},
-				}),
-			})
-			g.Assert(count(b)).Eql(72)
-
-			// check that we can still query outgoing
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			// result, err = store.GetManyRelatedEntities( []string{"http://data.mimiro.io/people/person-1"}, "*", false, nil)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1, "Expected still to find person-3 as a friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-3")
-
-			// and incoming
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1, "Expected still to find person-2 as reverse friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
-		})
-
-		g.It("Should store references of new deleted entities as deleted", func() {
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			friendsDS, _ := dsm.CreateDataset("friends", nil)
-
-			p1 := NewEntityFromMap(map[string]interface{}{
-				"id":    peopleNamespacePrefix + ":person-1",
-				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-				"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"},
-			})
-			p1.IsDeleted = true
-			_ = friendsDS.StoreEntities([]*Entity{
-				p1,
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-2",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Homer"},
-					"refs": map[string]interface{}{
-						peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
-					},
-				}),
-			})
-			// check that we can not query outgoing from deleted entity
-			result, err := store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				false,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(0)
-
-			// check that we can query incoming. this relation is owned by Homer
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-1"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-			g.Assert(result[0][1]).Eql(peopleNamespacePrefix + ":Friend")
-			g.Assert(result[0][2].(*Entity).ID).Eql(peopleNamespacePrefix + ":person-2")
-
-			// inverse query from person-3 should not return anything because person-1 (which owns the relation) is deleted
-			result, err = store.GetManyRelatedEntities(
-				[]string{"http://data.mimiro.io/people/person-3"},
-				peopleNamespacePrefix+":Friend",
-				true,
-				nil,
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(0)
-		})
-
-		g.It("Should build query results", func() {
-			// create dataset
-			ds, _ := dsm.CreateDataset("people", nil)
-
-			batchSize := 5
-			entities := make([]*Entity, batchSize)
-
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/model/",
-			)
-			rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
-
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
-				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
-				entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
-				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
-				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
-				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
-				entities[i] = entity
-			}
-
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			results, err := store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(results)).Eql(1)
-
-			invresults, err := store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults)).Eql(5)
-
-			invresults, err = store.getRelated("http://data.mimiro.io/model/Person", "*", true, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults)).Eql(5)
-
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
-				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
-				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
-				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
-				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
-				entities[i] = entity
-			}
-
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			time0 := time.Now().UnixNano()
-
-			invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults)).Eql(0)
-
-			results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(results)).Eql(0)
-
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
-				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
-				entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
-				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
-				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
-				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
-				entities[i] = entity
-			}
-
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults)).Eql(5)
-
-			results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(results)).Eql(1)
-
-			// test at point in time
-			from, _ := store.ToRelatedFrom(
-				[]string{"http://data.mimiro.io/people/p-1"},
-				RdfTypeURI,
-				false,
-				nil,
-				time0,
-			)
-			results2, _, err := store.GetRelatedAtTime(from[0], 0)
-			g.Assert(err).IsNil()
-			g.Assert(len(results2)).Eql(0)
-
-			from, _ = store.ToRelatedFrom(
-				[]string{"http://data.mimiro.io/model/Person"},
-				RdfTypeURI,
-				true,
-				nil,
-				time0,
-			)
-			invresults2, _, err := store.GetRelatedAtTime(from[0], 0)
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults2)).Eql(0)
-		})
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
 	})
-}
-
-func TestStore(test *testing.T) {
-	g := goblin.Goblin(test)
-	g.Describe("The dataset storage", func() {
-		testCnt := 0
-		var dsm *DsManager
-		var store *Store
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_store_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(test, false))
-			store = NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = NewDsManager(lc, e, store, NoOpBus())
-
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-
-		g.It("Should store the curi id mapping", func() {
-			cache := make(map[string]uint64)
-			id, _, _ := dsm.store.assertIDForURI("ns0:gra", cache)
-			err := dsm.store.commitIDTxn()
-			g.Assert(err).IsNil()
-			curi, _ := dsm.store.getURIForID(id)
-			g.Assert(curi).Eql("ns0:gra")
-		})
-
-		g.It("Should store entity batches without error", func() {
-			// create dataset
-			ds, _ := dsm.CreateDataset("people", nil)
-
-			entities := make([]*Entity, 1)
-			entity := NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["Name"] = "homer"
-			entity.References["type"] = "http://data.mimiro.io/model/Person"
-			entity.References["typed"] = "http://data.mimiro.io/model/Person"
-			entities[0] = entity
-
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil("Expected no error when storing entity")
-		})
-
-		g.It("Should replace entity namespace prefixes", func() {
-			// define store context
-			_, _ = store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
-			prefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/model/Person/")
-
-			entity := NewEntity(prefix+":homer", 0)
-			entity.Properties[prefix+":Name"] = "homer"
-			entity.References[prefix+":type"] = "ns1:Person"
-			entity.References[prefix+":company"] = "ns1:Person"
-
-			g.Assert(entity.ID).Eql(prefix + ":homer")
-			err := entity.ExpandIdentifiers(store)
-			g.Assert(err).IsNil()
-			g.Assert(entity.ID).Eql("http://data.mimiro.io/model/Person/homer")
-		})
-
-		g.It("Should make entities retrievable", func() {
-			// create dataset
-			ds, _ := dsm.CreateDataset("people", nil)
-
-			entities := make([]*Entity, 1)
-			entity := NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["Name"] = "homer"
-			entity.References["type"] = "http://data.mimiro.io/model/Person"
-			entity.References["typed"] = "http://data.mimiro.io/model/Person"
-			entities[0] = entity
-
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			allEntities := make([]*Entity, 0)
-			_, err = ds.MapEntities("", 0, func(e *Entity) error {
-				allEntities = append(allEntities, e)
-				return nil
-			})
-			g.Assert(err).IsNil()
-			g.Assert(len(allEntities)).Eql(1, "Expected to retrieve same number of entities as was written")
-		})
-
-		g.It("Should only update entities if they are different (batch)", func() {
-			// create dataset
-			ds, _ := dsm.CreateDataset("people", nil)
-
-			entities := make([]*Entity, 1)
-			entity := NewEntity("http://data.mimiro.io/people/homer", 0)
-			entity.Properties["Name"] = "homer"
-			entity.References["type"] = "http://data.mimiro.io/model/Person"
-			entity.References["typed"] = "http://data.mimiro.io/model/Person"
-			entities[0] = entity
-
-			// 1. store entity
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-			// and get first versions of object
-			res, err := ds.GetEntities("", 1)
-			g.Assert(err).IsNil()
-			firstVersionTS := res.Entities[0].Recorded
-
-			// 2. store again
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-			// and get version again
-			res, _ = ds.GetEntities("", 1)
-			g.Assert(res.Entities[0].Recorded).Eql(firstVersionTS, "Should be unchanged version")
-
-			// 3. set same name and store again
-			entity.Properties["Name"] = "homer"
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-			// and get version again
-			res, _ = ds.GetEntities("", 1)
-			g.Assert(res.Entities[0].Recorded).Eql(firstVersionTS, "Should be unchanged version")
-
-			// 4. now set a new name and store
-			entity.Properties["Name"] = "homer simpson"
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-			// version should change
-			res, _ = ds.GetEntities("", 1)
-			g.Assert(res.Entities[0].Recorded != firstVersionTS).IsTrue("Should be new version")
-		})
-
-		g.It("Should track changes", func() {
-			// create dataset
-			_, _ = dsm.CreateDataset("companies", nil)
-			_, _ = dsm.CreateDataset("animals", nil)
-			ds, err := dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
-
-			entities := make([]*Entity, 3)
-			entity1 := NewEntity("http://data.mimiro.io/people/homer", 0)
-			entities[0] = entity1
-			entity2 := NewEntity("http://data.mimiro.io/people/bob", 0)
-			entities[1] = entity2
-			entity3 := NewEntity("http://data.mimiro.io/people/jim", 0)
-			entities[2] = entity3
-
-			_ = ds.StoreEntities(entities)
-
-			_ = dsm.DeleteDataset("people")
-			ds, _ = dsm.CreateDataset("people", nil)
-
-			entities = make([]*Entity, 3)
-			entity1 = NewEntity("http://data.mimiro.io/people/homer", 0)
-			entities[0] = entity1
-			entity2 = NewEntity("http://data.mimiro.io/people/bob", 0)
-			entities[1] = entity2
-			entity3 = NewEntity("http://data.mimiro.io/people/jim", 0)
-			entities[2] = entity3
-
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			// get changes
-			changes, err := ds.GetChanges(0, 10, false)
-			g.Assert(err).IsNil()
-			g.Assert(len(changes.Entities)).Eql(3)
-			g.Assert(changes.NextToken).Eql(uint64(3))
-
-			changes, err = ds.GetChanges(1, 1, false)
-			g.Assert(err).IsNil()
-			g.Assert(len(changes.Entities)).Eql(1)
-			g.Assert(changes.NextToken).Eql(uint64(2))
-
-			changes, err = ds.GetChanges(2, 1, false)
-			g.Assert(err).IsNil()
-			g.Assert(len(changes.Entities)).Eql(1)
-			g.Assert(changes.NextToken).Eql(uint64(3))
-
-			changes, _ = ds.GetChanges(3, 10, false)
-			g.Assert(len(changes.Entities)).Eql(0)
-			g.Assert(changes.NextToken).Eql(uint64(3))
-
-			// store modified entities again and then get changes latest true
-			entity1.Properties = map[string]interface{}{"http://test.org/name": "homer"}
-			ds.StoreEntities(entities)
-
-			changes, _ = ds.GetChanges(0, 0, true)
-			g.Assert(len(changes.Entities)).Eql(3)
-			g.Assert(changes.NextToken).Eql(uint64(4))
-		})
-
-		g.It("Should paginate entities with continuation tokens", func() {
-			// create dataset
-			c, _ := dsm.CreateDataset("companies", nil)
-			_, _ = dsm.CreateDataset("animals", nil)
-			dsm.CreateDataset("people", nil)
-
-			_ = dsm.DeleteDataset("people")
-			ds, _ := dsm.CreateDataset("people", nil)
-
-			entities := make([]*Entity, 3)
-			entity1 := NewEntity("http://data.mimiro.io/people/homer", 0)
-			entities[0] = entity1
-			entity2 := NewEntity("http://data.mimiro.io/people/bob", 0)
-			entities[1] = entity2
-			entity3 := NewEntity("http://data.mimiro.io/people/jim", 0)
-			entities[2] = entity3
-
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-			// store same entitites in two datasets. should give merged results
-			err = c.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			result, err := ds.GetEntities("", 50)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(3, "Expected all 3 entitites back")
-
-			result1, err := ds.GetEntities(result.ContinuationToken, 1)
-			g.Assert(err).IsNil()
-			g.Assert(len(result1.Entities)).Eql(0, "first page should have returned all entities, "+
-				"therefore this page should be empty")
-			g.Assert(result1.ContinuationToken).Eql(result.ContinuationToken)
-
-			// test c token
-			result, err = ds.GetEntities("", 1)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(1, "we only asked for 1 entitiy this page")
-
-			result, err = ds.GetEntities(result.ContinuationToken, 5)
-			g.Assert(err).IsNil()
-			g.Assert(len(result.Entities)).Eql(2, "second page should have remaining 2 enitities")
-
-			g.Assert(result.Entities[0].ID).Eql("http://data.mimiro.io/people/bob", "first result 2nd page is not bob")
-		})
-
-		g.It("Should not struggle with many batch writes", func() {
-			g.Timeout(5 * time.Minute)
-			// create dataset
-			ds1, err := dsm.CreateDataset("people0", nil)
-			ds2, err := dsm.CreateDataset("people1", nil)
-			ds3, err := dsm.CreateDataset("people2", nil)
-			ds4, err := dsm.CreateDataset("people3", nil)
-			ds5, err := dsm.CreateDataset("people4", nil)
-
-			batchSize := 1000
-			iterationSize := 100
-
-			f := func(ds *Dataset, prefix string, wg *sync.WaitGroup) {
-				idcounter := uint64(0)
-				for j := 0; j < iterationSize; j++ {
-					entities := make([]*Entity, batchSize)
-					for i := 0; i < batchSize; i++ {
-						entity := NewEntity(prefix+strconv.Itoa(i), idcounter)
-						entity.Properties[prefix+":Name"] = "homer"
-						entity.References[prefix+":type"] = prefix + "/Person"
-						entity.References[prefix+":f1"] = prefix + "/Person-1"
-						entity.References[prefix+":f2"] = prefix + "/Person-2"
-						entity.References[prefix+":f3"] = prefix + "/Person-3"
-
-						entities[i] = entity
-						idcounter++
-					}
-					err = ds.StoreEntities(entities)
-					g.Assert(err).IsNil("Storing should never fail under load")
-				}
-				wg.Done()
-			}
-
-			var wg sync.WaitGroup
-			wg.Add(5)
-
-			go f(ds1, "http://data.mimiro.io/people/p1-", &wg)
-			go f(ds2, "http://data.mimiro.io/people/p1-", &wg)
-			go f(ds3, "http://data.mimiro.io/people/p1-", &wg)
-			go f(ds4, "http://data.mimiro.io/people/p1-", &wg)
-			go f(ds5, "http://data.mimiro.io/people/p1-", &wg)
-
-			wg.Wait()
-		})
-
-		g.It("Should do deletion detection when running in fullsync mode", func() {
-			// create dataset
-			ds, err := dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
-			batchSize := 5
-
-			err = ds.StartFullSync()
-			g.Assert(err).IsNil()
-
-			entities := make([]*Entity, batchSize)
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
-				entity.Properties["Name"] = "homer"
-				entities[i] = entity
-			}
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			err = ds.CompleteFullSync()
-			g.Assert(err).IsNil()
-
-			// start 2nd fullsync
-			err = ds.StartFullSync()
-			g.Assert(err).IsNil()
-
-			entities = make([]*Entity, 1)
-			entity := NewEntity("http://data.mimiro.io/people/p-0", 0)
-			entity.Properties["Name"] = "homer"
-			entities[0] = entity
-			// entities[0] = res.Entities[0]
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			err = ds.CompleteFullSync()
-			g.Assert(err).IsNil()
-
-			allEntities := make([]*Entity, 0)
-			deletedEntities := make([]*Entity, 0)
-			_, err = ds.MapEntities("", 0, func(e *Entity) error {
-				if !e.IsDeleted {
-					allEntities = append(allEntities, e)
-				} else {
-					deletedEntities = append(deletedEntities, e)
-				}
-				return nil
-			})
-			g.Assert(err).IsNil("MapEntities should have worked")
-			g.Assert(len(allEntities)).Eql(1, "There should be one undeleted entity left")
-			g.Assert(len(deletedEntities)).Eql(batchSize-1, "all other entities should be deleted")
-		})
-
-		g.It("Should enable iterating over a dataset (MapEntitites)", func() {
-			// create dataset
-			ds, err := dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
-			batchSize := 5
-
-			entities := make([]*Entity, batchSize)
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
-				entity.Properties["Name"] = "homer"
-				entities[i] = entity
-			}
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			var entity *Entity
-			ctoken, _ := ds.MapEntities("", 1, func(e *Entity) error {
-				entity = e
-				return nil
-			})
-			g.Assert(entities).IsNotZero("MapEntities should have processed 1 entity")
-			g.Assert(ctoken).IsNotZero("MapEntities should have given us a token")
-
-			var nextEntity *Entity
-			newtoken, _ := ds.MapEntities(ctoken, 1, func(e *Entity) error {
-				nextEntity = e
-				return nil
-			})
-			g.Assert(nextEntity).IsNotZero("MapEntities should have processed 1 entity again")
-			g.Assert(newtoken).IsNotZero("MapEntities should have given us a new token")
-			g.Assert(nextEntity.ID != entity.ID).IsTrue("We should have a different entity")
-			g.Assert(ctoken != newtoken).IsTrue("We should have a different token")
-		})
-
-		g.Describe(
-			"When retrieving data, it can combine multiple entities from different datasets with the same ID",
-			func() {
-				g.It("Should merge entity data from different entities with same id (partials)", func() {
-					e1 := NewEntity("x:e1", 0)
-					e2 := NewEntity("x:e1", 0)
-					partials := make([]*Entity, 2)
-					partials[0] = e1
-					partials[1] = e2
-					result := store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).IsNil()
-
-					e2.Properties["x:name"] = "homer"
-					result = store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).Eql("homer")
-				})
-
-				g.It("Should merge partials without error if a source is empty", func() {
-					e1 := NewEntity("x:e1", 0)
-					e2 := NewEntity("x:e1", 0)
-					partials := make([]*Entity, 2)
-					partials[0] = e1
-					partials[1] = e2
-
-					e1.Properties["x:name"] = "homer"
-
-					result := store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).Eql("homer")
-				})
-
-				g.It("Should merge partials if target entity is empty", func() {
-					e1 := NewEntity("x:e1", 0)
-					e2 := NewEntity("x:e1", 0)
-					partials := make([]*Entity, 2)
-					partials[0] = e1
-					partials[1] = e2
-
-					e2.Properties["x:name"] = "homer"
-
-					result := store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).Eql("homer")
-				})
-
-				g.It("Should merge single values from 2 partials to a list value", func() {
-					e1 := NewEntity("x:e1", 0)
-					e2 := NewEntity("x:e1", 0)
-					partials := make([]*Entity, 2)
-					partials[0] = e1
-					partials[1] = e2
-
-					e1.Properties["x:name"] = "homer"
-					e2.Properties["x:name"] = "bob"
-
-					result := store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).Eql([]interface{}{"homer", "bob"})
-				})
-
-				g.It("Should add single values to existing list when merging partials", func() {
-					e1 := NewEntity("x:e1", 0)
-					e2 := NewEntity("x:e1", 0)
-					partials := make([]*Entity, 2)
-					partials[0] = e1
-					partials[1] = e2
-
-					names := make([]interface{}, 0)
-					names = append(names, "homer")
-					names = append(names, "brian")
-					e1.Properties["x:name"] = names
-					e2.Properties["x:name"] = "bob"
-
-					result := store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).Eql([]interface{}{"homer", "brian", "bob"})
-				})
-
-				g.It("Should add list to existing single value when merging partials", func() {
-					e1 := NewEntity("x:e1", 0)
-					e2 := NewEntity("x:e1", 0)
-					partials := make([]*Entity, 2)
-					partials[0] = e1
-					partials[1] = e2
-
-					names := make([]interface{}, 0)
-					names = append(names, "homer")
-					names = append(names, "brian")
-					e1.Properties["x:name"] = "bob"
-					e2.Properties["x:name"] = names
-
-					result := store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).Eql([]interface{}{"bob", "homer", "brian"})
-				})
-
-				g.It("Should combine two value lists when merging partials", func() {
-					e1 := NewEntity("x:e1", 0)
-					e2 := NewEntity("x:e1", 0)
-					partials := make([]*Entity, 2)
-					partials[0] = e1
-					partials[1] = e2
-
-					names := make([]interface{}, 0)
-					names = append(names, "homer")
-					names = append(names, "brian")
-					e1.Properties["x:name"] = names
-
-					names1 := make([]interface{}, 0)
-					names1 = append(names1, "bob")
-					names1 = append(names1, "james")
-
-					e2.Properties["x:name"] = names1
-
-					result := store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).Eql([]interface{}{"homer", "brian", "bob", "james"})
-				})
-
-				g.It("Should merge 3 partials", func() {
-					e1 := NewEntity("x:e1", 0)
-					e2 := NewEntity("x:e1", 0)
-					e3 := NewEntity("x:e1", 0)
-					partials := make([]*Entity, 3)
-					partials[0] = e1
-					partials[1] = e2
-					partials[2] = e3
-
-					e1.Properties["x:name"] = "bob"
-
-					e2.Properties["x:name"] = "brian"
-					e2.Properties["x:dob"] = "01-01-2001"
-
-					e3.Properties["x:name"] = "james"
-
-					partials = make([]*Entity, 3)
-					partials[0] = e1
-					partials[1] = e2
-					partials[2] = e3
-
-					result := store.MergePartials(partials)
-					g.Assert(result).IsNotZero()
-					g.Assert(result.ID).Eql("x:e1")
-					g.Assert(result.Properties["x:name"]).Eql([]interface{}{"bob", "brian", "james"})
-					g.Assert(result.Properties["x:dob"]).Eql("01-01-2001")
-				})
-			},
-		)
-
-		g.It("Should build query results", func() {
-			// create dataset
-			ds, _ := dsm.CreateDataset("people", nil)
-
-			batchSize := 5
-			entities := make([]*Entity, batchSize)
-
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/model/",
-			)
-			rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
-
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
-				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
-				entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
-				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
-				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
-				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
-				entities[i] = entity
-			}
-
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			results, err := store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(results)).Eql(1)
-
-			invresults, err := store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults)).Eql(5)
-
-			invresults, err = store.getRelated("http://data.mimiro.io/model/Person", "*", true, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults)).Eql(5)
-
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
-				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
-				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
-				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
-				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
-				entities[i] = entity
-			}
-
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults)).Eql(0)
-
-			results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(results)).Eql(0)
-
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
-				entity.Properties[modelNamespacePrefix+":Name"] = "homer"
-				entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
-				entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
-				entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
-				entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
-				entities[i] = entity
-			}
-
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(invresults)).Eql(5)
-
-			results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
-			g.Assert(err).IsNil()
-			g.Assert(len(results)).Eql(1)
-		})
-
-		g.It("Should perform batch updates without error with concurrent requests", func() {
-			// create dataset
-			ds, err := dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
-
-			batchSize := 5000
-			entities := make([]*Entity, batchSize)
-
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
-				entity.Properties["Name"] = "homer"
-				entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
-				entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
-				entity.References["rdf:f2"] = "http://data.mimiro.io/people/Person-2"
-				entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
-				entities[i] = entity
-			}
-
-			var wg sync.WaitGroup
-			for i := 1; i <= 10; i++ {
-				wg.Add(1)
-				go func() {
-					err := ds.StoreEntities(entities)
-					g.Assert(err).IsNil("StoreEntities failed unexpectedly")
-					defer wg.Done()
-				}()
-			}
-			wg.Wait()
-		})
-
-		g.It("Should store and replace large batches without error", func() {
-			// create dataset
-			ds, _ := dsm.CreateDataset("people", nil)
-
-			batchSize := 5000
-			entities := make([]*Entity, batchSize)
-
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
-				entity.Properties["Name"] = "homer"
-
-				entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
-				entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
-				entity.References["rdf:f2"] = "http://data.mimiro.io/people/Person-2"
-				entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
-
-				entities[i] = entity
-			}
-			err := ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-
-			// replace
-			for i := 0; i < batchSize; i++ {
-				entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
-				entity.Properties["Name"] = "homer"
-
-				entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
-				entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
-				//		refs["rdf:f2"] = "http://data.mimiro.io/people/Person-2"
-				entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
-
-				entities[i] = entity
-			}
-
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil()
-			/*allEntities := make([]*Entity, 0)
-			ds.GetEntities(func(e *Entity) {
-				allEntities = append(allEntities, e)
-			})
-
-			if len(allEntities) != batchSize {
-				t.Fail()
-			} */
-			// replace again
-			/* for i := 0; i < batchSize; i++ {
-			   	entity := NewEntity("http://data.mimiro.io/people/p-" + strconv.Itoa(i), 0)
-			   	entity.Properties["Name"] = "homer"
-
-			   	entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
-			   	entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
-			   	entity.References["rdf:f2"] = "http://data.mimiro.io/people/Person-6"
-			   	entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
-
-			   	entities[i] = entity
-			   }
-
-			   ds.StoreEntities(entities) */
-		})
-
-		g.It("Should build correct query results with large number of entities", func() {
-			// namespaces
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			companyNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/company/",
-			)
-			modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/model/",
-			)
-			rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
-
-			// create dataset
-			peopleDataset, _ := dsm.CreateDataset("people", nil)
-			companiesDataset, _ := dsm.CreateDataset("companies", nil)
-
-			numOfCompanies := 10
-			numOfEmployees := 1000
-			companies := make([]*Entity, 0)
-			people := make([]*Entity, 0)
-			queryIds := make([]string, 0)
-			empID := 0
-
-			for i := 0; i < numOfCompanies; i++ {
-
-				c := NewEntity(companyNamespacePrefix+":company-"+strconv.Itoa(i), 0)
-				c.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Company"
-
-				for j := 0; j < numOfEmployees; j++ {
-					person := NewEntity(peopleNamespacePrefix+":person-"+strconv.Itoa(empID), 0)
-					person.Properties[peopleNamespacePrefix+":Name"] = "person " + strconv.Itoa(i)
-					person.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
-					person.References[peopleNamespacePrefix+":worksfor"] = companyNamespacePrefix + ":company-" + strconv.Itoa(
-						i,
-					)
-					people = append(people, person)
-
-					if empID < 100 {
-						queryIds = append(queryIds, "http://data.mimiro.io/people/person-"+strconv.Itoa(empID))
-					}
-
-					empID++
-				}
-
-				companies = append(companies, c)
-			}
-			err := companiesDataset.StoreEntities(companies)
-			g.Assert(err).IsNil()
-
-			err = peopleDataset.StoreEntities(people)
-			g.Assert(err).IsNil()
-			// query
-			result, err := store.GetManyRelatedEntities(
-				queryIds,
-				"http://data.mimiro.io/people/worksfor",
-				false,
-				[]string{},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(100)
-
-			// check inverse
-			queryIds = make([]string, 0)
-			queryIds = append(queryIds, "http://data.mimiro.io/company/company-1")
-			queryIds = append(queryIds, "http://data.mimiro.io/company/company-2")
-			result, err = store.GetManyRelatedEntities(
-				queryIds,
-				"http://data.mimiro.io/people/worksfor",
-				true,
-				[]string{},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(numOfEmployees * 2)
-		})
-
-		g.It("Should return entity placeholders (links) in queries", func() {
-			// namespaces
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			companyNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/company/",
-			)
-			modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/model/",
-			)
-			rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
-
-			// create dataset
-			peopleDataset, _ := dsm.CreateDataset("people", nil)
-			// 	companiesDataset, err := dsm.CreateDataset("companies")
-
-			people := make([]*Entity, 0)
-			queryIds := make([]string, 0)
-
-			person := NewEntity(peopleNamespacePrefix+":person-"+strconv.Itoa(1), 0)
-			person.Properties[peopleNamespacePrefix+":Name"] = "person " + strconv.Itoa(2)
-			person.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
-			person.References[peopleNamespacePrefix+":worksfor"] = companyNamespacePrefix + ":company-3"
-			people = append(people, person)
-
-			err := peopleDataset.StoreEntities(people)
-			g.Assert(err).IsNil()
-
-			queryIds = append(queryIds, "http://data.mimiro.io/people/person-"+strconv.Itoa(1))
-			// query
-			result, err := store.GetManyRelatedEntities(
-				queryIds,
-				"http://data.mimiro.io/people/worksfor",
-				false,
-				[]string{},
-			)
-			g.Assert(err).IsNil()
-			g.Assert(len(result)).Eql(1)
-		})
+	ginkgo.AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
 	})
-}
 
-func TestDatasetScope(test *testing.T) {
-	g := goblin.Goblin(test)
-	g.Describe("Scoped storage functions", func() {
-		testCnt := 0
-		var dsm *DsManager
-		var store *Store
-		var storeLocation string
-		var peopleNamespacePrefix string
-		var companyNamespacePrefix string
-		const PEOPLE = "people"
-		const COMPANIES = "companies"
-		const HISTORY = "history"
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_store_dsscope_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			lc := fxtest.NewLifecycle(internal.FxTestLog(test, false))
-			store = NewStore(lc, e, &statsd.NoOpClient{})
-			dsm = NewDsManager(lc, e, store, NoOpBus())
-
-			err = lc.Start(context.Background())
-			g.Assert(err).IsNil()
-
-			// namespaces
-			peopleNamespacePrefix, _ = store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
-			companyNamespacePrefix, _ = store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/company/",
-			)
-			modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/model/",
-			)
-			rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
-			// create dataset
-			peopleDataset, _ := dsm.CreateDataset(PEOPLE, nil)
-			companiesDataset, _ := dsm.CreateDataset(COMPANIES, nil)
-			employmentHistoryDataset, _ := dsm.CreateDataset(HISTORY, nil)
-
-			/* Install the following setup
-			{person: 1, workhistory: []int{}, currentwork: 1},
-			{person: 2, workhistory: []int{1}, currentwork: 2},
-			{person: 3, workhistory: []int{2}, currentwork: 1},
-			{person: 4, workhistory: []int{1, 2}, currentwork: 3},
-			{person: 5, workhistory: []int{3}, currentwork: 1},
-			*/
-			//insert companies
-			for _, companyID := range []int{1, 2, 3} {
-				cid := companyNamespacePrefix + ":company-" + strconv.Itoa(companyID)
-				_ = companiesDataset.StoreEntities([]*Entity{NewEntityFromMap(map[string]interface{}{
-					"id": cid,
-					"props": map[string]interface{}{
-						companyNamespacePrefix + ":Name": "Company " + strconv.Itoa(companyID),
-					},
-					"refs": map[string]interface{}{rdfNamespacePrefix + ":type": modelNamespacePrefix + ":Company"},
-				})})
-			}
-
-			// insert people with worksfor relations
-			currentWork := []int{1, 2, 1, 3, 1}
-			for personID, workID := range currentWork {
-				pid := peopleNamespacePrefix + ":person-" + strconv.Itoa(personID+1)
-				_ = peopleDataset.StoreEntities([]*Entity{NewEntityFromMap(map[string]interface{}{
-					"id": pid,
-					"props": map[string]interface{}{
-						peopleNamespacePrefix + ":Name": "Person " + strconv.Itoa(personID+1),
-					},
-					"refs": map[string]interface{}{
-						rdfNamespacePrefix + ":type": modelNamespacePrefix + ":Person",
-						peopleNamespacePrefix + ":worksfor": companyNamespacePrefix + ":company-" + strconv.Itoa(
-							workID,
-						),
-					},
-				})})
-			}
-
-			// insert workHistory
-			for personID, workHistIds := range [][]int{{}, {1}, {2}, {1, 2}, {3}} {
-				var workHistory []string
-				for _, histID := range workHistIds {
-					workHistory = append(workHistory, companyNamespacePrefix+":company-"+strconv.Itoa(histID))
-				}
-				pid := peopleNamespacePrefix + ":person-" + strconv.Itoa(personID+1)
-				entity := NewEntityFromMap(map[string]interface{}{
-					"id":    pid,
-					"props": map[string]interface{}{},
-					"refs": map[string]interface{}{
-						rdfNamespacePrefix + ":type":        modelNamespacePrefix + ":Employment",
-						peopleNamespacePrefix + ":Employee": strconv.Itoa(personID + 1),
-						peopleNamespacePrefix + ":worksfor": companyNamespacePrefix + ":company-" + strconv.Itoa(
-							currentWork[personID],
-						),
-						peopleNamespacePrefix + ":workedfor": workHistory,
-					},
-				})
-				_ = employmentHistoryDataset.StoreEntities([]*Entity{entity})
-			}
-		})
-		g.AfterEach(func() {
-			dsm.DeleteDataset(PEOPLE)
-			dsm.DeleteDataset(COMPANIES)
-			dsm.DeleteDataset(HISTORY)
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
-
-		g.It("Should return all of an entity's relations when no dataset constraints are applied", func() {
-			result, _ := store.GetManyRelatedEntities(
-				[]string{peopleNamespacePrefix + ":person-1"},
-				"http://data.mimiro.io/people/worksfor",
-				false,
-				[]string{},
-			)
-			g.Assert(len(result)).
-				Eql(1, "expected 1 relation to be found. both the people and workhistory datasets point to the same company.")
-
-			entity := findEntity(result, "ns4:company-1")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.ID).Eql("ns4:company-1", "first relation ID should be found")
-			g.Assert(entity.Properties["ns4:Name"]).Eql("Company 1", "first relation property should be resolved")
-		})
-
-		g.It("Should return only relation ID if access to relation dataset is not given", func() {
-			// constraint on "people" only. we should find the relation to a company in "people",
-			// but resolving the company should be omitted because we lack access to the "companies" dataset
-			result, _ := store.GetManyRelatedEntities(
-				[]string{peopleNamespacePrefix + ":person-1"},
-				"http://data.mimiro.io/people/worksfor",
-				false,
-				[]string{PEOPLE},
-			)
-			g.Assert(len(result)).Eql(1, "expected 1 relation to be found in people dataset (not in workHistory)")
-
-			entity := findEntity(result, "ns4:company-1")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.ID).Eql("ns4:company-1", "first relation ID should be found")
-			g.Assert(entity.Properties["ns4:Name"]).IsNil("first relation property should NOT be resolved")
-		})
-
-		g.It("Should not find outgoing relations if the datasets owning these relations are disallowed", func() {
-			// constraint on "companies". we cannot access outgoing refs in the "people" or "history" datasets, therefore we should not find anything
-			result, _ := store.GetManyRelatedEntities(
-				[]string{peopleNamespacePrefix + ":person-1"},
-				"http://data.mimiro.io/people/worksfor",
-				false,
-				[]string{COMPANIES},
-			)
-			g.Assert(len(result)).Eql(0, "expected 0 relation to be found (people and history are excluded)")
-		})
-
-		g.It("Should treat a list of (all) unknown datasets like an empty scope list", func() {
-			// constraint on bogus dataset. due to implementation, this dataset filter will be ignored, query behaves as unrestricted
-			// TODO: this can be discussed. Producing an error would make Queries less unpredictable. But ignoring invalid input makes the API more approachable
-			result, _ := store.GetManyRelatedEntities(
-				[]string{peopleNamespacePrefix + ":person-1"},
-				"http://data.mimiro.io/people/worksfor",
-				false,
-				[]string{"bogus"},
-			)
-			g.Assert(len(result)).Eql(1, "expected 1 relation (company-1)")
-
-			entity := findEntity(result, "ns4:company-1")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.ID).Eql("ns4:company-1", "first relation ID should be found")
-			g.Assert(entity.Properties["ns4:Name"]).Eql("Company 1", "first relation property should be resolved")
-		})
-
-		g.It("Should find relations in secondary datasets if main dataset is disallowed", func() {
-			// constraint on history dataset. we should find an outgoing relation from history to a company,
-			// but company resolving should be disabled since we lack access to the companies dataset
-			result, _ := store.GetManyRelatedEntities(
-				[]string{peopleNamespacePrefix + ":person-1"},
-				"http://data.mimiro.io/people/worksfor",
-				false,
-				[]string{HISTORY},
-			)
-			g.Assert(len(result)).Eql(1, "expected 1 relation to be found in people dataset (not in workHistory)")
-
-			entity := findEntity(result, "ns4:company-1")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.ID).Eql("ns4:company-1", "first relation ID should be found")
-			g.Assert(entity.Properties["ns4:Name"]).IsNil("first relation property should NOT be resolved")
-		})
-
-		g.It("Should return all incoming relations of an entity in inverse query, when no scope is given", func() {
-			// inverse query for "company-1", no datasets restriction. should find 3 people with resolved entities
-			result, _ := store.GetManyRelatedEntities(
-				[]string{companyNamespacePrefix + ":company-1"},
-				"http://data.mimiro.io/people/worksfor",
-				true,
-				[]string{},
-			)
-			g.Assert(len(result)).
-				Eql(3, "there are 6 relations, 3 in dataset people and 3 owned by history. all relations come from total of 3 people")
-			entity := findEntity(result, "ns3:person-5")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.Properties["ns3:Name"]).Eql("Person 5", "first relation property should be resolved")
-			g.Assert(len(entity.References)).Eql(4)
-			// verify that history entity has been merged in by checking for "workedfor"
-			g.Assert(entity.References["ns3:workedfor"].([]interface{})[0]).Eql("ns4:company-3",
-				"inverse query should find company-3 in history following 'worksfor' to person-5's employment enity")
-			// verify that worksfor is duplicated - since the relation is merged together from people and history
-			g.Assert(entity.References["ns3:worksfor"]).Eql([]interface{}{"ns4:company-1", "ns4:company-1"})
-		})
-
-		g.It("Should omit disallowed datasets when resolving found entities", func() {
-			// inverse query for "company-1" with only "people" accessible.
-			// should still find 3 people (incoming relation is owned by people dataset, which we have access to)
-			// people should be resolved
-			// but resolved relations in people should only be "people" data with no "history" refs merged in
-			result, _ := store.GetManyRelatedEntities(
-				[]string{companyNamespacePrefix + ":company-1"},
-				"http://data.mimiro.io/people/worksfor",
-				true,
-				[]string{PEOPLE},
-			)
-			g.Assert(len(result)).Eql(3, "expected 3 relations to be found in people dataset (not in workHistory)")
-
-			entity := findEntity(result, "ns3:person-5")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.ID).Eql("ns3:person-5", "first relation ID should be found")
-			g.Assert(entity.Properties["ns3:Name"]).Eql("Person 5", "first relation property should be resolved")
-			// make sure we only have two refs returned (worksfor + type), confirming that history refs have not been accessed
-			g.Assert(len(entity.References)).Eql(2)
-		})
-
-		g.It("Should not return results if the relation-owning datasets are disallowed", func() {
-			// inverse query for "company-1" with restriction to "companies" dataset.
-			// all incoming relations are stored in either history or people dataset.
-			// with access limited to companies dataset, we should not find incoming relations
-			result, _ := store.GetManyRelatedEntities(
-				[]string{companyNamespacePrefix + ":company-1"},
-				"http://data.mimiro.io/people/worksfor",
-				true,
-				[]string{COMPANIES},
-			)
-			g.Assert(len(result)).Eql(0)
-		})
-
-		g.It("Should resolve all elements in relation arrays, when no scope restriction is given", func() {
-			// find person-4 and follow its workedfor relations without restriction
-			// should find 2 companies in "history" dataset, and fully resolve the company entities
-			result, _ := store.GetManyRelatedEntities(
-				[]string{peopleNamespacePrefix + ":person-4"},
-				"http://data.mimiro.io/people/workedfor",
-				false,
-				[]string{},
-			)
-			g.Assert(len(result)).Eql(2, "expected 2 relations to be found in history dataset")
-
-			entity := findEntity(result, "ns4:company-2")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.ID).Eql("ns4:company-2", "first relation ID should be found")
-			g.Assert(entity.Properties["ns4:Name"]).Eql("Company 2", "first relation property should be resolved")
-		})
-
-		g.It("Should find, but not resolve all relations in an array if relation dataset is disallowed", func() {
-			// find person-4 and follow its workedfor relations in dataset "history"
-			// should find 2 companies in "history" dataset,
-			// but not fully resolve the company entities because we lack access to "company"
-			result, _ := store.GetManyRelatedEntities(
-				[]string{peopleNamespacePrefix + ":person-4"},
-				"http://data.mimiro.io/people/workedfor",
-				false,
-				[]string{HISTORY},
-			)
-			g.Assert(len(result)).Eql(2, "expected 2 relations to be found in history dataset")
-
-			entity := findEntity(result, "ns4:company-2")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.ID).Eql("ns4:company-2", "first relation ID should be found")
-			g.Assert(entity.Properties["ns4:Name"]).
-				IsNil("companies dataset is not accessible, therefor name should be nil")
-		})
-
-		g.It("Should inversely find all relations in an array", func() {
-			// find company-2 and inversely follow workedfor relations without restriction
-			// should find person 3 and 4 in "history" dataset, and fully resolve the person entities
-			result, _ := store.GetManyRelatedEntities(
-				[]string{companyNamespacePrefix + ":company-2"},
-				"http://data.mimiro.io/people/workedfor",
-				true,
-				[]string{},
-			)
-			g.Assert(len(result)).Eql(2, "expected 2 people to be found from history dataset")
-
-			entity := findEntity(result, "ns3:person-4")
-			g.Assert(entity).IsNotNil()
-			g.Assert(entity.ID).Eql("ns3:person-4", "first relation ID should be found")
-			g.Assert(entity.Properties["ns3:Name"]).Eql("Person 4", "first relation property should be resolved")
-			// There should be 4 references both from history and people
-			g.Assert(len(entity.References)).
-				Eql(4, "Expected 4 refs in inversly found person from people and history datasets")
-			// check that reference values are merged from all datasets. type should be list of type refs from both people and history
-			if reflect.DeepEqual(entity.References["ns2:type"], []string{"ns5:Person", "ns5:Employment"}) {
-				g.Failf("Expected Person+Employment as type ref values, but found %v", entity.References["ns2:type"])
-			}
-		})
-
-		g.It(
-			"Should inversely find all relations in array, but not resolve the relation-intities if no access",
-			func() {
-				// find company-2 and inversely follow workedfor relations with filter on history
-				// should find person 3 and 4 in "history" dataset, but not fully resolve the person entities
-				result, _ := store.GetManyRelatedEntities(
-					[]string{companyNamespacePrefix + ":company-2"},
-					"http://data.mimiro.io/people/workedfor",
-					true,
-					[]string{HISTORY},
-				)
-				g.Assert(len(result)).Eql(2, "expected 2 people to be found from history dataset")
-
-				entity := findEntity(result, "ns3:person-4")
-				g.Assert(entity).IsNotNil()
-				g.Assert(entity.ID).Eql("ns3:person-4", "first relation ID should be found")
-				g.Assert(entity.Properties["ns3:Name"]).
-					IsNil("Person 4 should not be resolved since access to people is missing")
-				// There should be 4 references both from history and people
-				g.Assert(len(entity.References)).Eql(4, "Expected 4 refs in inversly found person from history dataset")
-				// check that reference values are merged from all datasets. type should be list of type refs from both people and history
-				g.Assert(entity.References["ns2:type"]).
-					Eql("ns5:Employment", "Expected only Employment type, not Person type")
-			},
+	ginkgo.It("Should delete the correct old outgoing references in array after entity modified", func() {
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
 		)
+		friendsDS, _ := dsm.CreateDataset("friends", nil)
 
-		g.It("Should not inversly find array relations if relation-owning dataset is disallowed", func() {
-			// find company-2 and inversely follow workedfor relations with filter on people and companies
-			// should not find any relations since history access is not allowed, and workedfor is only stored there
-			result, _ := store.GetManyRelatedEntities(
-				[]string{companyNamespacePrefix + ":company-2"},
-				"http://data.mimiro.io/people/workedfor",
-				true,
-				[]string{PEOPLE, COMPANIES},
-			)
-			g.Assert(len(result)).Eql(0)
+		_ = friendsDS.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": []string{
+						peopleNamespacePrefix + ":person-3",
+						peopleNamespacePrefix + ":person-2",
+					},
+				},
+			}),
 		})
 
-		g.It("Should respect dataset scope in GetEntity (single lookup query)", func() {
-			// namespaces
-			employeeNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/employee/",
-			)
-			modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/model/",
-			)
-			rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+		// check that we can query outgoing
+		result, err := store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(2))
 
-			// create dataset
-			const PEOPLE = "people"
-			peopleDataset, _ := dsm.CreateDataset(PEOPLE, nil)
-			const EMPLOYEES = "employees"
-			employeeDataset, _ := dsm.CreateDataset(EMPLOYEES, nil)
+		// check that we can query incoming
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-2"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
 
-			_ = peopleDataset.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
-					"refs": map[string]interface{}{
-						rdfNamespacePrefix + ":type":     modelNamespacePrefix + ":Person",
-						peopleNamespacePrefix + ":knows": peopleNamespacePrefix + "person-2",
-					},
-				}),
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-2",
-					"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Bob"},
-					"refs": map[string]interface{}{
-						rdfNamespacePrefix + ":type":     modelNamespacePrefix + ":Person",
-						peopleNamespacePrefix + ":knows": peopleNamespacePrefix + "person-1",
-					},
-				}),
-			})
-
-			_ = employeeDataset.StoreEntities([]*Entity{
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-1",
-					"props": map[string]interface{}{employeeNamespacePrefix + ":Title": "President"},
-					"refs": map[string]interface{}{
-						rdfNamespacePrefix + ":type": modelNamespacePrefix + ":Employee",
-					},
-				}),
-				NewEntityFromMap(map[string]interface{}{
-					"id":    peopleNamespacePrefix + ":person-2",
-					"props": map[string]interface{}{employeeNamespacePrefix + ":Title": "Vice President"},
-					"refs": map[string]interface{}{
-						rdfNamespacePrefix + ":type":            modelNamespacePrefix + ":Employee",
-						employeeNamespacePrefix + ":Supervisor": peopleNamespacePrefix + ":person-1",
-					},
-				}),
-			})
-
-			// first no datasets restriction, check that props from both employee and people dataset are merged
-			result, err := store.GetEntity(peopleNamespacePrefix+":person-1", []string{})
-			g.Assert(err).IsNil()
-			g.Assert(result.Properties[employeeNamespacePrefix+":Title"]).Eql("President",
-				"expected to merge property employees:Title into result with value 'President'")
-			g.Assert(result.Properties[peopleNamespacePrefix+":Name"]).Eql("Lisa")
-
-			// now, restrict on dataset "people"
-			result, _ = store.GetEntity(peopleNamespacePrefix+":person-2", []string{PEOPLE})
-			// we should not find the Title from the employees dataset
-			g.Assert(result.Properties[employeeNamespacePrefix+":Title"]).IsNil()
-			// people:Name should be found though
-			g.Assert(result.Properties[peopleNamespacePrefix+":Name"]).Eql("Bob")
-
-			// now, restrict on dataset "employees". now Name should be gone but title should be found
-			result, _ = store.GetEntity(peopleNamespacePrefix+":person-2", []string{EMPLOYEES})
-			g.Assert(result.Properties[employeeNamespacePrefix+":Title"]).Eql("Vice President",
-				"expected to merge property employees:Title into result with value 'Vice President'")
-			g.Assert(result.Properties[peopleNamespacePrefix+":Name"]).IsNil()
+		// update lisa
+		e := NewEntityFromMap(map[string]interface{}{
+			"id":    peopleNamespacePrefix + ":person-1",
+			"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+			"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"},
 		})
 
-		g.It("Should perform txn updates without error", func() {
-			// create dataset
-			_, err := dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
+		_ = friendsDS.StoreEntities([]*Entity{
+			e,
+		})
+		// check that outgoing related entities is 0
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
 
-			_, err = dsm.CreateDataset("places", nil)
-			g.Assert(err).IsNil()
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-3"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
 
-			entities := make([]*Entity, 1)
-			entity := NewEntity("http://data.mimiro.io/people/person1", 0)
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-2"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(0))
+	})
+
+	ginkgo.It("Should delete the correct old outgoing references after entity modified", func() {
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		friendsDS, _ := dsm.CreateDataset("friends", nil)
+
+		_ = friendsDS.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
+				},
+			}),
+		})
+
+		// check that we can query outgoing
+		result, err := store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-3"))
+
+		// delete lisa
+		e := NewEntityFromMap(map[string]interface{}{
+			"id":    peopleNamespacePrefix + ":person-1",
+			"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+			"refs":  map[string]interface{}{},
+		})
+
+		_ = friendsDS.StoreEntities([]*Entity{
+			e,
+		})
+
+		// check that outgoing related entities is 0
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(0))
+	})
+
+	ginkgo.It("Should delete the correct incoming and outgoing references after entity deleted", func() {
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		friendsDS, _ := dsm.CreateDataset("friends", nil)
+
+		_ = friendsDS.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
+				},
+			}),
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-2",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Homer"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
+				},
+			}),
+		})
+
+		// check that we can query outgoing
+		result, err := store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-3"))
+
+		// check that we can query incoming
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-2"))
+
+		// delete lisa
+		e := NewEntityFromMap(map[string]interface{}{
+			"id":    peopleNamespacePrefix + ":person-1",
+			"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+			"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"},
+		})
+		e.IsDeleted = true
+
+		_ = friendsDS.StoreEntities([]*Entity{
+			e,
+		})
+
+		// check that outgoing related entities is 0
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(0))
+
+		// check that we can query incoming count to person-3 is 0
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-3"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(0))
+
+		// check that we can query incoming count to person-1 is still 1
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+	})
+
+	ginkgo.It("Should delete the correct incoming and outgoing references", func() {
+		b := store.database
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		workPrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/work/")
+		Expect(count(b)).To(Equal(16))
+
+		friendsDS, _ := dsm.CreateDataset("friends", nil)
+		Expect(count(b)).To(Equal(24))
+
+		workDS, _ := dsm.CreateDataset("work", nil)
+		Expect(count(b)).To(Equal(32))
+
+		_ = friendsDS.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3",
+				},
+			}),
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-2",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
+				},
+			}),
+		})
+		Expect(count(b)).To(Equal(55))
+
+		// check that we can query outgoing
+		result, err := store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-3"))
+
+		// check that we can query incoming
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-2"))
+
+		_ = workDS.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{workPrefix + ":Wage": "110"},
+				"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-2"},
+			}),
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-2",
+				"props": map[string]interface{}{workPrefix + ":Wage": "100"},
+				"refs":  map[string]interface{}{workPrefix + ":Coworker": peopleNamespacePrefix + ":person-3"},
+			}),
+		})
+		Expect(count(b)).To(Equal(72))
+
+		// check that we can still query outgoing
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		// result, err = store.GetManyRelatedEntities( []string{"http://data.mimiro.io/people/person-1"}, "*", false, nil)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1), "Expected still to find person-3 as a friend")
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-3"))
+
+		// and incoming
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1), "Expected still to find person-2 as reverse friend")
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-2"))
+	})
+
+	ginkgo.It("Should store references of new deleted entities as deleted", func() {
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		friendsDS, _ := dsm.CreateDataset("friends", nil)
+
+		p1 := NewEntityFromMap(map[string]interface{}{
+			"id":    peopleNamespacePrefix + ":person-1",
+			"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+			"refs":  map[string]interface{}{peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-3"},
+		})
+		p1.IsDeleted = true
+		_ = friendsDS.StoreEntities([]*Entity{
+			p1,
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-2",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Homer"},
+				"refs": map[string]interface{}{
+					peopleNamespacePrefix + ":Friend": peopleNamespacePrefix + ":person-1",
+				},
+			}),
+		})
+		// check that we can not query outgoing from deleted entity
+		result, err := store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			false,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(0))
+
+		// check that we can query incoming. this relation is owned by Homer
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-1"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+		Expect(result[0][1]).To(Equal(peopleNamespacePrefix + ":Friend"))
+		Expect(result[0][2].(*Entity).ID).To(Equal(peopleNamespacePrefix + ":person-2"))
+
+		// inverse query from person-3 should not return anything because person-1 (which owns the relation) is deleted
+		result, err = store.GetManyRelatedEntities(
+			[]string{"http://data.mimiro.io/people/person-3"},
+			peopleNamespacePrefix+":Friend",
+			true,
+			nil,
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(0))
+	})
+
+	ginkgo.It("Should build query results", func() {
+		// create dataset
+		ds, _ := dsm.CreateDataset("people", nil)
+
+		batchSize := 5
+		entities := make([]*Entity, batchSize)
+
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/model/",
+		)
+		rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+			entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+			entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
+			entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+			entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+			entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+			entities[i] = entity
+		}
+
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		results, err := store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(results)).To(Equal(1))
+
+		invresults, err := store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(invresults)).To(Equal(5))
+
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", "*", true, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(invresults)).To(Equal(5))
+
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+			entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+			entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+			entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+			entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+			entities[i] = entity
+		}
+
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		time0 := time.Now().UnixNano()
+
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(invresults)).To(Equal(0))
+
+		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(results)).To(Equal(0))
+
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+			entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+			entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
+			entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+			entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+			entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+			entities[i] = entity
+		}
+
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(invresults)).To(Equal(5))
+
+		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(results)).To(Equal(1))
+
+		// test at point in time
+		from, _ := store.ToRelatedFrom(
+			[]string{"http://data.mimiro.io/people/p-1"},
+			RdfTypeURI,
+			false,
+			nil,
+			time0,
+		)
+		results2, _, err := store.GetRelatedAtTime(from[0], 0)
+		Expect(err).To(BeNil())
+		Expect(len(results2)).To(Equal(0))
+
+		from, _ = store.ToRelatedFrom(
+			[]string{"http://data.mimiro.io/model/Person"},
+			RdfTypeURI,
+			true,
+			nil,
+			time0,
+		)
+		invresults2, _, err := store.GetRelatedAtTime(from[0], 0)
+		Expect(err).To(BeNil())
+		Expect(len(invresults2)).To(Equal(0))
+	})
+})
+
+var _ = ginkgo.Describe("The dataset storage", func() {
+	testCnt := 0
+	var dsm *DsManager
+	var store *Store
+	var storeLocation string
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_store_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(ginkgo.GinkgoT(), false))
+		store = NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = NewDsManager(lc, e, store, NoOpBus())
+
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
+	})
+	ginkgo.AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+
+	ginkgo.It("Should store the curi id mapping", func() {
+		cache := make(map[string]uint64)
+		id, _, _ := dsm.store.assertIDForURI("ns0:gra", cache)
+		err := dsm.store.commitIDTxn()
+		Expect(err).To(BeNil())
+		curi, _ := dsm.store.getURIForID(id)
+		Expect(curi).To(Equal("ns0:gra"))
+	})
+
+	ginkgo.It("Should store entity batches without error", func() {
+		// create dataset
+		ds, _ := dsm.CreateDataset("people", nil)
+
+		entities := make([]*Entity, 1)
+		entity := NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["Name"] = "homer"
+		entity.References["type"] = "http://data.mimiro.io/model/Person"
+		entity.References["typed"] = "http://data.mimiro.io/model/Person"
+		entities[0] = entity
+
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "Expected no error when storing entity")
+	})
+
+	ginkgo.It("Should replace entity namespace prefixes", func() {
+		// define store context
+		_, _ = store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+		prefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion("http://data.mimiro.io/model/Person/")
+
+		entity := NewEntity(prefix+":homer", 0)
+		entity.Properties[prefix+":Name"] = "homer"
+		entity.References[prefix+":type"] = "ns1:Person"
+		entity.References[prefix+":company"] = "ns1:Person"
+
+		Expect(entity.ID).To(Equal(prefix + ":homer"))
+		err := entity.ExpandIdentifiers(store)
+		Expect(err).To(BeNil())
+		Expect(entity.ID).To(Equal("http://data.mimiro.io/model/Person/homer"))
+	})
+
+	ginkgo.It("Should make entities retrievable", func() {
+		// create dataset
+		ds, _ := dsm.CreateDataset("people", nil)
+
+		entities := make([]*Entity, 1)
+		entity := NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["Name"] = "homer"
+		entity.References["type"] = "http://data.mimiro.io/model/Person"
+		entity.References["typed"] = "http://data.mimiro.io/model/Person"
+		entities[0] = entity
+
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		allEntities := make([]*Entity, 0)
+		_, err = ds.MapEntities("", 0, func(e *Entity) error {
+			allEntities = append(allEntities, e)
+			return nil
+		})
+		Expect(err).To(BeNil())
+		Expect(len(allEntities)).To(Equal(1), "Expected to retrieve same number of entities as was written")
+	})
+
+	ginkgo.It("Should only update entities if they are different (batch)", func() {
+		// create dataset
+		ds, _ := dsm.CreateDataset("people", nil)
+
+		entities := make([]*Entity, 1)
+		entity := NewEntity("http://data.mimiro.io/people/homer", 0)
+		entity.Properties["Name"] = "homer"
+		entity.References["type"] = "http://data.mimiro.io/model/Person"
+		entity.References["typed"] = "http://data.mimiro.io/model/Person"
+		entities[0] = entity
+
+		// 1. store entity
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+		// and get first versions of object
+		res, err := ds.GetEntities("", 1)
+		Expect(err).To(BeNil())
+		firstVersionTS := res.Entities[0].Recorded
+
+		// 2. store again
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+		// and get version again
+		res, _ = ds.GetEntities("", 1)
+		Expect(res.Entities[0].Recorded).To(Equal(firstVersionTS), "Should be unchanged version")
+
+		// 3. set same name and store again
+		entity.Properties["Name"] = "homer"
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+		// and get version again
+		res, _ = ds.GetEntities("", 1)
+		Expect(res.Entities[0].Recorded).To(Equal(firstVersionTS), "Should be unchanged version")
+
+		// 4. now set a new name and store
+		entity.Properties["Name"] = "homer simpson"
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+		// version should change
+		res, _ = ds.GetEntities("", 1)
+		Expect(res.Entities[0].Recorded != firstVersionTS).To(BeTrue(), "Should be new version")
+	})
+
+	ginkgo.It("Should track changes", func() {
+		// create dataset
+		_, _ = dsm.CreateDataset("companies", nil)
+		_, _ = dsm.CreateDataset("animals", nil)
+		ds, err := dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+
+		entities := make([]*Entity, 3)
+		entity1 := NewEntity("http://data.mimiro.io/people/homer", 0)
+		entities[0] = entity1
+		entity2 := NewEntity("http://data.mimiro.io/people/bob", 0)
+		entities[1] = entity2
+		entity3 := NewEntity("http://data.mimiro.io/people/jim", 0)
+		entities[2] = entity3
+
+		_ = ds.StoreEntities(entities)
+
+		_ = dsm.DeleteDataset("people")
+		ds, _ = dsm.CreateDataset("people", nil)
+
+		entities = make([]*Entity, 3)
+		entity1 = NewEntity("http://data.mimiro.io/people/homer", 0)
+		entities[0] = entity1
+		entity2 = NewEntity("http://data.mimiro.io/people/bob", 0)
+		entities[1] = entity2
+		entity3 = NewEntity("http://data.mimiro.io/people/jim", 0)
+		entities[2] = entity3
+
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		// get changes
+		changes, err := ds.GetChanges(0, 10, false)
+		Expect(err).To(BeNil())
+		Expect(len(changes.Entities)).To(Equal(3))
+		Expect(changes.NextToken).To(Equal(uint64(3)))
+
+		changes, err = ds.GetChanges(1, 1, false)
+		Expect(err).To(BeNil())
+		Expect(len(changes.Entities)).To(Equal(1))
+		Expect(changes.NextToken).To(Equal(uint64(2)))
+
+		changes, err = ds.GetChanges(2, 1, false)
+		Expect(err).To(BeNil())
+		Expect(len(changes.Entities)).To(Equal(1))
+		Expect(changes.NextToken).To(Equal(uint64(3)))
+
+		changes, _ = ds.GetChanges(3, 10, false)
+		Expect(len(changes.Entities)).To(Equal(0))
+		Expect(changes.NextToken).To(Equal(uint64(3)))
+
+		// store modified entities again and then get changes latest true
+		entity1.Properties = map[string]interface{}{"http://test.org/name": "homer"}
+		ds.StoreEntities(entities)
+
+		changes, _ = ds.GetChanges(0, 0, true)
+		Expect(len(changes.Entities)).To(Equal(3))
+		Expect(changes.NextToken).To(Equal(uint64(4)))
+	})
+
+	ginkgo.It("Should paginate entities with continuation tokens", func() {
+		// create dataset
+		c, _ := dsm.CreateDataset("companies", nil)
+		_, _ = dsm.CreateDataset("animals", nil)
+		dsm.CreateDataset("people", nil)
+
+		_ = dsm.DeleteDataset("people")
+		ds, _ := dsm.CreateDataset("people", nil)
+
+		entities := make([]*Entity, 3)
+		entity1 := NewEntity("http://data.mimiro.io/people/homer", 0)
+		entities[0] = entity1
+		entity2 := NewEntity("http://data.mimiro.io/people/bob", 0)
+		entities[1] = entity2
+		entity3 := NewEntity("http://data.mimiro.io/people/jim", 0)
+		entities[2] = entity3
+
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+		// store same entitites in two datasets. should give merged results
+		err = c.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		result, err := ds.GetEntities("", 50)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(3), "Expected all 3 entitites back")
+
+		result1, err := ds.GetEntities(result.ContinuationToken, 1)
+		Expect(err).To(BeNil())
+		Expect(len(result1.Entities)).To(Equal(0), "first page should have returned all entities, "+
+			"therefore this page should be empty")
+		Expect(result1.ContinuationToken).To(Equal(result.ContinuationToken))
+
+		// test c token
+		result, err = ds.GetEntities("", 1)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(1), "we only asked for 1 entitiy this page")
+
+		result, err = ds.GetEntities(result.ContinuationToken, 5)
+		Expect(err).To(BeNil())
+		Expect(len(result.Entities)).To(Equal(2), "second page should have remaining 2 enitities")
+
+		Expect(result.Entities[0].ID).To(Equal("http://data.mimiro.io/people/bob"), "first result 2nd page is not bob")
+	})
+
+	ginkgo.It("Should not struggle with many batch writes", func(_ ginkgo.SpecContext) {
+		// create dataset
+		ds1, err := dsm.CreateDataset("people0", nil)
+		ds2, err := dsm.CreateDataset("people1", nil)
+		ds3, err := dsm.CreateDataset("people2", nil)
+		ds4, err := dsm.CreateDataset("people3", nil)
+		ds5, err := dsm.CreateDataset("people4", nil)
+
+		batchSize := 1000
+		iterationSize := 100
+
+		f := func(ds *Dataset, prefix string, wg *sync.WaitGroup) {
+			idcounter := uint64(0)
+			for j := 0; j < iterationSize; j++ {
+				entities := make([]*Entity, batchSize)
+				for i := 0; i < batchSize; i++ {
+					entity := NewEntity(prefix+strconv.Itoa(i), idcounter)
+					entity.Properties[prefix+":Name"] = "homer"
+					entity.References[prefix+":type"] = prefix + "/Person"
+					entity.References[prefix+":f1"] = prefix + "/Person-1"
+					entity.References[prefix+":f2"] = prefix + "/Person-2"
+					entity.References[prefix+":f3"] = prefix + "/Person-3"
+
+					entities[i] = entity
+					idcounter++
+				}
+				err = ds.StoreEntities(entities)
+				Expect(err).To(BeNil(), "Storing should never fail under load")
+			}
+			wg.Done()
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(5)
+
+		go f(ds1, "http://data.mimiro.io/people/p1-", &wg)
+		go f(ds2, "http://data.mimiro.io/people/p1-", &wg)
+		go f(ds3, "http://data.mimiro.io/people/p1-", &wg)
+		go f(ds4, "http://data.mimiro.io/people/p1-", &wg)
+		go f(ds5, "http://data.mimiro.io/people/p1-", &wg)
+
+		wg.Wait()
+	}, ginkgo.SpecTimeout(5*time.Minute))
+
+	ginkgo.It("Should do deletion detection when running in fullsync mode", func() {
+		// create dataset
+		ds, err := dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+		batchSize := 5
+
+		err = ds.StartFullSync()
+		Expect(err).To(BeNil())
+
+		entities := make([]*Entity, batchSize)
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
 			entity.Properties["Name"] = "homer"
-			entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
-			entity.References["rdf:place"] = "http://data.mimiro.io/places/place1"
-			entities[0] = entity
+			entities[i] = entity
+		}
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
 
-			entities1 := make([]*Entity, 1)
-			entity1 := NewEntity("http://data.mimiro.io/places/place1", 0)
-			entity1.Properties["Name"] = "home"
-			entity1.References["rdf:type"] = "http://data.mimiro.io/model/Place"
-			entities1[0] = entity1
+		err = ds.CompleteFullSync()
+		Expect(err).To(BeNil())
 
-			txn := &Transaction{}
-			txn.DatasetEntities = make(map[string][]*Entity)
-			txn.DatasetEntities["people"] = entities
-			txn.DatasetEntities["places"] = entities1
+		// start 2nd fullsync
+		err = ds.StartFullSync()
+		Expect(err).To(BeNil())
 
-			err = store.ExecuteTransaction(txn)
-			g.Assert(err).IsNil()
+		entities = make([]*Entity, 1)
+		entity := NewEntity("http://data.mimiro.io/people/p-0", 0)
+		entity.Properties["Name"] = "homer"
+		entities[0] = entity
+		// entities[0] = res.Entities[0]
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
 
-			people := dsm.GetDataset("people")
-			peopleEntities, _ := people.GetEntities("", 100)
-			g.Assert(len(peopleEntities.Entities)).Eql(6)
+		err = ds.CompleteFullSync()
+		Expect(err).To(BeNil())
+
+		allEntities := make([]*Entity, 0)
+		deletedEntities := make([]*Entity, 0)
+		_, err = ds.MapEntities("", 0, func(e *Entity) error {
+			if !e.IsDeleted {
+				allEntities = append(allEntities, e)
+			} else {
+				deletedEntities = append(deletedEntities, e)
+			}
+			return nil
 		})
+		Expect(err).To(BeNil(), "MapEntities should have worked")
+		Expect(len(allEntities)).To(Equal(1), "There should be one undeleted entity left")
+		Expect(len(deletedEntities)).To(Equal(batchSize-1), "all other entities should be deleted")
+	})
 
-		g.It("should find deleted version of entity with lookup", func() {
-			peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
-				"http://data.mimiro.io/people/",
-			)
+	ginkgo.It("Should enable iterating over a dataset (MapEntitites)", func() {
+		// create dataset
+		ds, err := dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+		batchSize := 5
 
-			// create dataset
-			ds, err := dsm.CreateDataset("people", nil)
-			g.Assert(err).IsNil()
+		entities := make([]*Entity, batchSize)
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
+			entity.Properties["Name"] = "homer"
+			entities[i] = entity
+		}
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
 
-			entities := make([]*Entity, 1)
-			entity := NewEntity(peopleNamespacePrefix+":p1", 0)
+		var entity *Entity
+		ctoken, _ := ds.MapEntities("", 1, func(e *Entity) error {
+			entity = e
+			return nil
+		})
+		Expect(entities).NotTo(BeZero(), "MapEntities should have processed 1 entity")
+		Expect(ctoken).NotTo(BeZero(), "MapEntities should have given us a token")
+
+		var nextEntity *Entity
+		newtoken, _ := ds.MapEntities(ctoken, 1, func(e *Entity) error {
+			nextEntity = e
+			return nil
+		})
+		Expect(nextEntity).NotTo(BeZero(), "MapEntities should have processed 1 entity again")
+		Expect(newtoken).NotTo(BeZero(), "MapEntities should have given us a new token")
+		Expect(nextEntity.ID != entity.ID).To(BeTrue(), "We should have a different entity")
+		Expect(ctoken != newtoken).To(BeTrue(), "We should have a different token")
+	})
+
+	ginkgo.Describe(
+		"When retrieving data, it can combine multiple entities from different datasets with the same ID",
+		func() {
+			ginkgo.It("Should merge entity data from different entities with same id (partials)", func() {
+				e1 := NewEntity("x:e1", 0)
+				e2 := NewEntity("x:e1", 0)
+				partials := make([]*Entity, 2)
+				partials[0] = e1
+				partials[1] = e2
+				result := store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(BeNil())
+
+				e2.Properties["x:name"] = "homer"
+				result = store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(Equal("homer"))
+			})
+
+			ginkgo.It("Should merge partials without error if a source is empty", func() {
+				e1 := NewEntity("x:e1", 0)
+				e2 := NewEntity("x:e1", 0)
+				partials := make([]*Entity, 2)
+				partials[0] = e1
+				partials[1] = e2
+
+				e1.Properties["x:name"] = "homer"
+
+				result := store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(Equal("homer"))
+			})
+
+			ginkgo.It("Should merge partials if target entity is empty", func() {
+				e1 := NewEntity("x:e1", 0)
+				e2 := NewEntity("x:e1", 0)
+				partials := make([]*Entity, 2)
+				partials[0] = e1
+				partials[1] = e2
+
+				e2.Properties["x:name"] = "homer"
+
+				result := store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(Equal("homer"))
+			})
+
+			ginkgo.It("Should merge single values from 2 partials to a list value", func() {
+				e1 := NewEntity("x:e1", 0)
+				e2 := NewEntity("x:e1", 0)
+				partials := make([]*Entity, 2)
+				partials[0] = e1
+				partials[1] = e2
+
+				e1.Properties["x:name"] = "homer"
+				e2.Properties["x:name"] = "bob"
+
+				result := store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(Equal([]interface{}{"homer", "bob"}))
+			})
+
+			ginkgo.It("Should add single values to existing list when merging partials", func() {
+				e1 := NewEntity("x:e1", 0)
+				e2 := NewEntity("x:e1", 0)
+				partials := make([]*Entity, 2)
+				partials[0] = e1
+				partials[1] = e2
+
+				names := make([]interface{}, 0)
+				names = append(names, "homer")
+				names = append(names, "brian")
+				e1.Properties["x:name"] = names
+				e2.Properties["x:name"] = "bob"
+
+				result := store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(Equal([]interface{}{"homer", "brian", "bob"}))
+			})
+
+			ginkgo.It("Should add list to existing single value when merging partials", func() {
+				e1 := NewEntity("x:e1", 0)
+				e2 := NewEntity("x:e1", 0)
+				partials := make([]*Entity, 2)
+				partials[0] = e1
+				partials[1] = e2
+
+				names := make([]interface{}, 0)
+				names = append(names, "homer")
+				names = append(names, "brian")
+				e1.Properties["x:name"] = "bob"
+				e2.Properties["x:name"] = names
+
+				result := store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(Equal([]interface{}{"bob", "homer", "brian"}))
+			})
+
+			ginkgo.It("Should combine two value lists when merging partials", func() {
+				e1 := NewEntity("x:e1", 0)
+				e2 := NewEntity("x:e1", 0)
+				partials := make([]*Entity, 2)
+				partials[0] = e1
+				partials[1] = e2
+
+				names := make([]interface{}, 0)
+				names = append(names, "homer")
+				names = append(names, "brian")
+				e1.Properties["x:name"] = names
+
+				names1 := make([]interface{}, 0)
+				names1 = append(names1, "bob")
+				names1 = append(names1, "james")
+
+				e2.Properties["x:name"] = names1
+
+				result := store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(Equal([]interface{}{"homer", "brian", "bob", "james"}))
+			})
+
+			ginkgo.It("Should merge 3 partials", func() {
+				e1 := NewEntity("x:e1", 0)
+				e2 := NewEntity("x:e1", 0)
+				e3 := NewEntity("x:e1", 0)
+				partials := make([]*Entity, 3)
+				partials[0] = e1
+				partials[1] = e2
+				partials[2] = e3
+
+				e1.Properties["x:name"] = "bob"
+
+				e2.Properties["x:name"] = "brian"
+				e2.Properties["x:dob"] = "01-01-2001"
+
+				e3.Properties["x:name"] = "james"
+
+				partials = make([]*Entity, 3)
+				partials[0] = e1
+				partials[1] = e2
+				partials[2] = e3
+
+				result := store.MergePartials(partials)
+				Expect(result).NotTo(BeZero())
+				Expect(result.ID).To(Equal("x:e1"))
+				Expect(result.Properties["x:name"]).To(Equal([]interface{}{"bob", "brian", "james"}))
+				Expect(result.Properties["x:dob"]).To(Equal("01-01-2001"))
+			})
+		},
+	)
+
+	ginkgo.It("Should build query results", func() {
+		// create dataset
+		ds, _ := dsm.CreateDataset("people", nil)
+
+		batchSize := 5
+		entities := make([]*Entity, batchSize)
+
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/model/",
+		)
+		rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+			entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+			entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
+			entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+			entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+			entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+			entities[i] = entity
+		}
+
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		results, err := store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(results)).To(Equal(1))
+
+		invresults, err := store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(invresults)).To(Equal(5))
+
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", "*", true, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(invresults)).To(Equal(5))
+
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+			entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+			entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+			entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+			entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+			entities[i] = entity
+		}
+
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(invresults)).To(Equal(0))
+
+		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(results)).To(Equal(0))
+
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity(peopleNamespacePrefix+":p-"+strconv.Itoa(i), 0)
+			entity.Properties[modelNamespacePrefix+":Name"] = "homer"
+			entity.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
+			entity.References[modelNamespacePrefix+":f1"] = peopleNamespacePrefix + ":Person-1"
+			entity.References[modelNamespacePrefix+":f2"] = peopleNamespacePrefix + ":Person-2"
+			entity.References[modelNamespacePrefix+":f3"] = peopleNamespacePrefix + ":Person-3"
+			entities[i] = entity
+		}
+
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(invresults)).To(Equal(5))
+
+		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		Expect(err).To(BeNil())
+		Expect(len(results)).To(Equal(1))
+	})
+
+	ginkgo.It("Should perform batch updates without error with concurrent requests", func() {
+		// create dataset
+		ds, err := dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+
+		batchSize := 5000
+		entities := make([]*Entity, batchSize)
+
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
 			entity.Properties["Name"] = "homer"
 			entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
 			entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
 			entity.References["rdf:f2"] = "http://data.mimiro.io/people/Person-2"
 			entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
-			entities[0] = entity
+			entities[i] = entity
+		}
 
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil("StoreEntities failed unexpectedly")
-
-			// get entity
-			e, err := store.GetEntity(peopleNamespacePrefix+":p1", nil)
-			g.Assert(err).IsNil("GetEntity failed unexpectedly")
-			g.Assert(e.IsDeleted).IsFalse()
-
-			entities = make([]*Entity, 1)
-			entity = NewEntity(peopleNamespacePrefix+":p1", 0)
-			entity.IsDeleted = true
-			entities[0] = entity
-
-			err = ds.StoreEntities(entities)
-			g.Assert(err).IsNil("StoreEntities failed unexpectedly")
-
-			e, _ = store.GetEntity("http://data.mimiro.io/people/p1", nil)
-			g.Assert(e.IsDeleted).IsTrue()
-		})
+		var wg sync.WaitGroup
+		for i := 1; i <= 10; i++ {
+			wg.Add(1)
+			go func() {
+				err := ds.StoreEntities(entities)
+				Expect(err).To(BeNil(), "StoreEntities failed unexpectedly")
+				defer wg.Done()
+			}()
+		}
+		wg.Wait()
 	})
-}
+
+	ginkgo.It("Should store and replace large batches without error", func() {
+		// create dataset
+		ds, _ := dsm.CreateDataset("people", nil)
+
+		batchSize := 5000
+		entities := make([]*Entity, batchSize)
+
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
+			entity.Properties["Name"] = "homer"
+
+			entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
+			entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
+			entity.References["rdf:f2"] = "http://data.mimiro.io/people/Person-2"
+			entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
+
+			entities[i] = entity
+		}
+		err := ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+
+		// replace
+		for i := 0; i < batchSize; i++ {
+			entity := NewEntity("http://data.mimiro.io/people/p-"+strconv.Itoa(i), 0)
+			entity.Properties["Name"] = "homer"
+
+			entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
+			entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
+			//		refs["rdf:f2"] = "http://data.mimiro.io/people/Person-2"
+			entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
+
+			entities[i] = entity
+		}
+
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil())
+		/*allEntities := make([]*Entity, 0)
+		ds.GetEntities(func(e *Entity) {
+			allEntities = append(allEntities, e)
+		})
+
+		if len(allEntities) != batchSize {
+			t.Fail()
+		} */
+		// replace again
+		/* for i := 0; i < batchSize; i++ {
+		   	entity := NewEntity("http://data.mimiro.io/people/p-" + strconv.Itoa(i), 0)
+		   	entity.Properties["Name"] = "homer"
+
+		   	entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
+		   	entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
+		   	entity.References["rdf:f2"] = "http://data.mimiro.io/people/Person-6"
+		   	entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
+
+		   	entities[i] = entity
+		   }
+
+		   ds.StoreEntities(entities) */
+	})
+
+	ginkgo.It("Should build correct query results with large number of entities", func() {
+		// namespaces
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		companyNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/company/",
+		)
+		modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/model/",
+		)
+		rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+
+		// create dataset
+		peopleDataset, _ := dsm.CreateDataset("people", nil)
+		companiesDataset, _ := dsm.CreateDataset("companies", nil)
+
+		numOfCompanies := 10
+		numOfEmployees := 1000
+		companies := make([]*Entity, 0)
+		people := make([]*Entity, 0)
+		queryIds := make([]string, 0)
+		empID := 0
+
+		for i := 0; i < numOfCompanies; i++ {
+
+			c := NewEntity(companyNamespacePrefix+":company-"+strconv.Itoa(i), 0)
+			c.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Company"
+
+			for j := 0; j < numOfEmployees; j++ {
+				person := NewEntity(peopleNamespacePrefix+":person-"+strconv.Itoa(empID), 0)
+				person.Properties[peopleNamespacePrefix+":Name"] = "person " + strconv.Itoa(i)
+				person.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
+				person.References[peopleNamespacePrefix+":worksfor"] = companyNamespacePrefix + ":company-" + strconv.Itoa(
+					i,
+				)
+				people = append(people, person)
+
+				if empID < 100 {
+					queryIds = append(queryIds, "http://data.mimiro.io/people/person-"+strconv.Itoa(empID))
+				}
+
+				empID++
+			}
+
+			companies = append(companies, c)
+		}
+		err := companiesDataset.StoreEntities(companies)
+		Expect(err).To(BeNil())
+
+		err = peopleDataset.StoreEntities(people)
+		Expect(err).To(BeNil())
+		// query
+		result, err := store.GetManyRelatedEntities(
+			queryIds,
+			"http://data.mimiro.io/people/worksfor",
+			false,
+			[]string{},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(100))
+
+		// check inverse
+		queryIds = make([]string, 0)
+		queryIds = append(queryIds, "http://data.mimiro.io/company/company-1")
+		queryIds = append(queryIds, "http://data.mimiro.io/company/company-2")
+		result, err = store.GetManyRelatedEntities(
+			queryIds,
+			"http://data.mimiro.io/people/worksfor",
+			true,
+			[]string{},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(numOfEmployees * 2))
+	})
+
+	ginkgo.It("Should return entity placeholders (links) in queries", func() {
+		// namespaces
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		companyNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/company/",
+		)
+		modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/model/",
+		)
+		rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+
+		// create dataset
+		peopleDataset, _ := dsm.CreateDataset("people", nil)
+		// 	companiesDataset, err := dsm.CreateDataset("companies")
+
+		people := make([]*Entity, 0)
+		queryIds := make([]string, 0)
+
+		person := NewEntity(peopleNamespacePrefix+":person-"+strconv.Itoa(1), 0)
+		person.Properties[peopleNamespacePrefix+":Name"] = "person " + strconv.Itoa(2)
+		person.References[rdfNamespacePrefix+":type"] = modelNamespacePrefix + ":Person"
+		person.References[peopleNamespacePrefix+":worksfor"] = companyNamespacePrefix + ":company-3"
+		people = append(people, person)
+
+		err := peopleDataset.StoreEntities(people)
+		Expect(err).To(BeNil())
+
+		queryIds = append(queryIds, "http://data.mimiro.io/people/person-"+strconv.Itoa(1))
+		// query
+		result, err := store.GetManyRelatedEntities(
+			queryIds,
+			"http://data.mimiro.io/people/worksfor",
+			false,
+			[]string{},
+		)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(1))
+	})
+})
+
+var _ = ginkgo.Describe("Scoped storage functions", func() {
+	testCnt := 0
+	var dsm *DsManager
+	var store *Store
+	var storeLocation string
+	var peopleNamespacePrefix string
+	var companyNamespacePrefix string
+	const PEOPLE = "people"
+	const COMPANIES = "companies"
+	const HISTORY = "history"
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_store_dsscope_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		lc := fxtest.NewLifecycle(internal.FxTestLog(ginkgo.GinkgoT(), false))
+		store = NewStore(lc, e, &statsd.NoOpClient{})
+		dsm = NewDsManager(lc, e, store, NoOpBus())
+
+		err = lc.Start(context.Background())
+		Expect(err).To(BeNil())
+
+		// namespaces
+		peopleNamespacePrefix, _ = store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+		companyNamespacePrefix, _ = store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/company/",
+		)
+		modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/model/",
+		)
+		rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+		// create dataset
+		peopleDataset, _ := dsm.CreateDataset(PEOPLE, nil)
+		companiesDataset, _ := dsm.CreateDataset(COMPANIES, nil)
+		employmentHistoryDataset, _ := dsm.CreateDataset(HISTORY, nil)
+
+		/* Install the following setup
+		{person: 1, workhistory: []int{}, currentwork: 1},
+		{person: 2, workhistory: []int{1}, currentwork: 2},
+		{person: 3, workhistory: []int{2}, currentwork: 1},
+		{person: 4, workhistory: []int{1, 2}, currentwork: 3},
+		{person: 5, workhistory: []int{3}, currentwork: 1},
+		*/
+		//insert companies
+		for _, companyID := range []int{1, 2, 3} {
+			cid := companyNamespacePrefix + ":company-" + strconv.Itoa(companyID)
+			_ = companiesDataset.StoreEntities([]*Entity{NewEntityFromMap(map[string]interface{}{
+				"id": cid,
+				"props": map[string]interface{}{
+					companyNamespacePrefix + ":Name": "Company " + strconv.Itoa(companyID),
+				},
+				"refs": map[string]interface{}{rdfNamespacePrefix + ":type": modelNamespacePrefix + ":Company"},
+			})})
+		}
+
+		// insert people with worksfor relations
+		currentWork := []int{1, 2, 1, 3, 1}
+		for personID, workID := range currentWork {
+			pid := peopleNamespacePrefix + ":person-" + strconv.Itoa(personID+1)
+			_ = peopleDataset.StoreEntities([]*Entity{NewEntityFromMap(map[string]interface{}{
+				"id": pid,
+				"props": map[string]interface{}{
+					peopleNamespacePrefix + ":Name": "Person " + strconv.Itoa(personID+1),
+				},
+				"refs": map[string]interface{}{
+					rdfNamespacePrefix + ":type": modelNamespacePrefix + ":Person",
+					peopleNamespacePrefix + ":worksfor": companyNamespacePrefix + ":company-" + strconv.Itoa(
+						workID,
+					),
+				},
+			})})
+		}
+
+		// insert workHistory
+		for personID, workHistIds := range [][]int{{}, {1}, {2}, {1, 2}, {3}} {
+			var workHistory []string
+			for _, histID := range workHistIds {
+				workHistory = append(workHistory, companyNamespacePrefix+":company-"+strconv.Itoa(histID))
+			}
+			pid := peopleNamespacePrefix + ":person-" + strconv.Itoa(personID+1)
+			entity := NewEntityFromMap(map[string]interface{}{
+				"id":    pid,
+				"props": map[string]interface{}{},
+				"refs": map[string]interface{}{
+					rdfNamespacePrefix + ":type":        modelNamespacePrefix + ":Employment",
+					peopleNamespacePrefix + ":Employee": strconv.Itoa(personID + 1),
+					peopleNamespacePrefix + ":worksfor": companyNamespacePrefix + ":company-" + strconv.Itoa(
+						currentWork[personID],
+					),
+					peopleNamespacePrefix + ":workedfor": workHistory,
+				},
+			})
+			_ = employmentHistoryDataset.StoreEntities([]*Entity{entity})
+		}
+	})
+	ginkgo.AfterEach(func() {
+		dsm.DeleteDataset(PEOPLE)
+		dsm.DeleteDataset(COMPANIES)
+		dsm.DeleteDataset(HISTORY)
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
+
+	ginkgo.It("Should return all of an entity's relations when no dataset constraints are applied", func() {
+		result, _ := store.GetManyRelatedEntities(
+			[]string{peopleNamespacePrefix + ":person-1"},
+			"http://data.mimiro.io/people/worksfor",
+			false,
+			[]string{},
+		)
+		Expect(len(result)).
+			To(Equal(1), "expected 1 relation to be found. both the people and workhistory datasets point to the same company.")
+
+		entity := findEntity(result, "ns4:company-1")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.ID).To(Equal("ns4:company-1"), "first relation ID should be found")
+		Expect(entity.Properties["ns4:Name"]).To(Equal("Company 1"), "first relation property should be resolved")
+	})
+
+	ginkgo.It("Should return only relation ID if access to relation dataset is not given", func() {
+		// constraint on "people" only. we should find the relation to a company in "people",
+		// but resolving the company should be omitted because we lack access to the "companies" dataset
+		result, _ := store.GetManyRelatedEntities(
+			[]string{peopleNamespacePrefix + ":person-1"},
+			"http://data.mimiro.io/people/worksfor",
+			false,
+			[]string{PEOPLE},
+		)
+		Expect(len(result)).To(Equal(1), "expected 1 relation to be found in people dataset (not in workHistory)")
+
+		entity := findEntity(result, "ns4:company-1")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.ID).To(Equal("ns4:company-1"), "first relation ID should be found")
+		Expect(entity.Properties["ns4:Name"]).To(BeNil(), "first relation property should NOT be resolved")
+	})
+
+	ginkgo.It("Should not find outgoing relations if the datasets owning these relations are disallowed", func() {
+		// constraint on "companies". we cannot access outgoing refs in the "people" or "history" datasets, therefore we should not find anything
+		result, _ := store.GetManyRelatedEntities(
+			[]string{peopleNamespacePrefix + ":person-1"},
+			"http://data.mimiro.io/people/worksfor",
+			false,
+			[]string{COMPANIES},
+		)
+		Expect(len(result)).To(Equal(0), "expected 0 relation to be found (people and history are excluded)")
+	})
+
+	ginkgo.It("Should treat a list of (all) unknown datasets like an empty scope list", func() {
+		// constraint on bogus dataset. due to implementation, this dataset filter will be ignored, query behaves as unrestricted
+		// TODO: this can be discussed. Producing an error would make Queries less unpredictable. But ignoring invalid input makes the API more approachable
+		result, _ := store.GetManyRelatedEntities(
+			[]string{peopleNamespacePrefix + ":person-1"},
+			"http://data.mimiro.io/people/worksfor",
+			false,
+			[]string{"bogus"},
+		)
+		Expect(len(result)).To(Equal(1), "expected 1 relation (company-1)")
+
+		entity := findEntity(result, "ns4:company-1")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.ID).To(Equal("ns4:company-1"), "first relation ID should be found")
+		Expect(entity.Properties["ns4:Name"]).To(Equal("Company 1"), "first relation property should be resolved")
+	})
+
+	ginkgo.It("Should find relations in secondary datasets if main dataset is disallowed", func() {
+		// constraint on history dataset. we should find an outgoing relation from history to a company,
+		// but company resolving should be disabled since we lack access to the companies dataset
+		result, _ := store.GetManyRelatedEntities(
+			[]string{peopleNamespacePrefix + ":person-1"},
+			"http://data.mimiro.io/people/worksfor",
+			false,
+			[]string{HISTORY},
+		)
+		Expect(len(result)).To(Equal(1), "expected 1 relation to be found in people dataset (not in workHistory)")
+
+		entity := findEntity(result, "ns4:company-1")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.ID).To(Equal("ns4:company-1"), "first relation ID should be found")
+		Expect(entity.Properties["ns4:Name"]).To(BeNil(), "first relation property should NOT be resolved")
+	})
+
+	ginkgo.It("Should return all incoming relations of an entity in inverse query, when no scope is given", func() {
+		// inverse query for "company-1", no datasets restriction. should find 3 people with resolved entities
+		result, _ := store.GetManyRelatedEntities(
+			[]string{companyNamespacePrefix + ":company-1"},
+			"http://data.mimiro.io/people/worksfor",
+			true,
+			[]string{},
+		)
+		Expect(len(result)).
+			To(Equal(3), "there are 6 relations, 3 in dataset people and 3 owned by history. all relations come from total of 3 people")
+		entity := findEntity(result, "ns3:person-5")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.Properties["ns3:Name"]).To(Equal("Person 5"), "first relation property should be resolved")
+		Expect(len(entity.References)).To(Equal(4))
+		// verify that history entity has been merged in by checking for "workedfor"
+		Expect(entity.References["ns3:workedfor"].([]interface{})[0]).To(Equal("ns4:company-3"),
+			"inverse query should find company-3 in history following 'worksfor' to person-5's employment enity")
+		// verify that worksfor is duplicated - since the relation is merged together from people and history
+		Expect(entity.References["ns3:worksfor"]).To(Equal([]interface{}{"ns4:company-1", "ns4:company-1"}))
+	})
+
+	ginkgo.It("Should omit disallowed datasets when resolving found entities", func() {
+		// inverse query for "company-1" with only "people" accessible.
+		// should still find 3 people (incoming relation is owned by people dataset, which we have access to)
+		// people should be resolved
+		// but resolved relations in people should only be "people" data with no "history" refs merged in
+		result, _ := store.GetManyRelatedEntities(
+			[]string{companyNamespacePrefix + ":company-1"},
+			"http://data.mimiro.io/people/worksfor",
+			true,
+			[]string{PEOPLE},
+		)
+		Expect(len(result)).To(Equal(3), "expected 3 relations to be found in people dataset (not in workHistory)")
+
+		entity := findEntity(result, "ns3:person-5")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.ID).To(Equal("ns3:person-5"), "first relation ID should be found")
+		Expect(entity.Properties["ns3:Name"]).To(Equal("Person 5"), "first relation property should be resolved")
+		// make sure we only have two refs returned (worksfor + type), confirming that history refs have not been accessed
+		Expect(len(entity.References)).To(Equal(2))
+	})
+
+	ginkgo.It("Should not return results if the relation-owning datasets are disallowed", func() {
+		// inverse query for "company-1" with restriction to "companies" dataset.
+		// all incoming relations are stored in either history or people dataset.
+		// with access limited to companies dataset, we should not find incoming relations
+		result, _ := store.GetManyRelatedEntities(
+			[]string{companyNamespacePrefix + ":company-1"},
+			"http://data.mimiro.io/people/worksfor",
+			true,
+			[]string{COMPANIES},
+		)
+		Expect(len(result)).To(Equal(0))
+	})
+
+	ginkgo.It("Should resolve all elements in relation arrays, when no scope restriction is given", func() {
+		// find person-4 and follow its workedfor relations without restriction
+		// should find 2 companies in "history" dataset, and fully resolve the company entities
+		result, _ := store.GetManyRelatedEntities(
+			[]string{peopleNamespacePrefix + ":person-4"},
+			"http://data.mimiro.io/people/workedfor",
+			false,
+			[]string{},
+		)
+		Expect(len(result)).To(Equal(2), "expected 2 relations to be found in history dataset")
+
+		entity := findEntity(result, "ns4:company-2")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.ID).To(Equal("ns4:company-2"), "first relation ID should be found")
+		Expect(entity.Properties["ns4:Name"]).To(Equal("Company 2"), "first relation property should be resolved")
+	})
+
+	ginkgo.It("Should find, but not resolve all relations in an array if relation dataset is disallowed", func() {
+		// find person-4 and follow its workedfor relations in dataset "history"
+		// should find 2 companies in "history" dataset,
+		// but not fully resolve the company entities because we lack access to "company"
+		result, _ := store.GetManyRelatedEntities(
+			[]string{peopleNamespacePrefix + ":person-4"},
+			"http://data.mimiro.io/people/workedfor",
+			false,
+			[]string{HISTORY},
+		)
+		Expect(len(result)).To(Equal(2), "expected 2 relations to be found in history dataset")
+
+		entity := findEntity(result, "ns4:company-2")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.ID).To(Equal("ns4:company-2"), "first relation ID should be found")
+		Expect(entity.Properties["ns4:Name"]).
+			To(BeNil(), "companies dataset is not accessible, therefor name should be nil")
+	})
+
+	ginkgo.It("Should inversely find all relations in an array", func() {
+		// find company-2 and inversely follow workedfor relations without restriction
+		// should find person 3 and 4 in "history" dataset, and fully resolve the person entities
+		result, _ := store.GetManyRelatedEntities(
+			[]string{companyNamespacePrefix + ":company-2"},
+			"http://data.mimiro.io/people/workedfor",
+			true,
+			[]string{},
+		)
+		Expect(len(result)).To(Equal(2), "expected 2 people to be found from history dataset")
+
+		entity := findEntity(result, "ns3:person-4")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity.ID).To(Equal("ns3:person-4"), "first relation ID should be found")
+		Expect(entity.Properties["ns3:Name"]).To(Equal("Person 4"), "first relation property should be resolved")
+		// There should be 4 references both from history and people
+		Expect(len(entity.References)).
+			To(Equal(4), "Expected 4 refs in inversly found person from people and history datasets")
+		// check that reference values are merged from all datasets. type should be list of type refs from both people and history
+		if reflect.DeepEqual(entity.References["ns2:type"], []string{"ns5:Person", "ns5:Employment"}) {
+			ginkgo.Fail(
+				fmt.Sprintf(
+					"Expected Person+Employment as type ref values, but found %v",
+					entity.References["ns2:type"],
+				),
+			)
+		}
+	})
+
+	ginkgo.It(
+		"Should inversely find all relations in array, but not resolve the relation-intities if no access",
+		func() {
+			// find company-2 and inversely follow workedfor relations with filter on history
+			// should find person 3 and 4 in "history" dataset, but not fully resolve the person entities
+			result, _ := store.GetManyRelatedEntities(
+				[]string{companyNamespacePrefix + ":company-2"},
+				"http://data.mimiro.io/people/workedfor",
+				true,
+				[]string{HISTORY},
+			)
+			Expect(len(result)).To(Equal(2), "expected 2 people to be found from history dataset")
+
+			entity := findEntity(result, "ns3:person-4")
+			Expect(entity).NotTo(BeNil())
+			Expect(entity.ID).To(Equal("ns3:person-4"), "first relation ID should be found")
+			Expect(
+				entity.Properties["ns3:Name"],
+			).To(BeNil(), "Person 4 should not be resolved since access to people is missing")
+			// There should be 4 references both from history and people
+			Expect(len(entity.References)).To(Equal(4), "Expected 4 refs in inversly found person from history dataset")
+			// check that reference values are merged from all datasets. type should be list of type refs from both people and history
+			Expect(entity.References["ns2:type"]).
+				To(Equal("ns5:Employment"), "Expected only Employment type, not Person type")
+		},
+	)
+
+	ginkgo.It("Should not inversly find array relations if relation-owning dataset is disallowed", func() {
+		// find company-2 and inversely follow workedfor relations with filter on people and companies
+		// should not find any relations since history access is not allowed, and workedfor is only stored there
+		result, _ := store.GetManyRelatedEntities(
+			[]string{companyNamespacePrefix + ":company-2"},
+			"http://data.mimiro.io/people/workedfor",
+			true,
+			[]string{PEOPLE, COMPANIES},
+		)
+		Expect(len(result)).To(Equal(0))
+	})
+
+	ginkgo.It("Should respect dataset scope in GetEntity (single lookup query)", func() {
+		// namespaces
+		employeeNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/employee/",
+		)
+		modelNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/model/",
+		)
+		rdfNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(RdfNamespaceExpansion)
+
+		// create dataset
+		const PEOPLE = "people"
+		peopleDataset, _ := dsm.CreateDataset(PEOPLE, nil)
+		const EMPLOYEES = "employees"
+		employeeDataset, _ := dsm.CreateDataset(EMPLOYEES, nil)
+
+		_ = peopleDataset.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Lisa"},
+				"refs": map[string]interface{}{
+					rdfNamespacePrefix + ":type":     modelNamespacePrefix + ":Person",
+					peopleNamespacePrefix + ":knows": peopleNamespacePrefix + "person-2",
+				},
+			}),
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-2",
+				"props": map[string]interface{}{peopleNamespacePrefix + ":Name": "Bob"},
+				"refs": map[string]interface{}{
+					rdfNamespacePrefix + ":type":     modelNamespacePrefix + ":Person",
+					peopleNamespacePrefix + ":knows": peopleNamespacePrefix + "person-1",
+				},
+			}),
+		})
+
+		_ = employeeDataset.StoreEntities([]*Entity{
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-1",
+				"props": map[string]interface{}{employeeNamespacePrefix + ":Title": "President"},
+				"refs": map[string]interface{}{
+					rdfNamespacePrefix + ":type": modelNamespacePrefix + ":Employee",
+				},
+			}),
+			NewEntityFromMap(map[string]interface{}{
+				"id":    peopleNamespacePrefix + ":person-2",
+				"props": map[string]interface{}{employeeNamespacePrefix + ":Title": "Vice President"},
+				"refs": map[string]interface{}{
+					rdfNamespacePrefix + ":type":            modelNamespacePrefix + ":Employee",
+					employeeNamespacePrefix + ":Supervisor": peopleNamespacePrefix + ":person-1",
+				},
+			}),
+		})
+
+		// first no datasets restriction, check that props from both employee and people dataset are merged
+		result, err := store.GetEntity(peopleNamespacePrefix+":person-1", []string{})
+		Expect(err).To(BeNil())
+		Expect(result.Properties[employeeNamespacePrefix+":Title"]).To(Equal("President"),
+			"expected to merge property employees:Title into result with value 'President'")
+		Expect(result.Properties[peopleNamespacePrefix+":Name"]).To(Equal("Lisa"))
+
+		// now, restrict on dataset "people"
+		result, _ = store.GetEntity(peopleNamespacePrefix+":person-2", []string{PEOPLE})
+		// we should not find the Title from the employees dataset
+		Expect(result.Properties[employeeNamespacePrefix+":Title"]).To(BeNil())
+		// people:Name should be found though
+		Expect(result.Properties[peopleNamespacePrefix+":Name"]).To(Equal("Bob"))
+
+		// now, restrict on dataset "employees". now Name should be gone but title should be found
+		result, _ = store.GetEntity(peopleNamespacePrefix+":person-2", []string{EMPLOYEES})
+		Expect(result.Properties[employeeNamespacePrefix+":Title"]).To(Equal("Vice President"),
+			"expected to merge property employees:Title into result with value 'Vice President'")
+		Expect(result.Properties[peopleNamespacePrefix+":Name"]).To(BeNil())
+	})
+
+	ginkgo.It("Should perform txn updates without error", func() {
+		// create dataset
+		_, err := dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+
+		_, err = dsm.CreateDataset("places", nil)
+		Expect(err).To(BeNil())
+
+		entities := make([]*Entity, 1)
+		entity := NewEntity("http://data.mimiro.io/people/person1", 0)
+		entity.Properties["Name"] = "homer"
+		entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
+		entity.References["rdf:place"] = "http://data.mimiro.io/places/place1"
+		entities[0] = entity
+
+		entities1 := make([]*Entity, 1)
+		entity1 := NewEntity("http://data.mimiro.io/places/place1", 0)
+		entity1.Properties["Name"] = "home"
+		entity1.References["rdf:type"] = "http://data.mimiro.io/model/Place"
+		entities1[0] = entity1
+
+		txn := &Transaction{}
+		txn.DatasetEntities = make(map[string][]*Entity)
+		txn.DatasetEntities["people"] = entities
+		txn.DatasetEntities["places"] = entities1
+
+		err = store.ExecuteTransaction(txn)
+		Expect(err).To(BeNil())
+
+		people := dsm.GetDataset("people")
+		peopleEntities, _ := people.GetEntities("", 100)
+		Expect(len(peopleEntities.Entities)).To(Equal(6))
+	})
+
+	ginkgo.It("should find deleted version of entity with lookup", func() {
+		peopleNamespacePrefix, _ := store.NamespaceManager.AssertPrefixMappingForExpansion(
+			"http://data.mimiro.io/people/",
+		)
+
+		// create dataset
+		ds, err := dsm.CreateDataset("people", nil)
+		Expect(err).To(BeNil())
+
+		entities := make([]*Entity, 1)
+		entity := NewEntity(peopleNamespacePrefix+":p1", 0)
+		entity.Properties["Name"] = "homer"
+		entity.References["rdf:type"] = "http://data.mimiro.io/model/Person"
+		entity.References["rdf:f1"] = "http://data.mimiro.io/people/Person-1"
+		entity.References["rdf:f2"] = "http://data.mimiro.io/people/Person-2"
+		entity.References["rdf:f3"] = "http://data.mimiro.io/people/Person-3"
+		entities[0] = entity
+
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "StoreEntities failed unexpectedly")
+
+		// get entity
+		e, err := store.GetEntity(peopleNamespacePrefix+":p1", nil)
+		Expect(err).To(BeNil(), "GetEntity failed unexpectedly")
+		Expect(e.IsDeleted).To(BeFalse())
+
+		entities = make([]*Entity, 1)
+		entity = NewEntity(peopleNamespacePrefix+":p1", 0)
+		entity.IsDeleted = true
+		entities[0] = entity
+
+		err = ds.StoreEntities(entities)
+		Expect(err).To(BeNil(), "StoreEntities failed unexpectedly")
+
+		e, _ = store.GetEntity("http://data.mimiro.io/people/p1", nil)
+		Expect(e.IsDeleted).To(BeTrue())
+	})
+})
 
 func findEntity(result [][]interface{}, id string) *Entity {
 	var entity *Entity

--- a/internal/server/streamparser_test.go
+++ b/internal/server/streamparser_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
-	"go.uber.org/fx/fxtest"
-	"go.uber.org/zap"
-
 	"github.com/mimiro-io/datahub/internal"
 	"github.com/mimiro-io/datahub/internal/conf"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
 )
 
 func TestJsonOmitOnEntity(m *testing.T) {
@@ -39,38 +39,36 @@ func TestJsonOmitOnEntity(m *testing.T) {
 	}
 }
 
-func TestStreamParser(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("The stream parser", func() {
-		testCnt := 0
-		var store *Store
-		var storeLocation string
-		g.BeforeEach(func() {
-			testCnt += 1
-			storeLocation = fmt.Sprintf("./test_streamparser_%v", testCnt)
-			err := os.RemoveAll(storeLocation)
-			g.Assert(err).IsNil("should be allowed to clean testfiles in " + storeLocation)
-			e := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
+var _ = ginkgo.Describe("The stream parser", func() {
+	testCnt := 0
+	var store *Store
+	var storeLocation string
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		storeLocation = fmt.Sprintf("./test_streamparser_%v", testCnt)
+		err := os.RemoveAll(storeLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+storeLocation)
+		e := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
 
-			devNull, _ := os.Open("/dev/null")
-			oldErr := os.Stderr
-			os.Stderr = devNull
-			lc := fxtest.NewLifecycle(internal.FxTestLog(t, false))
-			store = NewStore(lc, e, &statsd.NoOpClient{})
-			lc.RequireStart()
-			os.Stderr = oldErr
-		})
-		g.AfterEach(func() {
-			_ = store.Close()
-			_ = os.RemoveAll(storeLocation)
-		})
+		devNull, _ := os.Open("/dev/null")
+		oldErr := os.Stderr
+		os.Stderr = devNull
+		lc := fxtest.NewLifecycle(internal.FxTestLog(ginkgo.GinkgoT(), false))
+		store = NewStore(lc, e, &statsd.NoOpClient{})
+		lc.RequireStart()
+		os.Stderr = oldErr
+	})
+	ginkgo.AfterEach(func() {
+		_ = store.Close()
+		_ = os.RemoveAll(storeLocation)
+	})
 
-		g.It("Should process transaction with dataset with array of entities", func() {
-			reader := strings.NewReader(
-				`{
+	ginkgo.It("Should process transaction with dataset with array of entities", func() {
+		reader := strings.NewReader(
+			`{
 						"@context" : {
 							"namespaces" : {
 								"mimiro-people" : "http://data.mimiro.io/people/",
@@ -87,19 +85,19 @@ func TestStreamParser(t *testing.T) {
 						]
 					}`)
 
-			esp := NewEntityStreamParser(store)
-			txn, err := esp.ParseTransaction(reader)
+		esp := NewEntityStreamParser(store)
+		txn, err := esp.ParseTransaction(reader)
 
-			g.Assert(txn).IsNotNil("Transaction cannot be nil")
-			g.Assert(err).IsNil("Parsing didnt produce the expected error")
+		Expect(txn).NotTo(BeNil(), "Transaction cannot be nil")
+		Expect(err).To(BeNil(), "Parsing didnt produce the expected error")
 
-			people := txn.DatasetEntities["people"]
-			g.Assert(people).IsNotNil("people dataset updates missing")
-		})
+		people := txn.DatasetEntities["people"]
+		Expect(people).NotTo(BeNil(), "people dataset updates missing")
+	})
 
-		g.It("Should process transaction with dataset with empty array of entities", func() {
-			reader := strings.NewReader(
-				`{
+	ginkgo.It("Should process transaction with dataset with empty array of entities", func() {
+		reader := strings.NewReader(
+			`{
 						"@context" : {
 							"namespaces" : {
 								"mimiro-people" : "http://data.mimiro.io/people/",
@@ -109,16 +107,16 @@ func TestStreamParser(t *testing.T) {
 						"people" : []
 					}`)
 
-			esp := NewEntityStreamParser(store)
-			txn, err := esp.ParseTransaction(reader)
+		esp := NewEntityStreamParser(store)
+		txn, err := esp.ParseTransaction(reader)
 
-			g.Assert(txn).IsNotNil("Transaction cannot be nil")
-			g.Assert(err).IsNil("Parsing didnt produce the expected error")
-		})
+		Expect(txn).NotTo(BeNil(), "Transaction cannot be nil")
+		Expect(err).To(BeNil(), "Parsing didnt produce the expected error")
+	})
 
-		g.It("Should error with transactions with no context", func() {
-			reader := strings.NewReader(
-				`{
+	ginkgo.It("Should error with transactions with no context", func() {
+		reader := strings.NewReader(
+			`{
 						"people" : [
 							{
 								"id" : "http://data.mimiro.io/people/12345"
@@ -126,15 +124,15 @@ func TestStreamParser(t *testing.T) {
 						]
 					}`)
 
-			esp := NewEntityStreamParser(store)
-			_, err := esp.ParseTransaction(reader)
+		esp := NewEntityStreamParser(store)
+		_, err := esp.ParseTransaction(reader)
 
-			g.Assert(err).IsNotNil("Parsing didnt produce the expected error")
-		})
+		Expect(err).NotTo(BeNil(), "Parsing didnt produce the expected error")
+	})
 
-		g.It("Should deal with transactions with only a context", func() {
-			reader := strings.NewReader(
-				`{
+	ginkgo.It("Should deal with transactions with only a context", func() {
+		reader := strings.NewReader(
+			`{
 						"@context" : {
 							"namespaces" : {
 								"mimiro-people" : "http://data.mimiro.io/people/",
@@ -143,15 +141,15 @@ func TestStreamParser(t *testing.T) {
 						}
 					}`)
 
-			esp := NewEntityStreamParser(store)
-			txn, err := esp.ParseTransaction(reader)
+		esp := NewEntityStreamParser(store)
+		txn, err := esp.ParseTransaction(reader)
 
-			g.Assert(err).IsNil("Parsing produced an unexpected error")
-			g.Assert(txn).IsNotNil("No transaction returned")
-		})
+		Expect(err).To(BeNil(), "Parsing produced an unexpected error")
+		Expect(txn).NotTo(BeNil(), "No transaction returned")
+	})
 
-		g.It("Should deal with @context, data and @continuation entities", func() {
-			reader := strings.NewReader(`[
+	ginkgo.It("Should deal with @context, data and @continuation entities", func() {
+		reader := strings.NewReader(`[
 				{ "id" : "@context",
 					"namespaces" : {
 						"mimiro-people" : "http://data.mimiro.io/people/",
@@ -166,22 +164,22 @@ func TestStreamParser(t *testing.T) {
 					"token" : "next-20"
 				} ]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNil("Parsing produced an unexpected error")
-			g.Assert(len(entities)).Eql(2, "Parser did produce wrong number of entities")
-
-			cont := entities[1]
-			g.Assert(cont.ID).Eql("@continuation", "Second and last entity was not continuation")
-			g.Assert(cont.GetStringProperty("token")).Eql("next-20", "Unexpected token value")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).To(BeNil(), "Parsing produced an unexpected error")
+		Expect(len(entities)).To(Equal(2), "Parser did produce wrong number of entities")
 
-		g.It("Should detect bad/missing entity ids", func() {
-			reader := strings.NewReader(` [ {
+		cont := entities[1]
+		Expect(cont.ID).To(Equal("@continuation"), "Second and last entity was not continuation")
+		Expect(cont.GetStringProperty("token")).To(Equal("next-20"), "Unexpected token value")
+	})
+
+	ginkgo.It("Should detect bad/missing entity ids", func() {
+		reader := strings.NewReader(` [ {
 					"id" : "@context",
 					"namespaces" : {
 						"mimiro-people" : "http://data.mimiro.io/people/",
@@ -196,18 +194,18 @@ func TestStreamParser(t *testing.T) {
 					"token" : "next-20"
 				}]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNotNil("Parsing did not produce expected error")
-			g.Assert(err.Error()).Eql("parsing error: Unable to parse entity: empty value not allowed")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).NotTo(BeNil(), "Parsing did not produce expected error")
+		Expect(err.Error()).To(Equal("parsing error: Unable to parse entity: empty value not allowed"))
+	})
 
-		g.It("Should detect missing default namespace in context", func() {
-			reader := strings.NewReader(`[ {
+	ginkgo.It("Should detect missing default namespace in context", func() {
+		reader := strings.NewReader(`[ {
 					"id" : "@context",
 					"namespaces" : {
 						"mimiro" : "http://data.mimiro.io/core/",
@@ -222,19 +220,19 @@ func TestStreamParser(t *testing.T) {
 					"token" : "next-20"
 				} ]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNotNil("Parsing did not produce expected error")
-			g.Assert(err.Error()).Eql("parsing error: Unable to parse entity: " +
-				"unable to parse properties no expansion for default prefix _ ")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).NotTo(BeNil(), "Parsing did not produce expected error")
+		Expect(err.Error()).To(Equal("parsing error: Unable to parse entity: " +
+			"unable to parse properties no expansion for default prefix _ "))
+	})
 
-		g.It("Should detect missing expansions", func() {
-			reader := strings.NewReader(` [ {
+	ginkgo.It("Should detect missing expansions", func() {
+		reader := strings.NewReader(` [ {
 					"id" : "@context",
 					"namespaces" : {
 						"mimiro" : "http://data.mimiro.io/core/",
@@ -249,18 +247,18 @@ func TestStreamParser(t *testing.T) {
 					"token" : "next-20"
 				} ]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNotNil("Parsing did not produce expected error")
-			g.Assert(err.Error()).Eql("parsing error: Unable to parse entity: no expansion for prefix woddle")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).NotTo(BeNil(), "Parsing did not produce expected error")
+		Expect(err.Error()).To(Equal("parsing error: Unable to parse entity: no expansion for prefix woddle"))
+	})
 
-		g.It("Should accept empty properties and empty refs", func() {
-			reader := strings.NewReader(` [ {
+	ginkgo.It("Should accept empty properties and empty refs", func() {
+		reader := strings.NewReader(` [ {
 					"id" : "@context",
 					"namespaces" : {
 						"mimiro" : "http://data.mimiro.io/core/",
@@ -272,18 +270,18 @@ func TestStreamParser(t *testing.T) {
 				{ "id" : "mimiro-people:26", "refs" : { }, "props" : { } },
 				{ "id" : "@continuation", "token" : "next-20" } ]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNil("Parsing produced unexpected error")
-			g.Assert(len(entities)).Eql(5, "Expect all entities to be represented")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).To(BeNil(), "Parsing produced unexpected error")
+		Expect(len(entities)).To(Equal(5), "Expect all entities to be represented")
+	})
 
-		g.It("Should handle nested entities", func() {
-			reader := strings.NewReader(` [ {
+	ginkgo.It("Should handle nested entities", func() {
+		reader := strings.NewReader(` [ {
 					"id" : "@context",
 					"namespaces" : {
 						"_" : "http://data.mimiro.io/core/",
@@ -300,28 +298,28 @@ func TestStreamParser(t *testing.T) {
 					}
 				} ]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNil("Parsing produced unexpected error")
-			g.Assert(len(entities)).Eql(1, "Expected correnct number of entitites")
-			addressSeen := false
-			for k, v := range entities[0].Properties {
-				if strings.HasSuffix(k, "address") {
-					addressSeen = true
-					subEntity, castOK := v.(*Entity)
-					g.Assert(castOK).IsTrue("Expected address value to be another entity instance")
-					g.Assert(len(subEntity.Properties)).Eql(1, "Expected sub-entity to have one property (line1)")
-				}
-			}
-			g.Assert(addressSeen).IsTrue("Expected address property to be mapped")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).To(BeNil(), "Parsing produced unexpected error")
+		Expect(len(entities)).To(Equal(1), "Expected correnct number of entitites")
+		addressSeen := false
+		for k, v := range entities[0].Properties {
+			if strings.HasSuffix(k, "address") {
+				addressSeen = true
+				subEntity, castOK := v.(*Entity)
+				Expect(castOK).To(BeTrue(), "Expected address value to be another entity instance")
+				Expect(len(subEntity.Properties)).To(Equal(1), "Expected sub-entity to have one property (line1)")
+			}
+		}
+		Expect(addressSeen).To(BeTrue(), "Expected address property to be mapped")
+	})
 
-		g.It("Should handle nested entities with arrays", func() {
-			reader := strings.NewReader(` [ {
+	ginkgo.It("Should handle nested entities with arrays", func() {
+		reader := strings.NewReader(` [ {
 					"id" : "@context",
 					"namespaces" : {
 						"_" : "http://data.mimiro.io/core/",
@@ -338,28 +336,28 @@ func TestStreamParser(t *testing.T) {
 					}
 				} ]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNil("Parsing produced unexpected error")
-			g.Assert(len(entities)).Eql(1, "Expected correnct number of entitites")
-			addressSeen := false
-			for k, v := range entities[0].Properties {
-				if strings.HasSuffix(k, "address") {
-					addressSeen = true
-					subEntity, castOK := v.(*Entity)
-					g.Assert(castOK).IsTrue("Expected address value to be another entity instance")
-					g.Assert(len(subEntity.Properties)).Eql(1, "Expected sub-entity to have one property (line1)")
-				}
-			}
-			g.Assert(addressSeen).IsTrue("Expected address property to be mapped")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).To(BeNil(), "Parsing produced unexpected error")
+		Expect(len(entities)).To(Equal(1), "Expected correnct number of entitites")
+		addressSeen := false
+		for k, v := range entities[0].Properties {
+			if strings.HasSuffix(k, "address") {
+				addressSeen = true
+				subEntity, castOK := v.(*Entity)
+				Expect(castOK).To(BeTrue(), "Expected address value to be another entity instance")
+				Expect(len(subEntity.Properties)).To(Equal(1), "Expected sub-entity to have one property (line1)")
+			}
+		}
+		Expect(addressSeen).To(BeTrue(), "Expected address property to be mapped")
+	})
 
-		g.It("Should handle nested entities with id", func() {
-			reader := strings.NewReader(` [ {
+	ginkgo.It("Should handle nested entities with id", func() {
+		reader := strings.NewReader(` [ {
 					"id" : "@context",
 					"namespaces" : {
 						"_" : "http://data.mimiro.io/core/",
@@ -379,29 +377,29 @@ func TestStreamParser(t *testing.T) {
 				}
 			]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNil("Parsing produced unexpected error")
-			g.Assert(len(entities)).Eql(1, "Expected correnct number of entitites")
-			addressSeen := false
-			for k, v := range entities[0].Properties {
-				if strings.HasSuffix(k, "address") {
-					addressSeen = true
-					subEntity, castOK := v.(*Entity)
-					g.Assert(castOK).IsTrue("Expected address value to be another entity instance")
-					g.Assert(len(subEntity.Properties)).Eql(1, "Expected sub-entity to have one property (line1)")
-					g.Assert(strings.HasSuffix(subEntity.ID, "44")).IsTrue("Expected sub-entity ID")
-				}
-			}
-			g.Assert(addressSeen).IsTrue("Expected address property to be mapped")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).To(BeNil(), "Parsing produced unexpected error")
+		Expect(len(entities)).To(Equal(1), "Expected correnct number of entitites")
+		addressSeen := false
+		for k, v := range entities[0].Properties {
+			if strings.HasSuffix(k, "address") {
+				addressSeen = true
+				subEntity, castOK := v.(*Entity)
+				Expect(castOK).To(BeTrue(), "Expected address value to be another entity instance")
+				Expect(len(subEntity.Properties)).To(Equal(1), "Expected sub-entity to have one property (line1)")
+				Expect(strings.HasSuffix(subEntity.ID, "44")).To(BeTrue(), "Expected sub-entity ID")
+			}
+		}
+		Expect(addressSeen).To(BeTrue(), "Expected address property to be mapped")
+	})
 
-		g.It("Should Ignore keys outside props and refs", func() {
-			reader := strings.NewReader(` [ {
+	ginkgo.It("Should Ignore keys outside props and refs", func() {
+		reader := strings.NewReader(` [ {
 					"id" : "@context",
 					"namespaces" : {
 						"_" : "http://data.mimiro.io/core/",
@@ -420,26 +418,25 @@ func TestStreamParser(t *testing.T) {
 				}
 			]`)
 
-			esp := NewEntityStreamParser(store)
-			entities := make([]*Entity, 0)
-			err := esp.ParseStream(reader, func(e *Entity) error {
-				entities = append(entities, e)
-				return nil
-			})
-			g.Assert(err).IsNil("Parsing produced unexpected error")
-			g.Assert(len(entities)).Eql(1, "Expected correct number of entitites")
-			addressSeen := false
-			for k, v := range entities[0].Properties {
-				if strings.HasSuffix(k, "address") {
-					addressSeen = true
-					subEntity, castOK := v.(*Entity)
-					g.Assert(castOK).IsTrue("Expected address value to be another entity instance")
-					g.Assert(len(subEntity.Properties)).Eql(0, "Expected sub-entity to have no property"+
-						" (line1 is not inside a props)")
-					g.Assert(strings.HasSuffix(subEntity.ID, "44")).IsTrue("Expected sub-entity ID")
-				}
-			}
-			g.Assert(addressSeen).IsTrue("Expected address property to be mapped")
+		esp := NewEntityStreamParser(store)
+		entities := make([]*Entity, 0)
+		err := esp.ParseStream(reader, func(e *Entity) error {
+			entities = append(entities, e)
+			return nil
 		})
+		Expect(err).To(BeNil(), "Parsing produced unexpected error")
+		Expect(len(entities)).To(Equal(1), "Expected correct number of entitites")
+		addressSeen := false
+		for k, v := range entities[0].Properties {
+			if strings.HasSuffix(k, "address") {
+				addressSeen = true
+				subEntity, castOK := v.(*Entity)
+				Expect(castOK).To(BeTrue(), "Expected address value to be another entity instance")
+				Expect(len(subEntity.Properties)).To(Equal(0), "Expected sub-entity to have no property"+
+					" (line1 is not inside a props)")
+				Expect(strings.HasSuffix(subEntity.ID, "44")).To(BeTrue(), "Expected sub-entity ID")
+			}
+		}
+		Expect(addressSeen).To(BeTrue(), "Expected address property to be mapped")
 	})
-}
+})

--- a/internal/server/streamparser_test.go
+++ b/internal/server/streamparser_test.go
@@ -22,12 +22,13 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/mimiro-io/datahub/internal"
-	"github.com/mimiro-io/datahub/internal/conf"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
+
+	"github.com/mimiro-io/datahub/internal"
+	"github.com/mimiro-io/datahub/internal/conf"
 )
 
 func TestJsonOmitOnEntity(m *testing.T) {

--- a/internal/service/dataset/iterator_test.go
+++ b/internal/service/dataset/iterator_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 
@@ -33,217 +34,219 @@ import (
 )
 
 func TestDatasetIterator(t *testing.T) {
-	g := goblin.Goblin(t)
-	g.Describe("A dataset iterator", func() {
-		storeLocation := "./test_service_dataset_iterator"
-		var lc *fxtest.Lifecycle
-		var dsm *server.DsManager
-		var ds0 *server.Dataset
-		var ds1 *server.Dataset
-		var ds2 *server.Dataset
-		var store *server.Store
-		g.Before(func() {
-			os.RemoveAll(storeLocation)
-			lc = fxtest.NewLifecycle(internal.FxTestLog(t, false))
-			env := &conf.Env{
-				Logger:        zap.NewNop().Sugar(),
-				StoreLocation: storeLocation,
-			}
-			store = server.NewStore(lc, env, &statsd.NoOpClient{})
-			dsm = server.NewDsManager(lc, env, store, server.NoOpBus())
-			lc.Start(context.Background())
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "service/Dataset Suite")
+}
 
-			ds0, _ = dsm.CreateDataset("arabic", nil)
-			ds0.StoreEntities([]*server.Entity{
-				server.NewEntity("1", 0),
-				server.NewEntity("2", 0),
-				server.NewEntity("3", 0),
-				server.NewEntity("4", 0),
-			})
-			ds1, _ = dsm.CreateDataset("roman", nil)
-			ds1.StoreEntities([]*server.Entity{
-				server.NewEntity("I", 0),
-				server.NewEntity("II", 0),
-				server.NewEntity("III", 0),
-				server.NewEntity("IV", 0),
-			})
-			ds2, _ = dsm.CreateDataset("letters", nil)
-			ds2.StoreEntities([]*server.Entity{
-				server.NewEntity("a", 0),
-				server.NewEntity("b", 0),
-				server.NewEntity("c", 0),
-				server.NewEntity("d", 0),
-			})
-		})
-		g.After(func() {
-			lc.Stop(context.Background())
-			os.RemoveAll(storeLocation)
-		})
-		g.It("should be able to create a 0 offset", func() {
-			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
-			g.Assert(err).IsNil()
-			it, err := dataset.At(0)
-			g.Assert(err).IsNil()
-			g.Assert(it.Error()).IsNil()
-			var continuationToken types.DatasetOffset = 0
-			var foundIds []string
-			for it.Next() {
-				jsonData := it.Item()
-				e := server.Entity{}
-				err := json.Unmarshal(jsonData, &e)
-				g.Assert(err).IsNil()
-				foundIds = append(foundIds, e.ID)
-				continuationToken = it.NextOffset()
-			}
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(foundIds).Equal([]string{"I", "II", "III", "IV"})
-			g.Assert(continuationToken).Equal(types.DatasetOffset(4))
-		})
-		g.It("should be able to create a 3 offset", func() {
-			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
-			g.Assert(err).IsNil()
-			it, err := dataset.At(3)
-			g.Assert(err).IsNil()
-			g.Assert(it.Error()).IsNil()
-			var continuationToken types.DatasetOffset = 0
-			var foundIds []string
-			for it.Next() {
-				jsonData := it.Item()
-				e := server.Entity{}
-				err := json.Unmarshal(jsonData, &e)
-				g.Assert(err).IsNil()
-				foundIds = append(foundIds, e.ID)
-				continuationToken = it.NextOffset()
-			}
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(foundIds).Equal([]string{"IV"})
-			g.Assert(continuationToken).Equal(types.DatasetOffset(4))
-		})
-		g.It("should produce correct nextOffsets", func() {
-			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
-			g.Assert(err).IsNil()
-			it, err := dataset.At(0)
-			g.Assert(err).IsNil()
-			g.Assert(it.Error()).IsNil()
-			var continuationToken types.DatasetOffset = 0
-			var foundIds []string
-			for it.Next() {
-				jsonData := it.Item()
-				e := server.Entity{}
-				err2 := json.Unmarshal(jsonData, &e)
-				g.Assert(err2).IsNil()
-				foundIds = append(foundIds, e.ID)
-				continuationToken = it.NextOffset()
-				if len(foundIds) == 2 {
-					break
-				}
-			}
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(foundIds).Equal([]string{"I", "II"})
-			g.Assert(continuationToken).Equal(types.DatasetOffset(2))
+var _ = Describe("A dataset iterator", Ordered, func() {
+	storeLocation := "./test_service_dataset_iterator"
+	var lc *fxtest.Lifecycle
+	var dsm *server.DsManager
+	var ds0 *server.Dataset
+	var ds1 *server.Dataset
+	var ds2 *server.Dataset
+	var store *server.Store
+	BeforeAll(func() {
+		os.RemoveAll(storeLocation)
+		lc = fxtest.NewLifecycle(internal.FxTestLog(GinkgoT(), false))
+		env := &conf.Env{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		store = server.NewStore(lc, env, &statsd.NoOpClient{})
+		dsm = server.NewDsManager(lc, env, store, server.NoOpBus())
+		lc.Start(context.Background())
 
-			it, err = dataset.At(continuationToken)
-			g.Assert(err).IsNil()
-			foundIds = []string{}
-			for it.Next() {
-				jsonData := it.Item()
-				e := server.Entity{}
-				err := json.Unmarshal(jsonData, &e)
-				g.Assert(err).IsNil()
-				foundIds = append(foundIds, e.ID)
-				continuationToken = it.NextOffset()
-			}
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(foundIds).Equal([]string{"III", "IV"})
-			g.Assert(continuationToken).Equal(types.DatasetOffset(4))
+		ds0, _ = dsm.CreateDataset("arabic", nil)
+		ds0.StoreEntities([]*server.Entity{
+			server.NewEntity("1", 0),
+			server.NewEntity("2", 0),
+			server.NewEntity("3", 0),
+			server.NewEntity("4", 0),
 		})
-		g.It("should be able to create a 4 offset", func() {
-			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
-			g.Assert(err).IsNil()
-			it, err := dataset.At(4)
-			g.Assert(err).IsNil()
-			g.Assert(it.Next()).IsFalse("nothing found")
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(it.NextOffset()).Equal(types.DatasetOffset(4))
+		ds1, _ = dsm.CreateDataset("roman", nil)
+		ds1.StoreEntities([]*server.Entity{
+			server.NewEntity("I", 0),
+			server.NewEntity("II", 0),
+			server.NewEntity("III", 0),
+			server.NewEntity("IV", 0),
 		})
-		g.It("should not fail for too large offset, but emit nothing", func() {
-			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
-			g.Assert(err).IsNil()
-			it, err := dataset.At(5)
-			g.Assert(err).IsNil()
-			g.Assert(it.Next()).IsFalse("nothing found")
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(it.NextOffset()).Equal(types.DatasetOffset(5))
-		})
-		g.It("should list inverse changes from 0", func() {
-			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
-			g.Assert(err).IsNil()
-			it, err := dataset.At(0)
-			g.Assert(err).IsNil()
-			it = it.Inverse()
-			g.Assert(it.Error()).IsNil()
-			var continuationToken types.DatasetOffset = 0
-			var foundIds []string
-			for it.Next() {
-				jsonData := it.Item()
-				e := server.Entity{}
-				err := json.Unmarshal(jsonData, &e)
-				g.Assert(err).IsNil()
-				foundIds = append(foundIds, e.ID)
-				continuationToken = it.NextOffset()
-			}
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(foundIds).Equal([]string{"IV", "III", "II", "I"})
-			g.Assert(continuationToken).Equal(types.DatasetOffset(0))
-		})
-		g.It("should produce correct inverse nextOffsets", func() {
-			dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
-			g.Assert(err).IsNil()
-			it, err := dataset.At(0)
-			it = it.Inverse()
-			g.Assert(err).IsNil()
-			g.Assert(it.Error()).IsNil()
-			var continuationToken types.DatasetOffset = 0
-			var foundIds []string
-			for it.Next() {
-				jsonData := it.Item()
-				e := server.Entity{}
-				err2 := json.Unmarshal(jsonData, &e)
-				g.Assert(err2).IsNil()
-				foundIds = append(foundIds, e.ID)
-				continuationToken = it.NextOffset()
-				if len(foundIds) == 2 {
-					break
-				}
-			}
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(foundIds).Equal([]string{"IV", "III"})
-			g.Assert(continuationToken).Equal(types.DatasetOffset(2))
-
-			it, err = dataset.At(continuationToken)
-			g.Assert(err).IsNil()
-			it = it.Inverse()
-			foundIds = []string{}
-			for it.Next() {
-				jsonData := it.Item()
-				e := server.Entity{}
-				err := json.Unmarshal(jsonData, &e)
-				g.Assert(err).IsNil()
-				foundIds = append(foundIds, e.ID)
-				continuationToken = it.NextOffset()
-			}
-			it.Close()
-			g.Assert(it.Error()).IsNil()
-			g.Assert(foundIds).Equal([]string{"II", "I"})
-			g.Assert(continuationToken).Equal(types.DatasetOffset(0))
+		ds2, _ = dsm.CreateDataset("letters", nil)
+		ds2.StoreEntities([]*server.Entity{
+			server.NewEntity("a", 0),
+			server.NewEntity("b", 0),
+			server.NewEntity("c", 0),
+			server.NewEntity("d", 0),
 		})
 	})
-}
+	AfterAll(func() {
+		lc.Stop(context.Background())
+		os.RemoveAll(storeLocation)
+	})
+	It("should be able to create a 0 offset", func() {
+		dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+		Expect(err).To(BeNil())
+		it, err := dataset.At(0)
+		Expect(err).To(BeNil())
+		Expect(it.Error()).To(BeNil())
+		var continuationToken types.DatasetOffset = 0
+		var foundIds []string
+		for it.Next() {
+			jsonData := it.Item()
+			e := server.Entity{}
+			err := json.Unmarshal(jsonData, &e)
+			Expect(err).To(BeNil())
+			foundIds = append(foundIds, e.ID)
+			continuationToken = it.NextOffset()
+		}
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(foundIds).To(Equal([]string{"I", "II", "III", "IV"}))
+		Expect(continuationToken).To(Equal(types.DatasetOffset(4)))
+	})
+	It("should be able to create a 3 offset", func() {
+		dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+		Expect(err).To(BeNil())
+		it, err := dataset.At(3)
+		Expect(err).To(BeNil())
+		Expect(it.Error()).To(BeNil())
+		var continuationToken types.DatasetOffset = 0
+		var foundIds []string
+		for it.Next() {
+			jsonData := it.Item()
+			e := server.Entity{}
+			err := json.Unmarshal(jsonData, &e)
+			Expect(err).To(BeNil())
+			foundIds = append(foundIds, e.ID)
+			continuationToken = it.NextOffset()
+		}
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(foundIds).To(Equal([]string{"IV"}))
+		Expect(continuationToken).To(Equal(types.DatasetOffset(4)))
+	})
+	It("should produce correct nextOffsets", func() {
+		dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+		Expect(err).To(BeNil())
+		it, err := dataset.At(0)
+		Expect(err).To(BeNil())
+		Expect(it.Error()).To(BeNil())
+		var continuationToken types.DatasetOffset = 0
+		var foundIds []string
+		for it.Next() {
+			jsonData := it.Item()
+			e := server.Entity{}
+			err2 := json.Unmarshal(jsonData, &e)
+			Expect(err2).To(BeNil())
+			foundIds = append(foundIds, e.ID)
+			continuationToken = it.NextOffset()
+			if len(foundIds) == 2 {
+				break
+			}
+		}
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(foundIds).To(Equal([]string{"I", "II"}))
+		Expect(continuationToken).To(Equal(types.DatasetOffset(2)))
+
+		it, err = dataset.At(continuationToken)
+		Expect(err).To(BeNil())
+		foundIds = []string{}
+		for it.Next() {
+			jsonData := it.Item()
+			e := server.Entity{}
+			err := json.Unmarshal(jsonData, &e)
+			Expect(err).To(BeNil())
+			foundIds = append(foundIds, e.ID)
+			continuationToken = it.NextOffset()
+		}
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(foundIds).To(Equal([]string{"III", "IV"}))
+		Expect(continuationToken).To(Equal(types.DatasetOffset(4)))
+	})
+	It("should be able to create a 4 offset", func() {
+		dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+		Expect(err).To(BeNil())
+		it, err := dataset.At(4)
+		Expect(err).To(BeNil())
+		Expect(it.Next()).To(BeFalse(), "nothing found")
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(it.NextOffset()).To(Equal(types.DatasetOffset(4)))
+	})
+	It("should not fail for too large offset, but emit nothing", func() {
+		dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+		Expect(err).To(BeNil())
+		it, err := dataset.At(5)
+		Expect(err).To(BeNil())
+		Expect(it.Next()).To(BeFalse(), "nothing found")
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(it.NextOffset()).To(Equal(types.DatasetOffset(5)))
+	})
+	It("should list inverse changes from 0", func() {
+		dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+		Expect(err).To(BeNil())
+		it, err := dataset.At(0)
+		Expect(err).To(BeNil())
+		it = it.Inverse()
+		Expect(it.Error()).To(BeNil())
+		var continuationToken types.DatasetOffset = 0
+		var foundIds []string
+		for it.Next() {
+			jsonData := it.Item()
+			e := server.Entity{}
+			err := json.Unmarshal(jsonData, &e)
+			Expect(err).To(BeNil())
+			foundIds = append(foundIds, e.ID)
+			continuationToken = it.NextOffset()
+		}
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(foundIds).To(Equal([]string{"IV", "III", "II", "I"}))
+		Expect(continuationToken).To(Equal(types.DatasetOffset(0)))
+	})
+	It("should produce correct inverse nextOffsets", func() {
+		dataset, err := ds.Of(server.NewBadgerAccess(store, dsm), ds1.ID)
+		Expect(err).To(BeNil())
+		it, err := dataset.At(0)
+		it = it.Inverse()
+		Expect(err).To(BeNil())
+		Expect(it.Error()).To(BeNil())
+		var continuationToken types.DatasetOffset = 0
+		var foundIds []string
+		for it.Next() {
+			jsonData := it.Item()
+			e := server.Entity{}
+			err2 := json.Unmarshal(jsonData, &e)
+			Expect(err2).To(BeNil())
+			foundIds = append(foundIds, e.ID)
+			continuationToken = it.NextOffset()
+			if len(foundIds) == 2 {
+				break
+			}
+		}
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(foundIds).To(Equal([]string{"IV", "III"}))
+		Expect(continuationToken).To(Equal(types.DatasetOffset(2)))
+
+		it, err = dataset.At(continuationToken)
+		Expect(err).To(BeNil())
+		it = it.Inverse()
+		foundIds = []string{}
+		for it.Next() {
+			jsonData := it.Item()
+			e := server.Entity{}
+			err := json.Unmarshal(jsonData, &e)
+			Expect(err).To(BeNil())
+			foundIds = append(foundIds, e.ID)
+			continuationToken = it.NextOffset()
+		}
+		it.Close()
+		Expect(it.Error()).To(BeNil())
+		Expect(foundIds).To(Equal([]string{"II", "I"}))
+		Expect(continuationToken).To(Equal(types.DatasetOffset(0)))
+	})
+})

--- a/internal/service/entity/ids_test.go
+++ b/internal/service/entity/ids_test.go
@@ -4,7 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/mimiro-io/datahub/internal/service/namespace"
 	"github.com/mimiro-io/datahub/internal/service/types"
@@ -27,42 +28,41 @@ func (n nsMock) LookupExpansionPrefix(input types.URI) (types.Prefix, error) {
 	return "", errors.New("unknown namespace")
 }
 
-func TestLookup_asCURIE(t *testing.T) {
-	mockNamespaces := namespace.NewManager(nsMock{})
-	g := goblin.Goblin(t)
-	g.Describe("asCURIE", func() {
-		g.It("should return curie for valid curie string", func() {
-			res, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo:bar")
-			g.Assert(err).IsNil()
-			g.Assert(res).Equal(types.CURIE("foo:bar"))
-		})
-		g.It("should fail valid curie string with unknown prefix", func() {
-			_, err := Lookup{namespaces: mockNamespaces}.asCURIE("hello:world")
-			g.Assert(err).IsNotNil()
-			g.Assert(err.Error()).Equal("unknown prefix")
-		})
-		g.It("should return for curie with prefix only", func() {
-			res, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo:")
-			g.Assert(err).IsNil()
-			g.Assert(res).Equal(types.CURIE("foo:"))
-		})
-		g.It("should fail simple string", func() {
-			_, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo")
-			g.Assert(err).IsNotNil()
-			g.Assert(err.Error()).Equal("input foo is neither in CURIE format (prefix:value) nor a URI")
-		})
-		g.It("should return curie for uri with known namespace", func() {
-			res, err := Lookup{namespaces: mockNamespaces}.asCURIE("http://foo/bar")
-			g.Assert(err).IsNil()
-			g.Assert(res).Equal(types.CURIE("foo:bar"))
-		})
-		g.It("should fail valid uri string with unknown namespace", func() {
-			_, err := Lookup{namespaces: mockNamespaces}.asCURIE("http://hello/world")
-			g.Assert(err).IsNotNil()
-			g.Assert(err.Error()).Equal("unknown namespace")
-		})
-	})
+func TestEntity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "service/Entity Suite")
 }
 
-func TestLookup_internalIdForCURIE(t *testing.T) {
-}
+var _ = Describe("asCURIE", func() {
+	mockNamespaces := namespace.NewManager(nsMock{})
+	It("should return curie for valid curie string", func() {
+		res, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo:bar")
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(types.CURIE("foo:bar")))
+	})
+	It("should fail valid curie string with unknown prefix", func() {
+		_, err := Lookup{namespaces: mockNamespaces}.asCURIE("hello:world")
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("unknown prefix"))
+	})
+	It("should return for curie with prefix only", func() {
+		res, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo:")
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(types.CURIE("foo:")))
+	})
+	It("should fail simple string", func() {
+		_, err := Lookup{namespaces: mockNamespaces}.asCURIE("foo")
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("input foo is neither in CURIE format (prefix:value) nor a URI"))
+	})
+	It("should return curie for uri with known namespace", func() {
+		res, err := Lookup{namespaces: mockNamespaces}.asCURIE("http://foo/bar")
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(types.CURIE("foo:bar")))
+	})
+	It("should fail valid uri string with unknown namespace", func() {
+		_, err := Lookup{namespaces: mockNamespaces}.asCURIE("http://hello/world")
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("unknown namespace"))
+	})
+})

--- a/internal/testutil.go
+++ b/internal/testutil.go
@@ -14,10 +14,12 @@
 
 package internal
 
-import "testing"
+import (
+	"go.uber.org/fx/fxtest"
+)
 
 type FxLogger struct {
-	t      testing.TB
+	t      fxtest.TB
 	active bool
 }
 
@@ -35,6 +37,6 @@ func (l *FxLogger) Logf(f string, a ...interface{}) {
 	}
 }
 
-func FxTestLog(t testing.TB, active bool) *FxLogger {
+func FxTestLog(t fxtest.TB, active bool) *FxLogger {
 	return &FxLogger{t: t, active: active}
 }

--- a/security_integration_test.go
+++ b/security_integration_test.go
@@ -25,544 +25,538 @@ import (
 	"testing"
 	"time"
 
-	"github.com/franela/goblin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/fx"
 
 	"github.com/mimiro-io/datahub"
 	"github.com/mimiro-io/datahub/internal/security"
 )
 
-func TestNodeSecurity(t *testing.T) {
-	g := goblin.Goblin(t)
+func TestFromOutside(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Intgration Suite")
+}
 
+var _ = Describe("The dataset endpoint", Ordered, func() {
 	var app *fx.App
 
 	location := "./node_security_integration_test"
 	securityLocation := "./node_security_integration_test_clients"
 	datahubURL := "http://localhost:24998/"
-
-	g.Describe("The dataset endpoint", func() {
-		g.Before(func() {
-			_ = os.RemoveAll(location)
-			_ = os.RemoveAll(securityLocation)
-			_ = os.Setenv("STORE_LOCATION", location)
-			_ = os.Setenv("PROFILE", "test")
-			_ = os.Setenv("SERVER_PORT", "24998")
-
-			_ = os.Setenv("AUTHORIZATION_MIDDLEWARE", "local")
-			_ = os.Setenv("ADMIN_USERNAME", "admin")
-			_ = os.Setenv("ADMIN_PASSWORD", "admin")
-			_ = os.Setenv("ENABLE_NODE_SECURITY", "true")
-			_ = os.Setenv("NODE_ID", "node1")
-			_ = os.Setenv("SECURITY_STORAGE_LOCATION", securityLocation)
-			_ = os.Setenv("DL_JWT_CLIENT_ID", "dummy_provider")
-
-			oldOut := os.Stdout
-			oldErr := os.Stderr
-			devNull, _ := os.Open("/dev/null")
-			os.Stdout = devNull
-			os.Stderr = devNull
-			app, _ = datahub.Start(context.Background())
-			os.Stdout = oldOut
-			os.Stderr = oldErr
-		})
-		g.After(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-			err := app.Stop(ctx)
-			defer cancel()
-			g.Assert(err).IsNil()
-			err = os.RemoveAll(location)
-			g.Assert(err).IsNil()
-			err = os.RemoveAll(securityLocation)
-			g.Assert(err).IsNil()
-			_ = os.Unsetenv("STORE_LOCATION")
-			_ = os.Unsetenv("PROFILE")
-			_ = os.Unsetenv("SERVER_PORT")
-
-			_ = os.Unsetenv("AUTHORIZATION_MIDDLEWARE")
-			_ = os.Unsetenv("ADMIN_USERNAME")
-			_ = os.Unsetenv("ADMIN_PASSWORD")
-			_ = os.Unsetenv("ENABLE_NODE_SECURITY")
-			_ = os.Unsetenv("NODE_ID")
-			_ = os.Unsetenv("SECURITY_STORAGE_LOCATION")
-		})
-
-		g.It("Should authenticate with admin credentials", func() {
-			g.Timeout(15 * time.Minute)
-
-			// create new dataset
-			data := url.Values{}
-			data.Set("grant_type", "client_credentials")
-			data.Set("client_id", "admin")
-			data.Set("client_secret", "admin")
-
-			reqURL := datahubURL + "security/token"
-			res, err := http.PostForm(reqURL, data)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotZero()
-			g.Assert(res.StatusCode).Eql(200)
-
-			decoder := json.NewDecoder(res.Body)
-			response := make(map[string]interface{})
-			err = decoder.Decode(&response)
-			g.Assert(err).IsNil()
-			token := response["access_token"].(string)
-			g.Assert(token).IsNotNil()
-
-			// check JWT valid for endpoint access (also tests the admin role)
-			reqURL = datahubURL + "datasets"
-			client := &http.Client{}
-			req, _ := http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-		})
-
-		g.It("Should support admin control over data structures", func() {
-			g.Timeout(15 * time.Minute)
-
-			// create new dataset
-			data := url.Values{}
-			data.Set("grant_type", "client_credentials")
-			data.Set("client_id", "admin")
-			data.Set("client_secret", "admin")
-
-			reqURL := datahubURL + "security/token"
-			res, err := http.PostForm(reqURL, data)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotZero()
-			g.Assert(res.StatusCode).Eql(200)
-
-			decoder := json.NewDecoder(res.Body)
-			response := make(map[string]interface{})
-			err = decoder.Decode(&response)
-			g.Assert(err).IsNil()
-			token := response["access_token"].(string)
-			g.Assert(token).IsNotNil()
-
-			// check JWT valid for endpoint access (also tests the admin role)
-			reqURL = datahubURL + "datasets"
-			client := &http.Client{}
-			req, _ := http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// register new client
-			clientInfo := &security.ClientInfo{}
-			clientInfo.ClientID = "client1"
-			_, publicKey := security.GenerateRsaKeyPair()
-			publicKeyPem, err := security.ExportRsaPublicKeyAsPem(publicKey)
-			g.Assert(err).IsNil()
-			clientInfo.PublicKey = []byte(publicKeyPem)
-
-			clientJSON, err := json.Marshal(clientInfo)
-			g.Assert(err).IsNil()
-
-			reqURL = datahubURL + "security/clients"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(clientJSON))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// get list of registered clients
-			reqURL = datahubURL + "security/clients"
-			client = &http.Client{}
-			req, _ = http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-			clientData, err := io.ReadAll(res.Body)
-			g.Assert(err).IsNil()
-			var clients map[string]*security.ClientInfo
-			err = json.Unmarshal(clientData, &clients)
-			g.Assert(err).IsNil()
-
-			g.Assert(len(clients)).Equal(1)
-			g.Assert(clients["client1"].PublicKey).Equal([]byte(publicKeyPem))
-
-			// delete client
-			clientInfo = &security.ClientInfo{}
-			clientInfo.ClientID = "client1"
-			clientInfo.Deleted = true
-			clientJSON, err = json.Marshal(clientInfo)
-			g.Assert(err).IsNil()
-
-			reqURL = datahubURL + "security/clients"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(clientJSON))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// get clients and check client1 is not there
-			reqURL = datahubURL + "security/clients"
-			client = &http.Client{}
-			req, _ = http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			clientData, err = io.ReadAll(res.Body)
-			g.Assert(err).IsNil()
-			// cd := string(clientData)
-			// cd = cd + ""
-			var deletedClients map[string]*security.ClientInfo
-			err = json.Unmarshal(clientData, &deletedClients)
-			g.Assert(err).IsNil()
-			g.Assert(len(deletedClients)).Equal(0)
-
-			// register client acls
-			acls := make([]*security.AccessControl, 0)
-			acl1 := &security.AccessControl{}
-			acl1.Action = "read"
-			acl1.Resource = "/datasets"
-			acls = append(acls, acl1)
-			aclJSON, err := json.Marshal(acls)
-			g.Assert(err).IsNil()
-
-			reqURL = datahubURL + "security/clients/client1/acl"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(aclJSON))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// fetch client acls
-			reqURL = datahubURL + "security/clients/client1/acl"
-			client = &http.Client{}
-			req, _ = http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			clientData, err = io.ReadAll(res.Body)
-			g.Assert(err).IsNil()
-			var clientacls []*security.AccessControl
-			err = json.Unmarshal(clientData, &clientacls)
-			g.Assert(err).IsNil()
-			g.Assert(len(clientacls)).Equal(1)
-
-			// clear client acls
-			reqURL = datahubURL + "security/clients/client1/acl"
-			client = &http.Client{}
-			req, _ = http.NewRequest("DELETE", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// register client roles
-			reqURL = datahubURL + "security/clients/client1/acl"
-			client = &http.Client{}
-			req, _ = http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			clientData, err = io.ReadAll(res.Body)
-			g.Assert(err).IsNil()
-			var deletedeclientacls []*security.AccessControl
-			err = json.Unmarshal(clientData, &deletedeclientacls)
-			g.Assert(err).IsNil()
-			g.Assert(len(deletedeclientacls)).Equal(0)
-		})
-		g.It("Should register client and allow access", func() {
-			g.Timeout(15 * time.Minute)
-
-			// get jwt for admin
-			data := url.Values{}
-			data.Set("grant_type", "client_credentials")
-			data.Set("client_id", "admin")
-			data.Set("client_secret", "admin")
-
-			reqURL := datahubURL + "security/token"
-			res, err := http.PostForm(reqURL, data)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotZero()
-			g.Assert(res.StatusCode).Eql(200)
-
-			decoder := json.NewDecoder(res.Body)
-			response := make(map[string]interface{})
-			err = decoder.Decode(&response)
-			g.Assert(err).IsNil()
-			token := response["access_token"].(string)
-			g.Assert(token).IsNotNil()
-
-			// check JWT valid for endpoint access (also tests the admin role)
-			reqURL = datahubURL + "datasets"
-			client := &http.Client{}
-			req, _ := http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// register new client
-			clientInfo := &security.ClientInfo{}
-			clientInfo.ClientID = "client1"
-			clientPrivateKey, publicKey := security.GenerateRsaKeyPair()
-			publicKeyPem, err := security.ExportRsaPublicKeyAsPem(publicKey)
-			g.Assert(err).IsNil()
-			clientInfo.PublicKey = []byte(publicKeyPem)
-
-			clientJSON, err := json.Marshal(clientInfo)
-			g.Assert(err).IsNil()
-
-			reqURL = datahubURL + "security/clients"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(clientJSON))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// register client acls
-			acls := make([]*security.AccessControl, 0)
-			acl1 := &security.AccessControl{}
-			acl1.Action = "write"
-			acl1.Resource = "/datasets*"
-			acls = append(acls, acl1)
-			aclJSON, err := json.Marshal(acls)
-			g.Assert(err).IsNil()
-
-			reqURL = datahubURL + "security/clients/client1/acl"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(aclJSON))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// get jwt for client
-			data1 := url.Values{}
-			data1.Set("grant_type", "client_credentials")
-			data1.Set("client_assertion_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
-
-			pem, err := security.CreateJWTForTokenRequest("client1", "node1", clientPrivateKey)
-			g.Assert(err).IsNil()
-			data1.Set("client_assertion", pem)
-
-			reqURL = datahubURL + "security/token"
-			res, err = http.PostForm(reqURL, data1)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotZero()
-			g.Assert(res.StatusCode).Eql(200)
-
-			decoder = json.NewDecoder(res.Body)
-			response = make(map[string]interface{})
-			err = decoder.Decode(&response)
-			g.Assert(err).IsNil()
-			clientToken := response["access_token"].(string)
-			g.Assert(clientToken).IsNotNil()
-
-			// use token to list datasets
-			reqURL = datahubURL + "datasets"
-			client = &http.Client{}
-			req, _ = http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + clientToken},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			jsonraw, _ := io.ReadAll(res.Body)
-			result := make([]map[string]interface{}, 0)
-			err = json.Unmarshal(jsonraw, &result)
-			g.Assert(err).IsNil()
-			g.Assert(len(result) == 1)
-		})
-
-		g.It("Should allow access to self via job and node jwt provider", func() {
-			g.Timeout(15 * time.Minute)
-
-			// get jwt for admin
-			data := url.Values{}
-			data.Set("grant_type", "client_credentials")
-			data.Set("client_id", "admin")
-			data.Set("client_secret", "admin")
-
-			reqURL := datahubURL + "security/token"
-			res, err := http.PostForm(reqURL, data)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotZero()
-			g.Assert(res.StatusCode).Eql(200)
-
-			decoder := json.NewDecoder(res.Body)
-			response := make(map[string]interface{})
-			err = decoder.Decode(&response)
-			g.Assert(err).IsNil()
-			token := response["access_token"].(string)
-			g.Assert(token).IsNotNil()
-
-			// check JWT valid for endpoint access (also tests the admin role)
-			reqURL = datahubURL + "datasets"
-			client := &http.Client{}
-			req, _ := http.NewRequest("GET", reqURL, nil)
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// register this node as a client to itself
-			clientInfo := &security.ClientInfo{}
-			clientInfo.ClientID = "node1"
-
-			// read the node private and public keys for use in this interaction
-			_, err = os.ReadFile(securityLocation + string(os.PathSeparator) + "node_key")
-			g.Assert(err).IsNil()
-			// clientPrivateKey, err := security.ParseRsaPrivateKeyFromPem(content)
-
-			content, err := os.ReadFile(securityLocation + string(os.PathSeparator) + "node_key.pub")
-			g.Assert(err).IsNil()
-			publicKey, err := security.ParseRsaPublicKeyFromPem(content)
-			g.Assert(err).IsNil()
-
-			// clientPrivateKey, publicKey := security.GenerateRsaKeyPair()
-			publicKeyPem, err := security.ExportRsaPublicKeyAsPem(publicKey)
-			g.Assert(err).IsNil()
-			clientInfo.PublicKey = []byte(publicKeyPem)
-
-			clientJSON, err := json.Marshal(clientInfo)
-			g.Assert(err).IsNil()
-
-			reqURL = datahubURL + "security/clients"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(clientJSON))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// register acl for client
-			acls := make([]*security.AccessControl, 0)
-			acl1 := &security.AccessControl{}
-			acl1.Action = "write"
-			acl1.Resource = "/datasets*"
-			acls = append(acls, acl1)
-			aclJSON, err := json.Marshal(acls)
-			g.Assert(err).IsNil()
-
-			reqURL = datahubURL + "security/clients/node1/acl"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(aclJSON))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// register nodetokenprovider
-			providerConfig := &security.ProviderConfig{}
-			providerConfig.Name = "node1provider"
-			providerConfig.Type = "nodebearer"
-			providerConfig.Endpoint = &security.ValueReader{
-				Type:  "text",
-				Value: datahubURL + "security/token",
-			}
-			providerConfig.Audience = &security.ValueReader{
-				Type:  "text",
-				Value: "node1",
-			}
-
-			providerJSON, err := json.Marshal(providerConfig)
-			g.Assert(err).IsNil()
-			reqURL = datahubURL + "provider/logins"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(providerJSON))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
-
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			// upload job to access remote (loopback) dataset
-			jobJSON := `{
+	BeforeAll(func() {
+		_ = os.RemoveAll(location)
+		_ = os.RemoveAll(securityLocation)
+		_ = os.Setenv("STORE_LOCATION", location)
+		_ = os.Setenv("PROFILE", "test")
+		_ = os.Setenv("SERVER_PORT", "24998")
+
+		_ = os.Setenv("AUTHORIZATION_MIDDLEWARE", "local")
+		_ = os.Setenv("ADMIN_USERNAME", "admin")
+		_ = os.Setenv("ADMIN_PASSWORD", "admin")
+		_ = os.Setenv("ENABLE_NODE_SECURITY", "true")
+		_ = os.Setenv("NODE_ID", "node1")
+		_ = os.Setenv("SECURITY_STORAGE_LOCATION", securityLocation)
+		_ = os.Setenv("DL_JWT_CLIENT_ID", "dummy_provider")
+
+		oldOut := os.Stdout
+		oldErr := os.Stderr
+		devNull, _ := os.Open("/dev/null")
+		os.Stdout = devNull
+		os.Stderr = devNull
+		app, _ = datahub.Start(context.Background())
+		os.Stdout = oldOut
+		os.Stderr = oldErr
+	})
+	AfterAll(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+		err := app.Stop(ctx)
+		defer cancel()
+		Expect(err).To(BeNil())
+		err = os.RemoveAll(location)
+		Expect(err).To(BeNil())
+		err = os.RemoveAll(securityLocation)
+		Expect(err).To(BeNil())
+		_ = os.Unsetenv("STORE_LOCATION")
+		_ = os.Unsetenv("PROFILE")
+		_ = os.Unsetenv("SERVER_PORT")
+
+		_ = os.Unsetenv("AUTHORIZATION_MIDDLEWARE")
+		_ = os.Unsetenv("ADMIN_USERNAME")
+		_ = os.Unsetenv("ADMIN_PASSWORD")
+		_ = os.Unsetenv("ENABLE_NODE_SECURITY")
+		_ = os.Unsetenv("NODE_ID")
+		_ = os.Unsetenv("SECURITY_STORAGE_LOCATION")
+	})
+
+	It("Should authenticate with admin credentials", func(_ SpecContext) {
+		// create new dataset
+		data := url.Values{}
+		data.Set("grant_type", "client_credentials")
+		data.Set("client_id", "admin")
+		data.Set("client_secret", "admin")
+
+		reqURL := datahubURL + "security/token"
+		res, err := http.PostForm(reqURL, data)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeZero())
+		Expect(res.StatusCode).To(Equal(200))
+
+		decoder := json.NewDecoder(res.Body)
+		response := make(map[string]interface{})
+		err = decoder.Decode(&response)
+		Expect(err).To(BeNil())
+		token := response["access_token"].(string)
+		Expect(token).NotTo(BeNil())
+
+		// check JWT valid for endpoint access (also tests the admin role)
+		reqURL = datahubURL + "datasets"
+		client := &http.Client{}
+		req, _ := http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+	}, SpecTimeout(15*time.Minute))
+
+	It("Should support admin control over data structures", func(_ SpecContext) {
+		// create new dataset
+		data := url.Values{}
+		data.Set("grant_type", "client_credentials")
+		data.Set("client_id", "admin")
+		data.Set("client_secret", "admin")
+
+		reqURL := datahubURL + "security/token"
+		res, err := http.PostForm(reqURL, data)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeZero())
+		Expect(res.StatusCode).To(Equal(200))
+
+		decoder := json.NewDecoder(res.Body)
+		response := make(map[string]interface{})
+		err = decoder.Decode(&response)
+		Expect(err).To(BeNil())
+		token := response["access_token"].(string)
+		Expect(token).NotTo(BeNil())
+
+		// check JWT valid for endpoint access (also tests the admin role)
+		reqURL = datahubURL + "datasets"
+		client := &http.Client{}
+		req, _ := http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// register new client
+		clientInfo := &security.ClientInfo{}
+		clientInfo.ClientID = "client1"
+		_, publicKey := security.GenerateRsaKeyPair()
+		publicKeyPem, err := security.ExportRsaPublicKeyAsPem(publicKey)
+		Expect(err).To(BeNil())
+		clientInfo.PublicKey = []byte(publicKeyPem)
+
+		clientJSON, err := json.Marshal(clientInfo)
+		Expect(err).To(BeNil())
+
+		reqURL = datahubURL + "security/clients"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(clientJSON))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// get list of registered clients
+		reqURL = datahubURL + "security/clients"
+		client = &http.Client{}
+		req, _ = http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+		clientData, err := io.ReadAll(res.Body)
+		Expect(err).To(BeNil())
+		var clients map[string]*security.ClientInfo
+		err = json.Unmarshal(clientData, &clients)
+		Expect(err).To(BeNil())
+
+		Expect(len(clients)).To(Equal(1))
+		Expect(clients["client1"].PublicKey).To(Equal([]byte(publicKeyPem)))
+
+		// delete client
+		clientInfo = &security.ClientInfo{}
+		clientInfo.ClientID = "client1"
+		clientInfo.Deleted = true
+		clientJSON, err = json.Marshal(clientInfo)
+		Expect(err).To(BeNil())
+
+		reqURL = datahubURL + "security/clients"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(clientJSON))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// get clients and check client1 is not there
+		reqURL = datahubURL + "security/clients"
+		client = &http.Client{}
+		req, _ = http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		clientData, err = io.ReadAll(res.Body)
+		Expect(err).To(BeNil())
+		// cd := string(clientData)
+		// cd = cd + ""
+		var deletedClients map[string]*security.ClientInfo
+		err = json.Unmarshal(clientData, &deletedClients)
+		Expect(err).To(BeNil())
+		Expect(len(deletedClients)).To(Equal(0))
+
+		// register client acls
+		acls := make([]*security.AccessControl, 0)
+		acl1 := &security.AccessControl{}
+		acl1.Action = "read"
+		acl1.Resource = "/datasets"
+		acls = append(acls, acl1)
+		aclJSON, err := json.Marshal(acls)
+		Expect(err).To(BeNil())
+
+		reqURL = datahubURL + "security/clients/client1/acl"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(aclJSON))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// fetch client acls
+		reqURL = datahubURL + "security/clients/client1/acl"
+		client = &http.Client{}
+		req, _ = http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		clientData, err = io.ReadAll(res.Body)
+		Expect(err).To(BeNil())
+		var clientacls []*security.AccessControl
+		err = json.Unmarshal(clientData, &clientacls)
+		Expect(err).To(BeNil())
+		Expect(len(clientacls)).To(Equal(1))
+
+		// clear client acls
+		reqURL = datahubURL + "security/clients/client1/acl"
+		client = &http.Client{}
+		req, _ = http.NewRequest("DELETE", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// register client roles
+		reqURL = datahubURL + "security/clients/client1/acl"
+		client = &http.Client{}
+		req, _ = http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		clientData, err = io.ReadAll(res.Body)
+		Expect(err).To(BeNil())
+		var deletedeclientacls []*security.AccessControl
+		err = json.Unmarshal(clientData, &deletedeclientacls)
+		Expect(err).To(BeNil())
+		Expect(len(deletedeclientacls)).To(Equal(0))
+	}, SpecTimeout(15*time.Minute))
+	It("Should register client and allow access", func(_ SpecContext) {
+		// get jwt for admin
+		data := url.Values{}
+		data.Set("grant_type", "client_credentials")
+		data.Set("client_id", "admin")
+		data.Set("client_secret", "admin")
+
+		reqURL := datahubURL + "security/token"
+		res, err := http.PostForm(reqURL, data)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeZero())
+		Expect(res.StatusCode).To(Equal(200))
+
+		decoder := json.NewDecoder(res.Body)
+		response := make(map[string]interface{})
+		err = decoder.Decode(&response)
+		Expect(err).To(BeNil())
+		token := response["access_token"].(string)
+		Expect(token).NotTo(BeNil())
+
+		// check JWT valid for endpoint access (also tests the admin role)
+		reqURL = datahubURL + "datasets"
+		client := &http.Client{}
+		req, _ := http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// register new client
+		clientInfo := &security.ClientInfo{}
+		clientInfo.ClientID = "client1"
+		clientPrivateKey, publicKey := security.GenerateRsaKeyPair()
+		publicKeyPem, err := security.ExportRsaPublicKeyAsPem(publicKey)
+		Expect(err).To(BeNil())
+		clientInfo.PublicKey = []byte(publicKeyPem)
+
+		clientJSON, err := json.Marshal(clientInfo)
+		Expect(err).To(BeNil())
+
+		reqURL = datahubURL + "security/clients"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(clientJSON))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// register client acls
+		acls := make([]*security.AccessControl, 0)
+		acl1 := &security.AccessControl{}
+		acl1.Action = "write"
+		acl1.Resource = "/datasets*"
+		acls = append(acls, acl1)
+		aclJSON, err := json.Marshal(acls)
+		Expect(err).To(BeNil())
+
+		reqURL = datahubURL + "security/clients/client1/acl"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(aclJSON))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// get jwt for client
+		data1 := url.Values{}
+		data1.Set("grant_type", "client_credentials")
+		data1.Set("client_assertion_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+
+		pem, err := security.CreateJWTForTokenRequest("client1", "node1", clientPrivateKey)
+		Expect(err).To(BeNil())
+		data1.Set("client_assertion", pem)
+
+		reqURL = datahubURL + "security/token"
+		res, err = http.PostForm(reqURL, data1)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeZero())
+		Expect(res.StatusCode).To(Equal(200))
+
+		decoder = json.NewDecoder(res.Body)
+		response = make(map[string]interface{})
+		err = decoder.Decode(&response)
+		Expect(err).To(BeNil())
+		clientToken := response["access_token"].(string)
+		Expect(clientToken).NotTo(BeNil())
+
+		// use token to list datasets
+		reqURL = datahubURL + "datasets"
+		client = &http.Client{}
+		req, _ = http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + clientToken},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		jsonraw, _ := io.ReadAll(res.Body)
+		result := make([]map[string]interface{}, 0)
+		err = json.Unmarshal(jsonraw, &result)
+		Expect(err).To(BeNil())
+		Expect(len(result) == 1)
+	}, SpecTimeout(15*time.Minute))
+
+	It("Should allow access to self via job and node jwt provider", func(_ SpecContext) {
+		// get jwt for admin
+		data := url.Values{}
+		data.Set("grant_type", "client_credentials")
+		data.Set("client_id", "admin")
+		data.Set("client_secret", "admin")
+
+		reqURL := datahubURL + "security/token"
+		res, err := http.PostForm(reqURL, data)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeZero())
+		Expect(res.StatusCode).To(Equal(200))
+
+		decoder := json.NewDecoder(res.Body)
+		response := make(map[string]interface{})
+		err = decoder.Decode(&response)
+		Expect(err).To(BeNil())
+		token := response["access_token"].(string)
+		Expect(token).NotTo(BeNil())
+
+		// check JWT valid for endpoint access (also tests the admin role)
+		reqURL = datahubURL + "datasets"
+		client := &http.Client{}
+		req, _ := http.NewRequest("GET", reqURL, nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// register this node as a client to itself
+		clientInfo := &security.ClientInfo{}
+		clientInfo.ClientID = "node1"
+
+		// read the node private and public keys for use in this interaction
+		_, err = os.ReadFile(securityLocation + string(os.PathSeparator) + "node_key")
+		Expect(err).To(BeNil())
+		// clientPrivateKey, err := security.ParseRsaPrivateKeyFromPem(content)
+
+		content, err := os.ReadFile(securityLocation + string(os.PathSeparator) + "node_key.pub")
+		Expect(err).To(BeNil())
+		publicKey, err := security.ParseRsaPublicKeyFromPem(content)
+		Expect(err).To(BeNil())
+
+		// clientPrivateKey, publicKey := security.GenerateRsaKeyPair()
+		publicKeyPem, err := security.ExportRsaPublicKeyAsPem(publicKey)
+		Expect(err).To(BeNil())
+		clientInfo.PublicKey = []byte(publicKeyPem)
+
+		clientJSON, err := json.Marshal(clientInfo)
+		Expect(err).To(BeNil())
+
+		reqURL = datahubURL + "security/clients"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(clientJSON))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// register acl for client
+		acls := make([]*security.AccessControl, 0)
+		acl1 := &security.AccessControl{}
+		acl1.Action = "write"
+		acl1.Resource = "/datasets*"
+		acls = append(acls, acl1)
+		aclJSON, err := json.Marshal(acls)
+		Expect(err).To(BeNil())
+
+		reqURL = datahubURL + "security/clients/node1/acl"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(aclJSON))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// register nodetokenprovider
+		providerConfig := &security.ProviderConfig{}
+		providerConfig.Name = "node1provider"
+		providerConfig.Type = "nodebearer"
+		providerConfig.Endpoint = &security.ValueReader{
+			Type:  "text",
+			Value: datahubURL + "security/token",
+		}
+		providerConfig.Audience = &security.ValueReader{
+			Type:  "text",
+			Value: "node1",
+		}
+
+		providerJSON, err := json.Marshal(providerConfig)
+		Expect(err).To(BeNil())
+		reqURL = datahubURL + "provider/logins"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer(providerJSON))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		// upload job to access remote (loopback) dataset
+		jobJSON := `{
 			"id" : "sync-from-remote-dataset-with-node-provider",
 			"title" : "sync-from-remote-dataset-with-node-provider",
 			"triggers": [{"triggerType": "cron", "jobType": "incremental", "schedule": "@every 2s"}],
@@ -575,78 +569,77 @@ func TestNodeSecurity(t *testing.T) {
 				"Type" : "DevNullSink"
 			}}`
 
-			reqURL = datahubURL + "jobs"
-			client = &http.Client{}
-			req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer([]byte(jobJSON)))
-			req.Header = http.Header{
-				"Content-Type":  []string{"application/json"},
-				"Authorization": []string{"Bearer " + token},
-			}
+		reqURL = datahubURL + "jobs"
+		client = &http.Client{}
+		req, _ = http.NewRequest("POST", reqURL, bytes.NewBuffer([]byte(jobJSON)))
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
 
-			res, err = client.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(201)
+		res, err = client.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(201))
 
-			// run job
-			req, _ = http.NewRequest("PUT", datahubURL+"job/sync-from-remote-dataset-with-node-provider/run", nil)
+		// run job
+		req, _ = http.NewRequest("PUT", datahubURL+"job/sync-from-remote-dataset-with-node-provider/run", nil)
+		req.Header = http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer " + token},
+		}
+		res, err = http.DefaultClient.Do(req)
+		Expect(err).To(BeNil())
+		Expect(res).NotTo(BeNil())
+		Expect(res.StatusCode).To(Equal(200))
+
+		for {
+			time.Sleep(100 * time.Millisecond)
+			// check job status
+			req, _ = http.NewRequest("GET", datahubURL+"jobs/_/history", nil)
 			req.Header = http.Header{
 				"Content-Type":  []string{"application/json"},
 				"Authorization": []string{"Bearer " + token},
 			}
 			res, err = http.DefaultClient.Do(req)
-			g.Assert(err).IsNil()
-			g.Assert(res).IsNotNil()
-			g.Assert(res.StatusCode).Eql(200)
-
-			for {
-				time.Sleep(100 * time.Millisecond)
-				// check job status
-				req, _ = http.NewRequest("GET", datahubURL+"jobs/_/history", nil)
-				req.Header = http.Header{
-					"Content-Type":  []string{"application/json"},
-					"Authorization": []string{"Bearer " + token},
-				}
-				res, err = http.DefaultClient.Do(req)
-				g.Assert(err).IsNil()
-				g.Assert(res).IsNotNil()
-				g.Assert(res.StatusCode).Eql(200)
-				body, _ := io.ReadAll(res.Body)
-				var hist []map[string]interface{}
-				_ = json.Unmarshal(body, &hist)
-				// t.Log(hist)
-				if len(hist) != 0 {
-					g.Assert(hist[0]["lastError"]).IsZero("no error expected")
-					break
-				}
-
+			Expect(err).To(BeNil())
+			Expect(res).NotTo(BeNil())
+			Expect(res.StatusCode).To(Equal(200))
+			body, _ := io.ReadAll(res.Body)
+			var hist []map[string]interface{}
+			_ = json.Unmarshal(body, &hist)
+			// t.Log(hist)
+			if len(hist) != 0 {
+				Expect(hist[0]["lastError"]).To(BeZero(), "no error expected")
+				break
 			}
+
+		}
+	}, SpecTimeout(15*time.Minute))
+
+	/*
+		It("Should remove client access", func() {
+			// create new dataset
+			res, err := http.Post(datahubURL, "application/json", strings.NewReader(""))
+			Expect(err).To(BeNil(),)
+			Expect(res).NotTo(BeZero(),)
+			Expect(res.StatusCode).To(Equal(200))
 		})
 
-		/*
-			g.It("Should remove client access", func() {
-				// create new dataset
-				res, err := http.Post(datahubURL, "application/json", strings.NewReader(""))
-				g.Assert(err).IsNil()
-				g.Assert(res).IsNotZero()
-				g.Assert(res.StatusCode).Eql(200)
-			})
+		It("Should retain users and acls after restart", func() {
+			// create new dataset
+			res, err := http.Post(datahubURL, "application/json", strings.NewReader(""))
+			Expect(err).To(BeNil(),)
+			Expect(res).NotTo(BeZero(),)
+			Expect(res.StatusCode).To(Equal(200))
+		})
 
-			g.It("Should retain users and acls after restart", func() {
-				// create new dataset
-				res, err := http.Post(datahubURL, "application/json", strings.NewReader(""))
-				g.Assert(err).IsNil()
-				g.Assert(res).IsNotZero()
-				g.Assert(res.StatusCode).Eql(200)
-			})
-
-			g.It("allow roles to be allocated to a client", func() {
-				// create new dataset
-				res, err := http.Post(datahubURL, "application/json", strings.NewReader(""))
-				g.Assert(err).IsNil()
-				g.Assert(res).IsNotZero()
-				g.Assert(res.StatusCode).Eql(200)
-			})
-		*/
-	})
-}
+		It("allow roles to be allocated to a client", func() {
+			// create new dataset
+			res, err := http.Post(datahubURL, "application/json", strings.NewReader(""))
+			Expect(err).To(BeNil(),)
+			Expect(res).NotTo(BeZero(),)
+			Expect(res.StatusCode).To(Equal(200))
+		})
+	*/
+})


### PR DESCRIPTION
migrate to ginkgo test framework.

the builtin go test runner still works, but it is recommended to install the ginkgo binaries (`go install github.com/onsi/ginkgo/v2/ginkgo`), since it gives more concise output. example using `ginkgo ./...`:

![image](https://user-images.githubusercontent.com/674691/234571848-9c69375d-06fd-4fbb-913b-3944bcdb56c5.png)
