### PR TITLE
Feature/63/include dataset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
-	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
@@ -91,5 +90,6 @@ require (
 	golang.org/x/tools v0.12.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -686,8 +686,7 @@ google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/internal/jobs/source/multi_source.go
+++ b/internal/jobs/source/multi_source.go
@@ -336,7 +336,7 @@ func (multiSource *MultiSource) processDependency(ctx context.Context, dep Depen
 							// a new API function which includes the target dataset in the bagder search key this would be more performant in
 							// cases where the ID exists in many datasets. Even better if we can have an API function version that allows
 							// reuse of a common read transaction.
-							mainEntity, err4 := multiSource.Store.GetEntityWithInternalID(e, targetDs)
+							mainEntity, err4 := multiSource.Store.GetEntityWithInternalID(e, targetDs, true)
 							if err4 != nil {
 								return fmt.Errorf("could not load entity %+v from dataset %v: %w", e, multiSource.DatasetName, err4)
 							}

--- a/internal/jobs/transform.go
+++ b/internal/jobs/transform.go
@@ -401,7 +401,7 @@ func (javascriptTransform *JavascriptTransform) Query(
 	datasets []string,
 ) [][]interface{} {
 	ts := time.Now()
-	results, err := javascriptTransform.Store.GetManyRelatedEntities(startingEntities, predicate, inverse, datasets)
+	results, err := javascriptTransform.Store.GetManyRelatedEntities(startingEntities, predicate, inverse, datasets, true)
 	_ = javascriptTransform.statsDClient.Timing("transform.Query.time",
 		time.Since(ts), javascriptTransform.statsDTags, 1)
 	if err != nil {
@@ -453,7 +453,7 @@ func (javascriptTransform *JavascriptTransform) PagedQuery(
 		}
 
 		ts := time.Now()
-		results, err := javascriptTransform.Store.GetManyRelatedEntitiesAtTime(conts, pageSize)
+		results, err := javascriptTransform.Store.GetManyRelatedEntitiesAtTime(conts, pageSize, true)
 		_ = javascriptTransform.statsDClient.Timing(
 			"transform.Query.time", time.Since(ts), javascriptTransform.statsDTags, 1)
 
@@ -483,7 +483,7 @@ func (javascriptTransform *JavascriptTransform) PagedQuery(
 
 func (javascriptTransform *JavascriptTransform) ByID(entityID string, datasets []string) *server.Entity {
 	ts := time.Now()
-	entity, err := javascriptTransform.Store.GetEntity(entityID, datasets)
+	entity, err := javascriptTransform.Store.GetEntity(entityID, datasets, true)
 	_ = javascriptTransform.statsDClient.Timing("transform.ById.time",
 		time.Since(ts), javascriptTransform.statsDTags, 1)
 	if err != nil {

--- a/internal/server/dataset.go
+++ b/internal/server/dataset.go
@@ -768,6 +768,7 @@ func (ds *Dataset) updateDataset(newItemCount int64, entities []*Entity) error {
 						return err
 					}
 					ds.store.datasets.Store(dataset.ID, dataset)
+					ds.store.datasetsByInternalID.Store(dataset.InternalID, dataset)
 				}
 			}
 		}
@@ -779,7 +780,7 @@ func (ds *Dataset) updateDataset(newItemCount int64, entities []*Entity) error {
 		// limit scope to core.Dataset, to avoid unlikely but possible
 		// bleeding in of properties from other datasets (partial merges)
 		datasets := []string{"core.Dataset"}
-		dsEntity, err := ds.store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, ds.ID), datasets)
+		dsEntity, err := ds.store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, ds.ID), datasets, true)
 		if err != nil {
 			return err
 		}

--- a/internal/server/dataset_test.go
+++ b/internal/server/dataset_test.go
@@ -94,7 +94,7 @@ var _ = ginkgo.Describe("A Dataset", func() {
 		Expect(err).To(BeNil(), "Expected entity to be stored without error")
 		// query
 		queryIds := []string{"http://data.mimiro.io/people/person-1"}
-		result, err := env.store.GetManyRelatedEntities(queryIds, "*", false, []string{})
+		result, err := env.store.GetManyRelatedEntities(queryIds, "*", false, []string{}, true)
 		Expect(err).To(BeNil(), "Expected query to succeed")
 
 		var company2Seen, company1Seen bool
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("A Dataset", func() {
 		Expect(err).To(BeNil(), "Expected entity to be stored without error")
 
 		// query
-		result, err = env.store.GetManyRelatedEntities(queryIds, "*", false, []string{})
+		result, err = env.store.GetManyRelatedEntities(queryIds, "*", false, []string{}, true)
 		Expect(err).To(BeNil(), "Expected query to succeed")
 
 		company3Seen := false

--- a/internal/server/garbagecollector_test.go
+++ b/internal/server/garbagecollector_test.go
@@ -143,7 +143,7 @@ var _ = ginkgo.Describe("The GarbageCollector", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -155,7 +155,7 @@ var _ = ginkgo.Describe("The GarbageCollector", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -181,7 +181,7 @@ var _ = ginkgo.Describe("The GarbageCollector", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1), "Expected still to find person-3 as a friend")
@@ -192,7 +192,7 @@ var _ = ginkgo.Describe("The GarbageCollector", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1), "Expected still to find person-2 as reverse friend")
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("The GarbageCollector", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			"*",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -221,7 +221,7 @@ var _ = ginkgo.Describe("The GarbageCollector", func() {
 			[]string{"http://data.mimiro.io/people/person-2"},
 			"*",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))

--- a/internal/server/get_related_test.go
+++ b/internal/server/get_related_test.go
@@ -358,6 +358,25 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
 	})
+	ginkgo.Describe("Should return unified entity with dataset properties", func() {
+		ginkgo.It("two datasets, both active", func() {
+			pref := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
+				{id: 1, friends: []int{2}},
+				{id: 2, friends: []int{}},
+			}))
+			_ = persist("family", store, dsm, buildTestBatch(store, []testPerson{
+				{id: 1, friends: []int{2}},
+				{id: 2, friends: []int{}},
+			}))
+			start := []string{pref + ":person-2"}
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, false)
+			Expect(err).To(BeNil())
+			Expect(queryResult.Relations).To(HaveLen(1))
+			Expect(queryResult.Relations[0].RelatedEntity.Properties["http://data.mimiro.io/core/partials"]).To(HaveLen(2))
+			Expect(queryResult.Relations[0].RelatedEntity.Properties["http://data.mimiro.io/core/partials"].([]any)[0].(*Entity).Properties["http://data.mimiro.io/core/datasetname"]).To(Equal("friends"))
+			Expect(queryResult.Relations[0].RelatedEntity.Properties["http://data.mimiro.io/core/partials"].([]any)[1].(*Entity).Properties["http://data.mimiro.io/core/datasetname"]).To(Equal("family"))
+		})
+	})
 	ginkgo.Describe("Multiple datasets and delete states, here:", func() {
 		ginkgo.It("two datasets, both active", func() {
 			pref := persist("friends", store, dsm, buildTestBatch(store, []testPerson{

--- a/internal/server/get_related_test.go
+++ b/internal/server/get_related_test.go
@@ -67,7 +67,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 1, friends: []int{3, 2, 4}},
 			}))
 			start := []string{peopleNamespacePrefix + ":person-1"}
-			result, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			result, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(result.Cont).To(BeZero())
 			Expect(len(result.Relations)).To(Equal(3), "person-1 points to p2, p3 and (empty) p4")
@@ -78,22 +78,22 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 			Expect(result.Relations[2].RelatedEntity.ID).To(Equal(peopleNamespacePrefix + ":person-2"))
 			Expect(result.Relations[2].RelatedEntity.Recorded).NotTo(BeZero(), "make sure person-2 is an real entity")
 
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 1)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 1, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Cont)).To(Equal(1))
 			Expect(len(result.Relations)).To(Equal(1))
 
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 2)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 2, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Cont)).To(Equal(1))
 			Expect(len(result.Relations)).To(Equal(2))
 
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 3)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 3, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Cont)).To(Equal(0))
 			Expect(len(result.Relations)).To(Equal(3))
 
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 4)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 4, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Cont)).To(Equal(0))
 			Expect(len(result.Relations)).To(Equal(3))
