### PR TITLE
always do first multisource job run as fullsync

### DIFF
--- a/internal/server/dataset.go
+++ b/internal/server/dataset.go
@@ -1025,8 +1025,7 @@ func (ds *Dataset) ProcessChangesRaw(
 	lastSeen := since
 	foundChanges := false
 
-	err := ds.store.database.View(func(btxn *badger.Txn) error {
-		txn := InstrumentedTxn(btxn, ds.store)
+	err := ds.store.database.View(func(txn *badger.Txn) error {
 		searchBuffer := make([]byte, 14)
 		binary.BigEndian.PutUint16(searchBuffer, DatasetEntityChangeLog)
 		binary.BigEndian.PutUint32(searchBuffer[2:], ds.InternalID)
@@ -1080,7 +1079,7 @@ func (ds *Dataset) ProcessChangesRaw(
 	}
 }
 
-func latestOnlyWrapper(k []byte, ds *Dataset, txn *InstrumentedTransaction,
+func latestOnlyWrapper(k []byte, ds *Dataset, txn *badger.Txn,
 	next func(entityChangeID []byte) error,
 ) func(entityChangeID []byte) error {
 	return func(entityChangeID []byte) error {


### PR DESCRIPTION
Solves #256 

- also avoid querying back in time when this is the first job run. this path should not be take when doing fullsync (which now is always the case with first runs) anyway, but for good measure.
- remove iterator instrumentation for performance