### PR TITLE
reject since parameter in entities request

### DIFF
--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -269,6 +269,12 @@ func (handler *datasetHandler) getEntitiesHandler(c echo.Context) error {
 	}
 
 	f := c.QueryParam("from")
+
+	since := c.QueryParam("since")
+	if since != "" {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("since parameter only supported for changes"))
+	}
+
 	reverse := c.QueryParam("reverse")
 	if reverse != "" {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("reverse parameter only supported for changes"))


### PR DESCRIPTION
if users try to use the /entities endpoint of a dataset to consume the dataset incrementally, datahub now returns an error. 