@@ -110,42 +110,42 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 			}))
 			// get everything
 			start := []string{peopleNamespacePrefix + ":person-1", peopleNamespacePrefix + ":person-2"}
-			result, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			result, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Cont)).To(BeZero())
 			// 3 relations from person-1 and 2 relations from person-2
 			Expect(len(result.Relations)).To(Equal(5))
 
 			// limit 1, should return first hit of first startUri
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 1)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 1, true)
 			Expect(err).To(BeNil())
 			// continuations for both startUris expected
 			Expect(len(result.Cont)).To(Equal(2))
 			Expect(len(result.Relations)).To(Equal(1))
 
 			// limit 3, room for all 3 relations of first startUri
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 3)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 3, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Relations)).To(Equal(3))
 			// only continuation for person-2 remains, since first startUri is exhausted
 			Expect(len(result.Cont)).To(Equal(1))
 
 			// limit 4, room for all 3 relations of first startUri plus 1 from other startUri
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 4)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 4, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Relations)).To(Equal(4))
 			// only continuation for person-2 remains, since first startUri is exhausted
 			Expect(len(result.Cont)).To(Equal(1))
 
 			// limit 5, room for all 3 relations of first startUri plus all 2 from other startUri
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 5)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 5, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Relations)).To(Equal(5))
 			// only continuation for person-2 remains, since first startUri is exhausted
 			Expect(len(result.Cont)).To(Equal(0))
 
 			// limit 6, room for all 3 relations of first startUri plus all 2 from other startUri
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 6)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 6, true)
 			Expect(err).To(BeNil())
 			Expect(len(result.Relations)).To(Equal(5))
 			// only continuation for person-2 remains, since first startUri is exhausted
@@ -163,19 +163,19 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 			}))
 			// get everything, p2 points to p1; and p1+p3 point to p2
 			start := []string{peopleNamespacePrefix + ":person-1", peopleNamespacePrefix + ":person-2"}
-			result, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			result, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(result.Cont).To(BeZero())
 			Expect(len(result.Relations)).To(Equal(3))
 			// limit 1, should return first hit of first startUri
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 1)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 1, true)
 			Expect(err).To(BeNil())
 			// person-1 is exhausted, only expect one cont token
 			Expect(len(result.Cont)).To(Equal(1))
 			Expect(len(result.Relations)).To(Equal(1))
 
 			// limit 2, room for all 1 relations of first startUri plus 1 from other startUri
-			result, err = store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 2)
+			result, err = store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 2, true)
 			Expect(err).To(BeNil())
 			// one token for rest of person-2 expected
 			Expect(len(result.Cont)).To(Equal(1))
@@ -188,12 +188,12 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 			{id: 2, friends: []int{11, 12, 13, 14, 15, 16, 17, 18, 19, 20}},
 		}))
 		start := []string{pref + ":person-1", pref + ":person-2"}
-		queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+		queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 		Expect(err).To(BeNil())
 		Expect(len(queryResult.Cont)).To(Equal(0))
 		Expect(len(queryResult.Relations)).To(Equal(19))
 
