### PR TITLE
use filtered namespace context in httpSink

### DIFF
--- a/internal/jobs/sink.go
+++ b/internal/jobs/sink.go
@@ -198,8 +198,7 @@ func (httpDatasetSink *httpDatasetSink) endFullSync(ctx context.Context, runner 
 	url := httpDatasetSink.Endpoint
 
 	allObjects := make([]interface{}, 1)
-	// TODO: https://mimiro.atlassian.net/browse/MIM-693
-	allObjects[0] = runner.store.GetGlobalContext()
+	allObjects[0] = httpDatasetSink.Store.GetGlobalContext(true)
 
 	jsonEntities, err := json.Marshal(allObjects)
 	if err != nil {
@@ -255,8 +254,7 @@ func (httpDatasetSink *httpDatasetSink) processEntities(runner *Runner, entities
 	url := httpDatasetSink.Endpoint
 
 	allObjects := make([]interface{}, len(entities)+1)
-	// TODO: https://mimiro.atlassian.net/browse/MIM-693
-	allObjects[0] = runner.store.GetGlobalContext()
+	allObjects[0] = httpDatasetSink.Store.GetGlobalContext(true)
 	for i := 0; i < len(entities); i++ {
 		allObjects[i+1] = entities[i]
 	}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -342,8 +342,19 @@ func (s *Store) GetNamespacedIdentifier(val string, localNamespaces map[string]s
 	}
 }
 
-func (s *Store) GetGlobalContext() *Context {
-	return s.NamespaceManager.GetContext(nil)
+func (s *Store) GetGlobalContext(strict bool) *Context {
+	completeCtx := s.NamespaceManager.GetContext(nil)
+	if !strict {
+		return completeCtx
+	}
+	// TODO: consider caching this. Currently GetGlobalContext is only called once per request so it's not called too often
+	filterdCtx := &Context{ID: "@context", Namespaces: make(map[string]string)}
+	for prefix, expansion := range completeCtx.Namespaces {
+		if strings.HasSuffix(expansion, "#") || strings.HasSuffix(expansion, "/") {
+			filterdCtx.Namespaces[prefix] = expansion
+		}
+	}
+	return filterdCtx
 }
 
 // Open Opens the store. Must be called before using.

--- a/internal/web/namespacehandler.go
+++ b/internal/web/namespacehandler.go
@@ -47,7 +47,7 @@ func NewNamespaceHandler(
 }
 
 func (handler *namespaceHandler) getNamespaces(c echo.Context) error {
-	v := handler.store.GetGlobalContext()
+	v := handler.store.GetGlobalContext(false)
 
 	return c.JSON(http.StatusOK, v.Namespaces)
 }

--- a/internal/web/queryhandler.go
+++ b/internal/web/queryhandler.go
@@ -215,7 +215,7 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 		// a returned Entity can be the product of multiple entities in multiple datasets with the same ID
 		// To get the correct namespace context, we'd have to use the supplied list of dataset names (query.Datasets)
 		// and merge their respective contexts to our result context here.
-		result[0] = handler.store.GetGlobalContext()
+		result[0] = handler.store.GetGlobalContext(false)
 
 		if entity == nil {
 			entity := &EmptyEntity{}
@@ -245,7 +245,7 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 		result := make([]interface{}, 3)
 		// To get the correct namespace context, we'd have to use the supplied list of dataset names (query.Datasets)
 		// and merge their respective contexts to our result context here.
-		result[0] = handler.store.GetGlobalContext()
+		result[0] = handler.store.GetGlobalContext(false)
 		result[1] = server.ToLegacyQueryResult(queryresult)
 		result[2], err = encodeCont(queryresult.Cont)
 		if err != nil {
@@ -262,7 +262,7 @@ func (handler *queryHandler) queryHandler(c echo.Context) error {
 		result := make([]interface{}, 2)
 		// To get the correct namespace context, we'd have to use the supplied list of dataset names (query.Datasets)
 		// and merge their respective contexts to our result context here.
-		result[0] = handler.store.GetGlobalContext()
+		result[0] = handler.store.GetGlobalContext(false)
 		result[1] = server.ToLegacyQueryResult(queryresult)
 		// for compatibility with older clients, do not add new array elem when no limit parameter was given
 		if includeContinuation {


### PR DESCRIPTION
HttpSink now makes sure to only add namespace prefixes that are fully valid.