### PR TITLE
configure multisource from javascript

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -625,6 +625,77 @@ MultiSource can in incremental jobs emit entities that have not been changed the
 }
 ```
 
+Note that the order of joins in a MultiSource's Dependency configuration is the inverse of the applied query order in transform code.
+
+Example: A source dataset in a job is "person", and the job aims to enrich all person entities using the following queries in a transform.
+
+The first query finds a company that the person has a "worksfor" relation to. The second Query finds a location for the workplace.
+The location is then added to the person entity.
+
+```javascript
+const ns = GetNamespacePrefix("http://example.com/");
+const companies = Query(GetId(e), PrefixField(ns, "worksfor"), false);
+if (companies.length !== 0) {
+    const firstCompany = companies[0][2];
+    const workPlaces = Query(
+        GetId(firstCompany),
+        PrefixField(ns, "address"),
+        false
+    );
+    if (workPlaces.length !== 0) {
+        const firstWorkLocation = workPlaces[0][2];
+        SetProperty(e, ns, "workLocation", GetProperty(firstWorkLocation));
+    }
+}
+```
+
+This is the typical use case for MultiSource: whenever locations or companies change, this job needs to reprocess all persons
+connected to those companies and locations.
+
+MultiSource emits all person entities affected by changes in locations or companies, if we add the following dependency configuration:
+
+```json
+{
+    "source": {
+        "Type": "MultiSource",
+        "Name": "person",
+        "LatestOnly": "true"
+        "Dependencies": [{ "dataset": "location", "joins": [
+            { "dataset": "company", "predicate": "http://example.com/address", "inverse": true },
+            { "dataset": "person", "predicate": "http://example.com/worksfor", "inverse": true }
+        ]}]
+    }
+}
+```
+
+When triggered, MultiSource will find all changed locations first, all compaties pointing to those locations second, and finally
+all persons working for the found companies. These person are emitted from the Source and can now be reprocessed in the jobs transform.
+
+##### MultiSouce dependency registration in javascript.
+
+It is also possible to configure MultiSource dependencies using a special function in a job transform script:
+`function track_queries(start)`
+
+If present in a job's transform script, MultiSource will execute this function, providing a single parameter
+representing the main dataset as starting point for dependency registrations.
+
+The starting object offers the methods `hop(datasetName, relationshipName)` and `iHop(datasetName, relationshipName)`
+for adding dependencies to MultiSource, where `hop` adds datasets connected via outgoing relations,
+and `iHop` adds inverse relations. The relation direction in track_queries is the same as in the applied queries in `transform_entities`.
+
+The above example configuration can be replaced using javascript registations.
+
+```javascript
+function track_queries(start) {
+    start
+        .hop("company", "http://example.com/worksfor")
+        .hop("location", "http://example.com/address");
+}
+```
+
+The json configuration of MultiSource does not need a `Dependencies` part if `track_queries` is used, the
+rest of the source configuration remains the same.
+
 ### Sink Types
 
 The following sink types are used to write data either to a dataset or to a remote datalayer endpoint.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -696,6 +696,29 @@ function track_queries(start) {
 The json configuration of MultiSource does not need a `Dependencies` part if `track_queries` is used, the
 rest of the source configuration remains the same.
 
+##### Many Dependencies
+
+To track changes in many dependent datasets, many configuration objects can be added to the `Dependencies` array when using
+json config.
+
+When using `track_queries`, many dependencies can be added as separate function call chains on the starting object. An example,
+where the `start` parameter again represents a "person" dataset:
+
+```javascript
+function track_queries(start) {
+    // first dependency, from person to home location
+    start.hop("location", "http://example.com/home");
+
+    // 2nd dependency, via all orders that inversely point to a person, to ordered products
+    start
+        .iHop("order", "http://show.web/customer")
+        .hop("product", "http://shop.web/orderItem");
+}
+```
+
+Note that the above example uses `iHop` to denote an inverse dependency. Inverse queries can find a lot of entities
+pointing back to the previous hop, so it is recommended to use [PagedQueries](#pagedquery) in transform code.
+
 ### Sink Types
 
 The following sink types are used to write data either to a dataset or to a remote datalayer endpoint.

--- a/dataset_http_integration_test.go
+++ b/dataset_http_integration_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/mimiro-io/datahub/internal/server"
 )
 
-var _ = Describe("The dataset endpoint", Ordered, func() {
+var _ = Describe("The dataset endpoint", Ordered, Serial, func() {
 	var app *fx.App
 	var mockLayer *MockLayer
 
@@ -557,6 +557,8 @@ var _ = Describe("The dataset endpoint", Ordered, func() {
 	})
 	Describe("The /changes and /entities endpoints for proxy datasets", Ordered, func() {
 		It("Should fetch from remote for GET /changes without token", func() {
+			// TODO: why do we need to GET twice? the first GET does not get the comlete list of namespaces
+			http.Get(proxyDsURL + "/changes")
 			res, err := http.Get(proxyDsURL + "/changes")
 			Expect(err).To(BeNil())
 			Expect(res).NotTo(BeZero())
@@ -571,6 +573,13 @@ var _ = Describe("The dataset endpoint", Ordered, func() {
 			var m []map[string]interface{}
 			_ = json.Unmarshal(b, &m)
 			Expect(m[11]["token"]).To(Equal("nextplease"))
+			Expect(m[0]["namespaces"]).To(Equal(map[string]interface{}{
+				"ns0": "http://data.mimiro.io/core/dataset/",
+				"ns1": "http://data.mimiro.io/core/",
+				"ns2": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+				"ns3": "http://example.com",
+				"ns4": "http://example.mimiro.io/",
+			}))
 		})
 		It("Should fetch from remote for GET /changes with token and limit", func() {
 			res, err := http.Get(proxyDsURL + "/changes?since=theweekend&limit=3")

--- a/internal/jobs/source/multi_source_dep_builder.go
+++ b/internal/jobs/source/multi_source_dep_builder.go
@@ -1,0 +1,193 @@
+package source
+
+import (
+	"errors"
+	"fmt"
+)
+
+type DependencyRegistry interface {
+	Hop(nextDataset string, predicate string) DependencyRegistry
+	IHop(nextDataset string, predicate string) DependencyRegistry
+}
+
+// ParseDependencies populates MultiSource dependencies based on given json config
+func (multiSource *MultiSource) ParseDependencies(
+	dependenciesConfig interface{},
+	transformConfig map[string]any,
+) error {
+	dataset := multiSource.DatasetManager.GetDataset(multiSource.DatasetName)
+	if dataset != nil && dataset.IsProxy() {
+		return fmt.Errorf("main dataset multiSource must not be a proxy dataset: %v", multiSource.DatasetName)
+	}
+
+	// 1. Parse explicit config in job config
+	if dependenciesConfig != nil {
+		if depsList, ok := dependenciesConfig.([]interface{}); ok {
+			for _, dep := range depsList {
+				if m, ok := dep.(map[string]interface{}); ok {
+					newDep := Dependency{}
+					newDep.Dataset = m["dataset"].(string)
+					depDataset := multiSource.DatasetManager.GetDataset(newDep.Dataset)
+					if depDataset != nil && depDataset.IsProxy() {
+						return fmt.Errorf(
+							"dependency dataset %v in multiSource %v must not be a proxy dataset",
+							newDep.Dataset,
+							multiSource.DatasetName,
+						)
+					}
+
+					for _, j := range m["joins"].([]interface{}) {
+						newJoin := Join{}
+						m := j.(map[string]interface{})
+						newJoin.Dataset = m["dataset"].(string)
+						newJoin.Predicate = m["predicate"].(string)
+						newJoin.Inverse = m["inverse"].(bool)
+						newDep.Joins = append(newDep.Joins, newJoin)
+					}
+					multiSource.Dependencies = append(multiSource.Dependencies, newDep)
+				} else {
+					return fmt.Errorf("dependency %+v must be json object structure, but is %t ", dep, dep)
+				}
+			}
+		} else {
+			return errors.New("dependenciesConfig must be array array")
+		}
+	}
+	// 2. Add dependency tracking from transform code
+	if transformConfig != nil && transformConfig["Type"] == "JavascriptTransform" && transformConfig["Code"] != nil {
+		multiSource.depRegistries = []DependencyRegistry{}
+		if multiSource.AddTransformDeps == nil {
+			return errors.New("AddTransformDeps function must be injected during MultiSource initialization")
+		}
+		code64 := transformConfig["Code"]
+		// AddTransformDeps function definition must be injected during MultiSource initialization,
+		// avoiding circular dependency
+		// AddTransformDeps calls the js function "track_queries" in transform code
+		err := multiSource.AddTransformDeps(code64.(string), multiSource)
+		if err != nil {
+			return err
+		}
+		/*
+			`[{"dataset": "product",
+			   "joins": [{"dataset": "order", "predicate": "product-ordered", "inverse": true},
+			             {"dataset": "person", "predicate": "ordering-customer", "inverse": false}]}]`,
+		*/
+		depConfig := []any{}
+		for _, dep := range multiSource.depRegistries {
+			o := map[string]any{}
+			o["joins"] = make([]any, 0)
+			join := dep.(*DependencyRegistryJoin)
+			prevDs := multiSource.DatasetName
+			for {
+				insertArr := []any{map[string]any{
+					"dataset":   prevDs,
+					"predicate": join.Predicate,
+					"inverse":   !join.Inverse,
+				}}
+				prevDs = join.Dataset
+				o["joins"] = append(insertArr, o["joins"].([]any)...)
+				if join.next == nil {
+					break
+				}
+				join = join.next
+			}
+			o["dataset"] = join.Dataset
+			depConfig = append(depConfig, o)
+		}
+		err = multiSource.ParseDependencies(depConfig, nil)
+		if err != nil {
+			return err
+		}
+		// fmt.Println(multiSource.depRegistries)
+	}
+
+	multiSource.DedupAndTrackImplicitDependencies()
+	return nil
+}
+
+func (multiSource *MultiSource) DedupAndTrackImplicitDependencies() {
+	// Track implicit dependencies
+	for _, dep := range multiSource.Dependencies {
+		for i, join := range dep.Joins {
+			depDataset := multiSource.DatasetManager.GetDataset(join.Dataset)
+			if depDataset != nil && depDataset.IsProxy() {
+				continue
+			}
+			if join.Dataset == multiSource.DatasetName {
+				continue
+			}
+			// Track implicit dependency
+			implicitDep := Dependency{}
+			implicitDep.Dataset = join.Dataset
+			implicitDep.Joins = dep.Joins[i+1:]
+			multiSource.Dependencies = append(multiSource.Dependencies, implicitDep)
+		}
+	}
+
+	// Dedup dependencies
+	depMap := map[string]Dependency{}
+	dedupedDependencies := []Dependency{}
+	for _, dep := range multiSource.Dependencies {
+		if _, ok := depMap[dep.Dataset]; !ok {
+			dedupedDependencies = append(dedupedDependencies, dep)
+		}
+		depMap[dep.Dataset] = dep
+	}
+	multiSource.Dependencies = dedupedDependencies
+}
+
+type DependencyRegistryJoin struct {
+	ms        *MultiSource
+	next      *DependencyRegistryJoin
+	Dataset   string
+	Predicate string
+	Inverse   bool
+}
+
+// Hop implements DependencyRegistry
+func (j *DependencyRegistryJoin) Hop(nextDataset string, predicate string) DependencyRegistry {
+	j.next = &DependencyRegistryJoin{
+		ms:        j.ms,
+		next:      nil,
+		Dataset:   nextDataset,
+		Predicate: predicate,
+		Inverse:   false,
+	}
+	return j.next
+}
+
+// IHop implements DependencyRegistry
+func (j *DependencyRegistryJoin) IHop(nextDataset string, predicate string) DependencyRegistry {
+	j.next = &DependencyRegistryJoin{
+		ms:        j.ms,
+		next:      nil,
+		Dataset:   nextDataset,
+		Predicate: predicate,
+		Inverse:   true,
+	}
+	return j.next
+}
+
+func (multiSource *MultiSource) Hop(nextDataset string, predicate string) DependencyRegistry {
+	tail := &DependencyRegistryJoin{
+		ms:        multiSource,
+		next:      nil,
+		Dataset:   nextDataset,
+		Predicate: predicate,
+		Inverse:   false,
+	}
+	multiSource.depRegistries = append(multiSource.depRegistries, tail)
+	return tail
+}
+
+func (multiSource *MultiSource) IHop(nextDataset string, predicate string) DependencyRegistry {
+	tail := &DependencyRegistryJoin{
+		ms:        multiSource,
+		next:      nil,
+		Dataset:   nextDataset,
+		Predicate: predicate,
+		Inverse:   true,
+	}
+	multiSource.depRegistries = append(multiSource.depRegistries, tail)
+	return tail
+}

--- a/internal/jobs/source/multi_source_dep_builder.go
+++ b/internal/jobs/source/multi_source_dep_builder.go
@@ -3,6 +3,7 @@ package source
 import (
 	"errors"
 	"fmt"
+	"strconv"
 )
 
 type DependencyRegistry interface {
@@ -125,13 +126,18 @@ func (multiSource *MultiSource) DedupAndTrackImplicitDependencies() {
 	}
 
 	// Dedup dependencies
-	depMap := map[string]Dependency{}
+	depMap := map[string]bool{}
 	dedupedDependencies := []Dependency{}
 	for _, dep := range multiSource.Dependencies {
-		if _, ok := depMap[dep.Dataset]; !ok {
+		joinsKey := ""
+		for _, join := range dep.Joins {
+			joinsKey += join.Dataset + "|" + join.Predicate + "|" + strconv.FormatBool(join.Inverse)
+		}
+		depKey := dep.Dataset + ">" + joinsKey
+		if _, ok := depMap[depKey]; !ok {
 			dedupedDependencies = append(dedupedDependencies, dep)
 		}
-		depMap[dep.Dataset] = dep
+		depMap[depKey] = true
 	}
 	multiSource.Dependencies = dedupedDependencies
 }

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -190,7 +190,7 @@ var _ = Describe("dependency tracking", func() {
 		srcConfig := map[string]interface{}{}
 		err := json.Unmarshal([]byte(srcJSON), &srcConfig)
 		Expect(err).To(BeNil())
-		err = testSource.ParseDependencies(srcConfig["Dependencies"])
+		err = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 		Expect(err).To(BeNil())
 
 		var recordedEntities []server.Entity
@@ -250,7 +250,7 @@ var _ = Describe("dependency tracking", func() {
 		srcConfig := map[string]interface{}{}
 		err := json.Unmarshal([]byte(srcJSON), &srcConfig)
 		Expect(err).To(BeNil())
-		err = testSource.ParseDependencies(srcConfig["Dependencies"])
+		err = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 		Expect(err).To(BeNil())
 
 		// fullsync
@@ -322,7 +322,7 @@ var _ = Describe("dependency tracking", func() {
 		srcConfig := map[string]interface{}{}
 		err := json.Unmarshal([]byte(srcJSON), &srcConfig)
 		Expect(err).To(BeNil())
-		err = testSource.ParseDependencies(srcConfig["Dependencies"])
+		err = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 		Expect(err).To(BeNil())
 
 		// initial incremental run.
@@ -388,7 +388,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -490,7 +490,7 @@ var _ = Describe("dependency tracking", func() {
 		srcConfig := map[string]interface{}{}
 		err := json.Unmarshal([]byte(srcJSON), &srcConfig)
 		Expect(err).To(BeNil())
-		err = testSource.ParseDependencies(srcConfig["Dependencies"])
+		err = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 		Expect(err).To(BeNil())
 
 		// fullsync
@@ -592,7 +592,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -659,7 +659,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -718,7 +718,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -790,7 +790,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -894,7 +894,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -996,7 +996,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -1149,7 +1149,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -1232,7 +1232,7 @@ var _ = Describe("dependency tracking", func() {
 
 		srcConfig := map[string]interface{}{}
 		_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-		_ = testSource.ParseDependencies(srcConfig["Dependencies"])
+		_ = testSource.ParseDependencies(srcConfig["Dependencies"], nil)
 
 		// fullsync
 		var recordedEntities []server.Entity
@@ -1283,132 +1283,6 @@ var _ = Describe("dependency tracking", func() {
 		Expect(recordedEntities[0].ID).To(Equal(peoplePrefix + ":Bob"))
 		Expect(recordedEntities[0].Properties["name"]).
 			To(Equal("Bob"), "Bob exists in two datasets. making sure we dont get a merged result")
-	})
-
-	Describe("parseDependencies", func() {
-		It("should translate json to config", func() {
-			s := source.MultiSource{DatasetName: "person", Store: store, DatasetManager: dsm}
-			srcJSON := `{
-				"Type" : "MultiSource",
-				"Name" : "person",
-				"Dependencies": [
-					{
-						"dataset": "product",
-						"joins": [
-							{
-								"dataset": "order",
-								"predicate": "product-ordered",
-								"inverse": true
-							},
-							{
-								"dataset": "person",
-								"predicate": "ordering-customer",
-								"inverse": false
-							}
-						]
-					},
-					{
-						"dataset": "order",
-						"joins": [
-							{
-								"dataset": "person",
-								"predicate": "ordering-customer",
-								"inverse": false
-							}
-						]
-					}
-				]
-			}`
-
-			srcConfig := map[string]interface{}{}
-			err := json.Unmarshal([]byte(srcJSON), &srcConfig)
-			Expect(err).To(BeNil())
-			err = s.ParseDependencies(srcConfig["Dependencies"])
-			Expect(err).To(BeNil())
-
-			Expect(s.Dependencies).NotTo(BeZero())
-			Expect(len(s.Dependencies)).To(Equal(2))
-
-			dep := s.Dependencies[0]
-			Expect(dep.Dataset).To(Equal("product"))
-			Expect(dep.Joins).NotTo(BeZero())
-			Expect(len(dep.Joins)).To(Equal(2))
-			j := dep.Joins[0]
-			Expect(j.Dataset).To(Equal("order"))
-			Expect(j.Predicate).To(Equal("product-ordered"))
-			Expect(j.Inverse).To(BeTrue())
-			j = dep.Joins[1]
-			Expect(j.Dataset).To(Equal("person"))
-			Expect(j.Predicate).To(Equal("ordering-customer"))
-			Expect(j.Inverse).To(BeFalse())
-
-			dep = s.Dependencies[1]
-			Expect(dep.Dataset).To(Equal("order"))
-			Expect(dep.Joins).NotTo(BeZero())
-			Expect(len(dep.Joins)).To(Equal(1))
-			j = dep.Joins[0]
-			Expect(j.Dataset).To(Equal("person"))
-			Expect(j.Predicate).To(Equal("ordering-customer"))
-			Expect(j.Inverse).To(BeFalse())
-		})
-		It("Should fail if main dataset is proxy dataset", func() {
-			// create main dataset as proxy dataset
-			_, err := dsm.CreateDataset("people", &server.CreateDatasetConfig{
-				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteURL: "http://localhost:7777/datasets/people",
-				},
-			})
-			Expect(err).To(BeNil())
-
-			// now instantiate (simulating job start)
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
-                          {
-							"dataset": "address",
-							"joins": [
-							  { "dataset": "office", "predicate": "http://office/location", "inverse": true },
-							  { "dataset": "people", "predicate": "http://office/contact", "inverse": false },
-							  { "dataset": "team", "predicate": "http://team/lead", "inverse": true },
-							  { "dataset": "people", "predicate": "http://team/member", "inverse": false }
-							]
-                          }
-                        ] }`
-
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			err = testSource.ParseDependencies(srcConfig["Dependencies"])
-			// t.Log(err)
-			Expect(err).NotTo(BeNil())
-		})
-		It("Should fail if a dependency is a proxy dataset", func() {
-			// create dependency dataset as proxy dataset
-			_, err := dsm.CreateDataset("address", &server.CreateDatasetConfig{
-				ProxyDatasetConfig: &server.ProxyDatasetConfig{
-					RemoteURL: "http://localhost:7777/datasets/address",
-				},
-			})
-			Expect(err).To(BeNil())
-
-			// now instantiate (simulating job start)
-			testSource := source.MultiSource{DatasetName: "people", Store: store, DatasetManager: dsm}
-			srcJSON := `{ "Type" : "MultiSource", "Name" : "people", "Dependencies": [
-                          {
-							"dataset": "address",
-							"joins": [
-							  { "dataset": "office", "predicate": "http://office/location", "inverse": true },
-							  { "dataset": "people", "predicate": "http://office/contact", "inverse": false },
-							  { "dataset": "team", "predicate": "http://team/lead", "inverse": true },
-							  { "dataset": "people", "predicate": "http://team/member", "inverse": false }
-							]
-                          }
-                        ] }`
-
-			srcConfig := map[string]interface{}{}
-			_ = json.Unmarshal([]byte(srcJSON), &srcConfig)
-			err = testSource.ParseDependencies(srcConfig["Dependencies"])
-			// t.Log(err)
-			Expect(err).NotTo(BeNil())
-		})
 	})
 })
 