-		queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 2)
+		queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 2, true)
 		Expect(err).To(BeNil())
 		Expect(len(queryResult.Cont)).To(Equal(2))
 		Expect(len(queryResult.Relations)).To(Equal(2))
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 		Expect(queryResult.Relations[1].RelatedEntity.ID).To(Equal(pref + ":person-9"))
 		Expect(queryResult.Cont[0].RelationIndexFromKey).NotTo(BeNil())
 		startFromCont := queryResult.Cont
-		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 3)
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 3, true)
 		Expect(err).To(BeNil())
 		Expect(len(queryResult.Cont)).To(Equal(2))
 		Expect(len(queryResult.Relations)).To(Equal(3))
@@ -213,13 +213,13 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 		startFromCont = queryResult.Cont
 
 		// get get next 3, leaving exactly 1 result remaining for 1st startURI
-		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 3)
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 3, true)
 		Expect(err).To(BeNil())
 		Expect(len(queryResult.Cont)).To(Equal(2))
 		Expect(len(queryResult.Relations)).To(Equal(3))
 		Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal(pref + ":person-5"))
 		Expect(queryResult.Relations[2].RelatedEntity.ID).To(Equal(pref + ":person-3"))
-		queryResult, err = store.GetManyRelatedEntitiesAtTime(queryResult.Cont, 0)
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(queryResult.Cont, 0, true)
 		Expect(err).To(BeNil())
 		Expect(queryResult.Cont).To(BeNil())
 		Expect(len(queryResult.Relations)).To(Equal(11))
@@ -227,13 +227,13 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 		Expect(queryResult.Relations[10].RelatedEntity.ID).To(Equal(pref + ":person-11"))
 
 		// get all of remaining items from 1st startURI
-		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 4)
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 4, true)
 		Expect(err).To(BeNil())
 		Expect(len(queryResult.Cont)).To(Equal(1), "1st exhausted query, one remaining")
 		Expect(len(queryResult.Relations)).To(Equal(4))
 		Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal(pref + ":person-5"))
 		Expect(queryResult.Relations[3].RelatedEntity.ID).To(Equal(pref + ":person-2"))
-		queryResult, err = store.GetManyRelatedEntitiesAtTime(queryResult.Cont, 0)
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(queryResult.Cont, 0, true)
 		Expect(err).To(BeNil())
 		Expect(queryResult.Cont).To(BeNil())
 		Expect(len(queryResult.Relations)).To(Equal(10))
@@ -241,13 +241,13 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 		Expect(queryResult.Relations[9].RelatedEntity.ID).To(Equal(pref + ":person-11"))
 
 		// get all of remaining items from 1st startURI plus 1st item from 2nd startURI
-		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 5)
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(startFromCont, 5, true)
 		Expect(err).To(BeNil())
 		Expect(len(queryResult.Cont)).To(Equal(1), "1st exhausted query, one remaining")
 		Expect(len(queryResult.Relations)).To(Equal(5))
 		Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal(pref + ":person-5"))
 		Expect(queryResult.Relations[4].RelatedEntity.ID).To(Equal(pref + ":person-20"))
-		queryResult, err = store.GetManyRelatedEntitiesAtTime(queryResult.Cont, 0)
+		queryResult, err = store.GetManyRelatedEntitiesAtTime(queryResult.Cont, 0, true)
 		Expect(err).To(BeNil())
 		Expect(queryResult.Cont).To(BeNil())
 		Expect(len(queryResult.Relations)).To(Equal(9))
@@ -267,7 +267,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 
 		// make sure we find person 4 as friend now, even though it is deleted from family.
 		start := []string{pref + ":person-1"}
-		queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+		queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 		Expect(err).To(BeNil())
 		Expect(queryResult.Relations).To(HaveLen(4))
 		Expect(queryResult.Relations[0].PredicateURI).To(Equal("ns3:Family"))
@@ -288,13 +288,13 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 1, deleted: false, friends: []int{2}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"friends"}, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"friends"}, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].PredicateURI).To(Equal("ns3:Friend"))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].PredicateURI).To(Equal("ns3:Friend"))
@@ -310,14 +310,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 1, deleted: false, friends: []int{2}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"friends"}, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"friends"}, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].PredicateURI).To(Equal("ns3:Friend"))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].PredicateURI).To(Equal("ns3:Friend"))
@@ -330,11 +330,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 1, deleted: true, friends: []int{2}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"friends"}, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"friends"}, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -349,11 +349,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 1, deleted: true, friends: []int{2}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"friends"}, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"friends"}, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -369,14 +369,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.Properties[pref+":Name"]).To(Equal([]any{"Person 1", "Person 1"}), "merged properties expected")
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -392,14 +392,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.Properties[pref+":Name"]).To(Equal("Person 1"), "only one partial expected")
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -416,14 +416,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 1, deleted: true, friends: []int{2}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.Properties[pref+":Name"]).To(Equal("Person 1"), "only one partial expected")
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -443,14 +443,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.Properties[pref+":Name"]).To(Equal("Person 1"), "only one partial expected")
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -466,14 +466,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.Properties[pref+":Name"]).To(Equal("Person 1"), "only one partial expected")
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -490,14 +490,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.Properties[pref+":Name"]).To(Equal("Person 1"), "only one partial expected")
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -517,14 +517,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.Properties[pref+":Name"]).To(Equal("Person 1"), "only one partial expected")
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -540,11 +540,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -562,11 +562,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -581,11 +581,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -603,11 +603,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -625,11 +625,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -644,11 +644,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 1, deleted: true, friends: []int{2}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -666,11 +666,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -692,11 +692,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -718,11 +718,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -756,14 +756,14 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-2"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
 			Expect(queryResult.Relations[0].RelatedEntity.Properties[pref+":Name"]).To(Equal("Person 1"), "only one partial expected")
 			Expect(queryResult.Relations[0].RelatedEntity.IsDeleted).To(BeFalse())
 			start = []string{pref + ":person-1"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -800,7 +800,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 					{id: 2, friends: []int{}},
 				})) */
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -840,7 +840,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 					{id: 2, friends: []int{}},
 				})) */
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -883,7 +883,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 					{id: 2, friends: []int{}},
 				})) */
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -920,7 +920,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 					{id: 2, friends: []int{}},
 				})) */
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -958,7 +958,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 					{id: 2, friends: []int{}},
 				})) */
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(2))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
@@ -1008,7 +1008,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 					{id: 2, friends: []int{}},
 				})) */
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(2))
 		})
