### PR TITLE
ensure incremental runs of multisource jobs dont panic

### DIFF
--- a/internal/jobs/source/multi_source.go
+++ b/internal/jobs/source/multi_source.go
@@ -173,9 +173,14 @@ func (multiSource *MultiSource) processDependency(dep Dependency, d *MultiDatase
 	}
 	d.activeDS = dep.Dataset
 
+	if d.DependencyTokens == nil {
+		d.DependencyTokens = make(map[string]*StringDatasetContinuation)
+	}
+
 	depSince := d.DependencyTokens[d.activeDS]
 	if depSince == nil {
 		depSince = &StringDatasetContinuation{}
+		d.DependencyTokens[d.activeDS] = depSince
 	}
 
 	// When working through a dependency dataset, we first find all changes since the last run in that dependency
@@ -341,10 +346,6 @@ func (multiSource *MultiSource) processDependency(dep Dependency, d *MultiDatase
 				}
 			}
 		}
-	}
-
-	if d.DependencyTokens == nil {
-		d.DependencyTokens = make(map[string]*StringDatasetContinuation)
 	}
 
 	d.DependencyTokens[dep.Dataset] = &StringDatasetContinuation{Token: strconv.Itoa(int(continuation))}

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -62,7 +62,7 @@ var _ = Describe("The Eventbus", func() {
 		e := &conf.Env{
 			Logger:        zap.NewNop().Sugar(),
 			StoreLocation: storeLocation,
-			Port:          "5555",
+			Port:          "25555",
 			Auth:          &conf.AuthConfig{Middleware: "noop"},
 			RunnerConfig:  &conf.RunnerConfig{PoolIncremental: 10, PoolFull: 5},
 		}
@@ -135,7 +135,7 @@ var _ = Describe("The Eventbus", func() {
 				{ "id" : "homer" }
             ]`)
 
-		_, err := http.Post("http://localhost:5555/datasets/people/entities", "application/json", reader)
+		_, err := http.Post("http://localhost:25555/datasets/people/entities", "application/json", reader)
 		Expect(err).To(BeNil())
 		wg.Wait()
 		Expect(eventReceived).To(BeTrue())


### PR DESCRIPTION
When the result of a dependency check exceeded the job batch size in the first ever processing of said dependency, this could lead to a panic