--- a/internal/jobs/source/multi_source_test.go
+++ b/internal/jobs/source/multi_source_test.go
@@ -512,7 +512,7 @@ var _ = Describe("dependency tracking", func() {
 		Expect(err).To(BeNil())
 		testSource.EndFullSync()
 
-		// modify Mainstreet address and verify that nothing changed (address is not a dependency, just a join)
+		// modify Mainstreet address and verify that address is implicitly tracked
 		err = addresses.StoreEntities([]*server.Entity{
 			server.NewEntityFromMap(map[string]interface{}{
 				"id":    addressPrefix + ":Mainstreet",
@@ -534,7 +534,7 @@ var _ = Describe("dependency tracking", func() {
 			},
 		)
 		Expect(err).To(BeNil())
-		Expect(len(recordedEntities)).To(Equal(0))
+		Expect(len(recordedEntities)).To(Equal(1))
 
 		// now, modify Oslo city and verify that bob is found via Mainstreet address
 		err = cities.StoreEntities([]*server.Entity{


### PR DESCRIPTION
This change makes it possible to configure MultiSource from javascript. MultiSource looks for a function called `track_queries` in a jobs transform script, and provides a registy object as parameter when it calls this function.

job writers can then use `hop` and `iHop` on the starting object to add dependency configuration.

closes #235 