@@ -1047,10 +1047,10 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 					{id: 2, friends: []int{}},
 				})) */
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"people"}, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"people"}, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"family"}, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", true, []string{"family"}, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 		})
@@ -1063,12 +1063,12 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
 			start = []string{pref + ":person-2"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, pref+":Friend", true, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, pref+":Friend", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
@@ -1080,11 +1080,11 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 1, deleted: true, friends: []int{2}, family: []int{2}},
 			}))
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 			start = []string{pref + ":person-2"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, pref+":Friend", true, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, pref+":Friend", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(0))
 		})
@@ -1099,13 +1099,13 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0, true)
 			Expect(err).To(BeNil())
 
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
 			start = []string{pref + ":person-2"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, pref+":Friend", true, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, pref+":Friend", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
@@ -1120,12 +1120,12 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
 			start = []string{pref + ":person-2"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, pref+":Friend", true, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, pref+":Friend", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(1))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))
@@ -1136,7 +1136,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 				{id: 2, friends: []int{}},
 			}))
 			start := []string{pref + ":person-1"}
-			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0)
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, "*", false, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(2))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-2"))
@@ -1144,7 +1144,7 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 			Expect(queryResult.Relations[1].RelatedEntity.ID).To(Equal("ns3:person-2"))
 			Expect(queryResult.Relations[1].RelatedEntity.Properties[pref+":Name"]).To(Equal("Person 2"))
 			start = []string{pref + ":person-2"}
