### PR TITLE
fix star-query bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/bamzi/jobrunner v1.0.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/dop251/goja v1.0.0
-	github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/gojektech/heimdall/v6 v6.1.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
@@ -30,6 +29,8 @@ replace github.com/dop251/goja => github.com/mimiro-io/goja v1.0.0
 
 require (
 	github.com/lestrrat-go/jwx/v2 v2.0.9
+	github.com/onsi/ginkgo/v2 v2.9.2
+	github.com/onsi/gomega v1.27.6
 	github.com/pkg/errors v0.9.1
 )
 
@@ -71,8 +72,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
-	github.com/onsi/gomega v1.27.6 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf h1:NrF81UtW8gG2LBGkXFQFqlfNnvMt9WdB46sfdJY4oqc=
-github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf/go.mod h1:VzmDKDJVZI3aJmnRI9VjAn9nJ8qPPsN1fqzr9dqInIo=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/internal/server/dataset_test.go
+++ b/internal/server/dataset_test.go
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("A Dataset", func() {
 		_ = env.store.Close()
 		_ = os.RemoveAll(storeLocation)
 	})
-	ginkgo.It("XXX Should accept both single strings and string arrays as refs values", func() {
+	ginkgo.It("Should accept both single strings and string arrays as refs values", func() {
 		// add a first person with all new refs
 		person := NewEntity(env.peopleNamespacePrefix+":person-1", 1)
 		person.Properties[env.peopleNamespacePrefix+":Name"] = "person 1"

--- a/security_integration_test.go
+++ b/security_integration_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestFromOutside(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Intgration Suite")
+	RunSpecs(t, "Integration Suite")
 }
 
 var _ = Describe("The dataset endpoint", Ordered, func() {


### PR DESCRIPTION
when same relation was moved to different predicate in a change, outgoing queries would not always find all active relations. the added test is a case that previously would fail.