### PR TITLE
Add check to handle missing related entity

### DIFF
--- a/internal/server/get_related_test.go
+++ b/internal/server/get_related_test.go
@@ -1173,6 +1173,18 @@ var _ = ginkgo.Describe("GetManyRelatedEntitiesBatch", func() {
 			Expect(queryResult.Relations[1].RelatedEntity.IsDeleted).To(BeFalse())
 		})
 	})
+	ginkgo.Describe("Merged Partials", func() {
+		ginkgo.It("Set to false with ref pointing to missing entity", func() {
+			pref := persist("friends", store, dsm, buildTestBatch(store, []testPerson{
+				{id: 1, friends: []int{3}},
+				{id: 2, friends: []int{}},
+			}))
+			start := []string{pref + ":person-1"}
+			queryResult, err := store.GetManyRelatedEntitiesBatch(start, pref+":Friend", false, nil, 0, false)
+			Expect(err).To(BeNil())
+			Expect(queryResult.Relations).To(HaveLen(1))
+		})
+	})
 })
 
 func persist(dsName string, store *Store, dsm *DsManager, b []*Entity) string {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -738,7 +738,7 @@ func (s *Store) GetEntityAtPointInTimeWithInternalID(
 	var resultEntity *Entity
 	if mergePartials {
 		resultEntity = s.mergePartials(partials)
-	} else {
+	} else if len(partials) > 0 {
 		resultEntity = s.createMultiOriginEntity(partials)
 	}
 


### PR DESCRIPTION
Applies when doing queries with mergePartials set to false. This would cause a panic when a ref was pointing to a non existing entity.