-			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0)
+			queryResult, err = store.GetManyRelatedEntitiesBatch(start, "*", true, nil, 0, true)
 			Expect(err).To(BeNil())
 			Expect(queryResult.Relations).To(HaveLen(2))
 			Expect(queryResult.Relations[0].RelatedEntity.ID).To(Equal("ns3:person-1"))

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -659,7 +659,7 @@ func (s *Store) GetEntityAtPointInTimeWithInternalID(
 				if !e.IsDeleted {
 					if !mergePartials {
 						// add dataset to entity
-						ds, ok := s.datasetsByInternalID.Load(currentDatasetID)
+						ds, ok := s.datasetsByInternalID.Load(previousDatasetID)
 						if ok {
 							e.Properties["http://data.mimiro.io/core/datasetname"] = (ds.(*Dataset)).ID
 						} else {
@@ -692,6 +692,16 @@ func (s *Store) GetEntityAtPointInTimeWithInternalID(
 			e.References = make(map[string]interface{})
 		}
 		if !e.IsDeleted {
+			if !mergePartials {
+				// add dataset to entity
+				ds, ok := s.datasetsByInternalID.Load(previousDatasetID)
+				if ok {
+					e.Properties["http://data.mimiro.io/core/datasetname"] = (ds.(*Dataset)).ID
+				} else {
+					return nil, errors.New("dataset not found")
+				}
+			}
+
 			partials = append(partials, e)
 		} else {
 			hasDeleted = true

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -543,6 +543,7 @@ func (s *Store) mergePartials(partials []*Entity) *Entity {
 
 func (s *Store) createMultiOriginEntity(partials []*Entity) *Entity {
 	result := &Entity{}
+	result.ID = partials[0].ID
 	result.Properties = make(map[string]interface{})
 	propKey := "http://data.mimiro.io/core/partials"
 	result.Properties[propKey] = make([]interface{}, 0)

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -49,6 +49,7 @@ type qresult struct {
 type Store struct {
 	database             *badger.DB
 	datasets             *sync.Map              // concurrent map of datasets
+	datasetsByInternalID *sync.Map              // concurrent map of datasets
 	deletedDatasets      map[uint32]bool        // list of datasets to be garbage collected
 	storeLocation        string                 // local location of data folder
 	nextDatasetID        uint32                 // the next internal id for a dataset
@@ -61,8 +62,8 @@ type Store struct {
 	fullsyncLeaseTimeout time.Duration
 	blockCacheSize       int64
 	valueLogFileSize     int64
-	maxCompactionLevels int
-	SlowLogThreshold    time.Duration
+	maxCompactionLevels  int
+	SlowLogThreshold     time.Duration
 }
 
 type BadgerLogger struct { // we use this to implement the Badger Logger interface
@@ -83,6 +84,7 @@ func NewStore(lc fx.Lifecycle, env *conf.Env, statsdClient statsd.ClientInterfac
 	}
 	store := &Store{
 		datasets:             &sync.Map{},
+		datasetsByInternalID: &sync.Map{},
 		deletedDatasets:      make(map[uint32]bool),
 		storeLocation:        env.StoreLocation,
 		logger:               env.Logger.Named("store"),
@@ -454,6 +456,7 @@ func (s *Store) loadDatasets() error {
 		ds := i.(*Dataset)
 		ds.store = s
 		s.datasets.Store(ds.ID, ds)
+		s.datasetsByInternalID.Store(ds.InternalID, ds)
 		return nil
 	})
 }
@@ -538,11 +541,24 @@ func (s *Store) mergePartials(partials []*Entity) *Entity {
 	return nil
 }
 
+func (s *Store) createMultiOriginEntity(partials []*Entity) *Entity {
+	result := &Entity{}
+	result.Properties = make(map[string]interface{})
+	propKey := "http://data.mimiro.io/core/partials"
+	result.Properties[propKey] = make([]interface{}, 0)
+
+	for _, partial := range partials {
+		result.Properties[propKey] = append(result.Properties[propKey].([]interface{}), partial)
+	}
+
+	return result
+}
+
 func (s *Store) IsCurie(uri string) bool {
 	return strings.HasPrefix(uri, "ns")
 }
 
-func (s *Store) GetEntity(uri string, datasets []string) (*Entity, error) {
+func (s *Store) GetEntity(uri string, datasets []string, mergePartials bool) (*Entity, error) {
 	var curie string
 	var err error
 	if strings.HasPrefix(uri, "ns") {
@@ -564,7 +580,7 @@ func (s *Store) GetEntity(uri string, datasets []string) (*Entity, error) {
 		return nil, nil // todo: maybe an empty entity
 	}
 	scope := s.DatasetsToInternalIDs(datasets)
-	entity, err := s.GetEntityWithInternalID(internalID, scope)
+	entity, err := s.GetEntityWithInternalID(internalID, scope, mergePartials)
 	if err != nil {
 		return nil, err
 	}
@@ -575,6 +591,7 @@ func (s *Store) GetEntityAtPointInTimeWithInternalID(
 	internalID uint64,
 	at int64,
 	targetDatasetIds []uint32,
+	mergePartials bool,
 ) (*Entity, error) {
 	/*
 		binary.BigEndian.PutUint16(entityIdBuffer, ENTITY_ID_TO_JSON_INDEX_ID)
@@ -617,9 +634,7 @@ func (s *Store) GetEntityAtPointInTimeWithInternalID(
 
 		// check if dataset has been deleted, or must be excluded
 		datasetDeleted := s.deletedDatasets[currentDatasetID]
-		datasetIncluded := len(
-			targetDatasetIds,
-		) == 0 // no specified datasets means no restriction - all datasets are allowed
+		datasetIncluded := len(targetDatasetIds) == 0 // no specified datasets means no restriction - all datasets are allowed
 		if !datasetIncluded {
 			for _, id := range targetDatasetIds {
 				if id == currentDatasetID {
@@ -642,6 +657,15 @@ func (s *Store) GetEntityAtPointInTimeWithInternalID(
 					return nil, err
 				}
 				if !e.IsDeleted {
+					if !mergePartials {
+						// add dataset to entity
+						ds, ok := s.datasetsByInternalID.Load(currentDatasetID)
+						if ok {
+							e.Properties["http://data.mimiro.io/core/datasetname"] = (ds.(*Dataset)).ID
+						} else {
+							return nil, errors.New("dataset not found")
+						}
+					}
 					partials = append(partials, e)
 				} else {
 					hasDeleted = true
@@ -674,28 +698,33 @@ func (s *Store) GetEntityAtPointInTimeWithInternalID(
 		}
 	}
 	// merge partials
-	mergedEntity := s.mergePartials(partials)
+	var resultEntity *Entity
+	if mergePartials {
+		resultEntity = s.mergePartials(partials)
+	} else {
+		resultEntity = s.createMultiOriginEntity(partials)
+	}
 
 	// if no entity for this id then return the empty object
-	if mergedEntity == nil {
-		mergedEntity = &Entity{}
-		mergedEntity.Properties = make(map[string]interface{})
-		mergedEntity.References = make(map[string]interface{})
+	if resultEntity == nil {
+		resultEntity = &Entity{}
+		resultEntity.Properties = make(map[string]interface{})
+		resultEntity.References = make(map[string]interface{})
 
-		mergedEntity.InternalID = internalID
-		mergedEntity.IsDeleted = hasDeleted
+		resultEntity.InternalID = internalID
+		resultEntity.IsDeleted = hasDeleted
 		uri, err := s.getURIForID(internalID)
 		if err != nil {
 			return nil, err
 		}
-		mergedEntity.ID = uri
+		resultEntity.ID = uri
 	}
 
-	return mergedEntity, nil
+	return resultEntity, nil
 }
 
-func (s *Store) GetEntityWithInternalID(internalID uint64, targetDatasetIds []uint32) (*Entity, error) {
-	return s.GetEntityAtPointInTimeWithInternalID(internalID, time.Now().UnixNano(), targetDatasetIds)
+func (s *Store) GetEntityWithInternalID(internalID uint64, targetDatasetIds []uint32, mergePartials bool) (*Entity, error) {
+	return s.GetEntityAtPointInTimeWithInternalID(internalID, time.Now().UnixNano(), targetDatasetIds, mergePartials)
 }
 
 type RelatedEntityResult struct {
@@ -726,8 +755,8 @@ func (s *Store) GetManyRelatedEntities(
 	predicate string,
 	inverse bool,
 	datasets []string,
-) ([][]any, error) {
-	res, err := s.GetManyRelatedEntitiesBatch(startPoints, predicate, inverse, datasets, 0)
+	mergePartials bool) ([][]any, error) {
+	res, err := s.GetManyRelatedEntitiesBatch(startPoints, predicate, inverse, datasets, 0, mergePartials)
 	if err != nil {
 		return nil, err
 	}
@@ -753,14 +782,13 @@ func (s *Store) GetManyRelatedEntitiesBatch(
 	predicate string,
 	inverse bool,
 	datasets []string,
-	limit int,
-) (RelatedEntitiesQueryResult, error) {
+	limit int, mergePartials bool) (RelatedEntitiesQueryResult, error) {
 	queryTime := time.Now().UnixNano()
 	from, err := s.ToRelatedFrom(startPoints, predicate, inverse, datasets, queryTime)
 	if err != nil {
 		return RelatedEntitiesQueryResult{}, err
 	}
-	return s.GetManyRelatedEntitiesAtTime(from, limit)
+	return s.GetManyRelatedEntitiesAtTime(from, limit, mergePartials)
 }
 
 func (s *Store) ToRelatedFrom(
@@ -849,13 +877,13 @@ func (s *Store) GetPredicateID(predicate string, txn *badger.Txn) (uint64, error
 	return pid, err
 }
 
-func (s *Store) GetManyRelatedEntitiesAtTime(from []*RelatedFrom, limit int) (RelatedEntitiesQueryResult, error) {
+func (s *Store) GetManyRelatedEntitiesAtTime(from []*RelatedFrom, limit int, mergePartials bool) (RelatedEntitiesQueryResult, error) {
 	result := RelatedEntitiesQueryResult{}
 	unlimited := limit == 0
 	var relatedFroms []*RelatedFrom
 	for _, startPoint := range from {
 		if (limit > 0) || unlimited {
-			relatedEntities, err := s.getRelatedEntitiesAtTime(startPoint, limit)
+			relatedEntities, err := s.getRelatedEntitiesAtTime(startPoint, limit, mergePartials)
 			if err != nil {
 				return RelatedEntitiesQueryResult{}, err
 			}
@@ -872,7 +900,7 @@ func (s *Store) GetManyRelatedEntitiesAtTime(from []*RelatedFrom, limit int) (Re
 	return result, nil
 }
 
-func (s *Store) getRelatedEntitiesAtTime(from *RelatedFrom, limit int) (RelatedEntitiesResult, error) {
+func (s *Store) getRelatedEntitiesAtTime(from *RelatedFrom, limit int, mergePartials bool) (RelatedEntitiesResult, error) {
 	relations, cont, err := s.GetRelatedAtTime(from, limit)
 	if err != nil {
 		return RelatedEntitiesResult{}, err
@@ -888,7 +916,7 @@ func (s *Store) getRelatedEntitiesAtTime(from *RelatedFrom, limit int) (RelatedE
 			return RelatedEntitiesResult{}, err
 		}
 
-		relatedEntity, err := s.GetEntityWithInternalID(r.EntityID, from.Datasets)
+		relatedEntity, err := s.GetEntityWithInternalID(r.EntityID, from.Datasets, mergePartials)
 		if err != nil {
 			return RelatedEntitiesResult{}, err
 		}
@@ -923,9 +951,8 @@ func (s *Store) getRelated(
 	startPoint string,
 	predicate string,
 	inverse bool,
-	datasets []string,
-) ([]RelatedEntityResult, error) {
-	res, err := s.GetManyRelatedEntitiesBatch([]string{startPoint}, predicate, inverse, datasets, 0)
+	datasets []string, mergePartials bool) ([]RelatedEntityResult, error) {
+	res, err := s.GetManyRelatedEntitiesBatch([]string{startPoint}, predicate, inverse, datasets, 0, mergePartials)
 	return res.Relations, err
 }
 

--- a/internal/server/store_test.go
+++ b/internal/server/store_test.go
@@ -86,7 +86,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(2))
@@ -96,7 +96,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-2"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -125,7 +125,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-3"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-2"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(0))
@@ -161,7 +161,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -184,7 +184,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(0))
@@ -218,7 +218,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -230,7 +230,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -254,7 +254,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(0))
@@ -264,7 +264,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-3"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(0))
@@ -274,7 +274,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -317,7 +317,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -329,7 +329,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -355,7 +355,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		// result, err = store.GetManyRelatedEntities( []string{"http://data.mimiro.io/people/person-1"}, "*", false, nil)
 		Expect(err).To(BeNil())
@@ -367,7 +367,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1), "Expected still to find person-2 as reverse friend")
@@ -401,7 +401,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			false,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(0))
@@ -411,7 +411,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-1"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -423,7 +423,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			[]string{"http://data.mimiro.io/people/person-3"},
 			peopleNamespacePrefix+":Friend",
 			true,
-			nil,
+			nil, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(0))
@@ -457,15 +457,15 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 		err := ds.StoreEntities(entities)
 		Expect(err).To(BeNil())
 
-		results, err := store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		results, err := store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(results)).To(Equal(1))
 
-		invresults, err := store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		invresults, err := store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(invresults)).To(Equal(5))
 
-		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", "*", true, []string{})
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", "*", true, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(invresults)).To(Equal(5))
 
@@ -483,11 +483,11 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 
 		time0 := time.Now().UnixNano()
 
-		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(invresults)).To(Equal(0))
 
-		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(results)).To(Equal(0))
 
@@ -504,11 +504,11 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 		err = ds.StoreEntities(entities)
 		Expect(err).To(BeNil())
 
-		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(invresults)).To(Equal(5))
 
-		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(results)).To(Equal(1))
 
@@ -1090,15 +1090,15 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 		err := ds.StoreEntities(entities)
 		Expect(err).To(BeNil())
 
-		results, err := store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		results, err := store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(results)).To(Equal(1))
 
-		invresults, err := store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		invresults, err := store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(invresults)).To(Equal(5))
 
-		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", "*", true, []string{})
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", "*", true, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(invresults)).To(Equal(5))
 
@@ -1114,11 +1114,11 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 		err = ds.StoreEntities(entities)
 		Expect(err).To(BeNil())
 
-		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(invresults)).To(Equal(0))
 
-		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(results)).To(Equal(0))
 
@@ -1135,11 +1135,11 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 		err = ds.StoreEntities(entities)
 		Expect(err).To(BeNil())
 
-		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{})
+		invresults, err = store.getRelated("http://data.mimiro.io/model/Person", RdfTypeURI, true, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(invresults)).To(Equal(5))
 
-		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{})
+		results, err = store.getRelated("http://data.mimiro.io/people/p-1", RdfTypeURI, false, []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(len(results)).To(Equal(1))
 	})
@@ -1291,7 +1291,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			queryIds,
 			"http://data.mimiro.io/people/worksfor",
 			false,
-			[]string{},
+			[]string{}, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(100))
@@ -1304,7 +1304,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			queryIds,
 			"http://data.mimiro.io/people/worksfor",
 			true,
-			[]string{},
+			[]string{}, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(numOfEmployees * 2))
@@ -1345,7 +1345,7 @@ var _ = ginkgo.Describe("The dataset storage", func() {
 			queryIds,
 			"http://data.mimiro.io/people/worksfor",
 			false,
-			[]string{},
+			[]string{}, true,
 		)
 		Expect(err).To(BeNil())
 		Expect(len(result)).To(Equal(1))
@@ -1466,7 +1466,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{peopleNamespacePrefix + ":person-1"},
 			"http://data.mimiro.io/people/worksfor",
 			false,
-			[]string{},
+			[]string{}, true,
 		)
 		Expect(len(result)).
 			To(Equal(1), "expected 1 relation to be found. both the people and workhistory datasets point to the same company.")
@@ -1484,7 +1484,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{peopleNamespacePrefix + ":person-1"},
 			"http://data.mimiro.io/people/worksfor",
 			false,
-			[]string{PEOPLE},
+			[]string{PEOPLE}, true,
 		)
 		Expect(len(result)).To(Equal(1), "expected 1 relation to be found in people dataset (not in workHistory)")
 
@@ -1500,7 +1500,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{peopleNamespacePrefix + ":person-1"},
 			"http://data.mimiro.io/people/worksfor",
 			false,
-			[]string{COMPANIES},
+			[]string{COMPANIES}, true,
 		)
 		Expect(len(result)).To(Equal(0), "expected 0 relation to be found (people and history are excluded)")
 	})
@@ -1512,7 +1512,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{peopleNamespacePrefix + ":person-1"},
 			"http://data.mimiro.io/people/worksfor",
 			false,
-			[]string{"bogus"},
+			[]string{"bogus"}, true,
 		)
 		Expect(len(result)).To(Equal(1), "expected 1 relation (company-1)")
 
@@ -1529,7 +1529,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{peopleNamespacePrefix + ":person-1"},
 			"http://data.mimiro.io/people/worksfor",
 			false,
-			[]string{HISTORY},
+			[]string{HISTORY}, true,
 		)
 		Expect(len(result)).To(Equal(1), "expected 1 relation to be found in people dataset (not in workHistory)")
 
@@ -1545,7 +1545,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{companyNamespacePrefix + ":company-1"},
 			"http://data.mimiro.io/people/worksfor",
 			true,
-			[]string{},
+			[]string{}, true,
 		)
 		Expect(len(result)).
 			To(Equal(3), "there are 6 relations, 3 in dataset people and 3 owned by history. all relations come from total of 3 people")
@@ -1569,7 +1569,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{companyNamespacePrefix + ":company-1"},
 			"http://data.mimiro.io/people/worksfor",
 			true,
-			[]string{PEOPLE},
+			[]string{PEOPLE}, true,
 		)
 		Expect(len(result)).To(Equal(3), "expected 3 relations to be found in people dataset (not in workHistory)")
 
@@ -1589,7 +1589,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{companyNamespacePrefix + ":company-1"},
 			"http://data.mimiro.io/people/worksfor",
 			true,
-			[]string{COMPANIES},
+			[]string{COMPANIES}, true,
 		)
 		Expect(len(result)).To(Equal(0))
 	})
@@ -1601,7 +1601,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{peopleNamespacePrefix + ":person-4"},
 			"http://data.mimiro.io/people/workedfor",
 			false,
-			[]string{},
+			[]string{}, true,
 		)
 		Expect(len(result)).To(Equal(2), "expected 2 relations to be found in history dataset")
 
@@ -1619,7 +1619,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{peopleNamespacePrefix + ":person-4"},
 			"http://data.mimiro.io/people/workedfor",
 			false,
-			[]string{HISTORY},
+			[]string{HISTORY}, true,
 		)
 		Expect(len(result)).To(Equal(2), "expected 2 relations to be found in history dataset")
 
@@ -1637,7 +1637,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{companyNamespacePrefix + ":company-2"},
 			"http://data.mimiro.io/people/workedfor",
 			true,
-			[]string{},
+			[]string{}, true,
 		)
 		Expect(len(result)).To(Equal(2), "expected 2 people to be found from history dataset")
 
@@ -1668,7 +1668,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 				[]string{companyNamespacePrefix + ":company-2"},
 				"http://data.mimiro.io/people/workedfor",
 				true,
-				[]string{HISTORY},
+				[]string{HISTORY}, true,
 			)
 			Expect(len(result)).To(Equal(2), "expected 2 people to be found from history dataset")
 
@@ -1693,7 +1693,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 			[]string{companyNamespacePrefix + ":company-2"},
 			"http://data.mimiro.io/people/workedfor",
 			true,
-			[]string{PEOPLE, COMPANIES},
+			[]string{PEOPLE, COMPANIES}, true,
 		)
 		Expect(len(result)).To(Equal(0))
 	})
@@ -1752,21 +1752,21 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 		})
 
 		// first no datasets restriction, check that props from both employee and people dataset are merged
-		result, err := store.GetEntity(peopleNamespacePrefix+":person-1", []string{})
+		result, err := store.GetEntity(peopleNamespacePrefix+":person-1", []string{}, true)
 		Expect(err).To(BeNil())
 		Expect(result.Properties[employeeNamespacePrefix+":Title"]).To(Equal("President"),
 			"expected to merge property employees:Title into result with value 'President'")
 		Expect(result.Properties[peopleNamespacePrefix+":Name"]).To(Equal("Lisa"))
 
 		// now, restrict on dataset "people"
-		result, _ = store.GetEntity(peopleNamespacePrefix+":person-2", []string{PEOPLE})
+		result, _ = store.GetEntity(peopleNamespacePrefix+":person-2", []string{PEOPLE}, true)
 		// we should not find the Title from the employees dataset
 		Expect(result.Properties[employeeNamespacePrefix+":Title"]).To(BeNil())
 		// people:Name should be found though
 		Expect(result.Properties[peopleNamespacePrefix+":Name"]).To(Equal("Bob"))
 
 		// now, restrict on dataset "employees". now Name should be gone but title should be found
-		result, _ = store.GetEntity(peopleNamespacePrefix+":person-2", []string{EMPLOYEES})
+		result, _ = store.GetEntity(peopleNamespacePrefix+":person-2", []string{EMPLOYEES}, true)
 		Expect(result.Properties[employeeNamespacePrefix+":Title"]).To(Equal("Vice President"),
 			"expected to merge property employees:Title into result with value 'Vice President'")
 		Expect(result.Properties[peopleNamespacePrefix+":Name"]).To(BeNil())
@@ -1803,7 +1803,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 
 		// check counts after txn
 		datasets := []string{"core.Dataset"}
-		dsEntity, err := store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, "people"), datasets)
+		dsEntity, err := store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, "people"), datasets, true)
 		Expect(err).To(BeNil())
 
 		if dsEntity != nil {
@@ -1813,7 +1813,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 		}
 
 		// check that the item counts have been updated	for places
-		dsEntity, err = store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, "places"), datasets)
+		dsEntity, err = store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, "places"), datasets, true)
 		Expect(err).To(BeNil())
 
 		if dsEntity != nil {
@@ -1831,7 +1831,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 
 		// check counts after txn
 		datasets = []string{"core.Dataset"}
-		dsEntity, err = store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, people.ID), datasets)
+		dsEntity, err = store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, people.ID), datasets, true)
 		Expect(err).To(BeNil())
 
 		if dsEntity != nil {
@@ -1841,7 +1841,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 		}
 
 		// check that the item counts have been updated	for places
-		dsEntity, err = store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, "places"), datasets)
+		dsEntity, err = store.GetEntity(fmt.Sprintf("%s:%s", dsInfo.DatasetPrefix, "places"), datasets, true)
 		Expect(err).To(BeNil())
 
 		if dsEntity != nil {
@@ -1873,7 +1873,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 		Expect(err).To(BeNil(), "StoreEntities failed unexpectedly")
 
 		// get entity
-		e, err := store.GetEntity(peopleNamespacePrefix+":p1", nil)
+		e, err := store.GetEntity(peopleNamespacePrefix+":p1", nil, true)
 		Expect(err).To(BeNil(), "GetEntity failed unexpectedly")
 		Expect(e.IsDeleted).To(BeFalse())
 
@@ -1885,7 +1885,7 @@ var _ = ginkgo.Describe("Scoped storage functions", func() {
 		err = ds.StoreEntities(entities)
 		Expect(err).To(BeNil(), "StoreEntities failed unexpectedly")
 
-		e, err = store.GetEntity("http://data.mimiro.io/people/p1", nil)
+		e, err = store.GetEntity("http://data.mimiro.io/people/p1", nil, true)
 		Expect(err).To(BeNil(), "GetEntity failed unexpectedly")
 		Expect(e.IsDeleted).To(BeTrue())
 	})

--- a/internal/web/queryhandler.go
+++ b/internal/web/queryhandler.go
@@ -55,6 +55,7 @@ type Query struct {
 	Details          bool     `json:"details"`
 	Limit            int      `json:"limit"`
 	Continuations    []string `json:"continuations"`
+	NoPartialMerging bool     `json:"noPartialMerging"`
 }
 
 type NamespacePrefix struct {
@@ -205,7 +206,7 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 	}
 
 	if query.EntityID != "" {
-		entity, err := handler.store.GetEntity(query.EntityID, query.Datasets)
+		entity, err := handler.store.GetEntity(query.EntityID, query.Datasets, !query.NoPartialMerging)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -236,7 +237,7 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
-		queryresult, err := handler.store.GetManyRelatedEntitiesAtTime(cont, query.Limit)
+		queryresult, err := handler.store.GetManyRelatedEntitiesAtTime(cont, query.Limit, !query.NoPartialMerging)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -253,7 +254,7 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 		return c.JSON(http.StatusOK, result)
 	} else {
 		// do query
-		queryresult, err := handler.store.GetManyRelatedEntitiesBatch(query.StartingEntities, query.Predicate, query.Inverse, query.Datasets, query.Limit)
+		queryresult, err := handler.store.GetManyRelatedEntitiesBatch(query.StartingEntities, query.Predicate, query.Inverse, query.Datasets, query.Limit, !query.NoPartialMerging)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}


### PR DESCRIPTION
When query for an entity by id or when executing a related entities query there is an option to not merge the set of partial entities into one, but instead return an entity that contains all partial entities. The added benefit is that each partial entity also has the dataset it belongs to as a value of the props collection. 