### PR TITLE
disable arm build temporarily

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,26 +2,25 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   release:
     types:
       - published
 
 env:
-  DOCKERHUB_REPOSITORY : mimiro/datahub
-  
+  DOCKERHUB_REPOSITORY: mimiro/datahub
+
 jobs:
   Docker_AMD64:
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
-      
+
     steps:
-    
       - name: Checkout code
-        uses: actions/checkout@v2  
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
@@ -75,7 +74,7 @@ jobs:
             echo "Setting Unstable Image"
             echo "image_tag=${{ env.DOCKERHUB_REPOSITORY }}:${{ steps.semver-tag.outputs.tag }}-$GITHUB_RUN_NUMBER-unstable-$(uname -m)" >> $GITHUB_OUTPUT
           fi
-       
+
       # Login to Docker registry except on PR
       - name: Login to DockerHub
         id: docker_login
@@ -83,7 +82,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}      
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build Docker Image
         uses: docker/build-push-action@v2
@@ -93,47 +92,47 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ${{ steps.image_tag.outputs.image_tag }} 
+          tags: ${{ steps.image_tag.outputs.image_tag }}
 
       - name: Trivy vulnerability scan
-        uses : aquasecurity/trivy-action@master
-        with :
-          image-ref: '${{ steps.image_tag.outputs.image_tag }}'
-          format: 'table'
-          exit-code: '1'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ steps.image_tag.outputs.image_tag }}"
+          format: "table"
+          exit-code: "1"
           ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'         
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
 
       - name: Push Image to DockerHub
         id: dockerhub_push
         if: |
           (
-            ( github.ref == 'refs/heads/master' && github.event_name == 'push' ) 
-            || 
+            ( github.ref == 'refs/heads/master' && github.event_name == 'push' )
+            ||
             ( github.event_name == 'release')
-          ) 
-            && 
-          ( github.event_name != 'pull_request')  
+          )
+            &&
+          ( github.event_name != 'pull_request')
 
         run: |
           docker image push ${{ steps.image_tag.outputs.image_tag }}
 
   Docker_ARM64:
     runs-on: ARM64
+    if: false # skip this build temporarily, until we have a compatible runner
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
-      
+
     steps:
-    
       - name: Checkout code
-        uses: actions/checkout@v2  
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx (enable caching)
         uses: docker/setup-buildx-action@v1
-            
+
       - name: install semver tool
         run: pip3 install semver
 
@@ -167,7 +166,6 @@ jobs:
           NEXT=$( /home/ec2-user/.local/bin/pysemver bump patch $VERSION )
           echo "tag=$NEXT" >> $GITHUB_OUTPUT
 
-
       - name: "Calculated unstable tag"
         run: echo "base tag next unstable version... ${{ steps.semver-tag.outputs.tag }}"
 
@@ -182,7 +180,7 @@ jobs:
             echo "Setting Unstable Image"
             echo "image_tag=${{ env.DOCKERHUB_REPOSITORY }}:${{ steps.semver-tag.outputs.tag }}-$GITHUB_RUN_NUMBER-unstable-$(uname -m)" >> $GITHUB_OUTPUT
           fi
-       
+
       # Login to Docker registry except on PR
       - name: Login to DockerHub
         id: docker_login
@@ -190,7 +188,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}      
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build Docker Image
         uses: docker/build-push-action@v2
@@ -200,53 +198,53 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ${{ steps.image_tag.outputs.image_tag }} 
+          tags: ${{ steps.image_tag.outputs.image_tag }}
 
       - name: Trivy vulnerability scan
-        uses : aquasecurity/trivy-action@master
-        with :
-          image-ref: '${{ steps.image_tag.outputs.image_tag }}'
-          format: 'table'
-          exit-code: '1'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ steps.image_tag.outputs.image_tag }}"
+          format: "table"
+          exit-code: "1"
           ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'         
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
 
       - name: Push Image to DockerHub
         id: dockerhub_push
         if: |
           (
-            ( github.ref == 'refs/heads/master' && github.event_name == 'push' ) 
-            || 
+            ( github.ref == 'refs/heads/master' && github.event_name == 'push' )
+            ||
             ( github.event_name == 'release')
-          ) 
-            && 
-          ( github.event_name != 'pull_request')        
+          )
+            &&
+          ( github.event_name != 'pull_request')
         run: |
           docker image push ${{ steps.image_tag.outputs.image_tag }}
-    
+
   Docker_Manifest:
     runs-on: ubuntu-latest
-    needs: [Docker_AMD64,Docker_ARM64]
+    #needs: [Docker_AMD64, Docker_ARM64] # do not require ARM64 while disabled
+    needs: [Docker_AMD64]
     if: |
       (
-        ( github.ref == 'refs/heads/master' && github.event_name == 'push' ) 
-        || 
+        ( github.ref == 'refs/heads/master' && github.event_name == 'push' )
+        ||
         ( github.event_name == 'release')
-      ) 
-        && 
-      ( github.event_name != 'pull_request') 
+      )
+        &&
+      ( github.event_name != 'pull_request')
 
-    steps:   
-      
+    steps:
       - name: Checkout code
-        uses: actions/checkout@v2  
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: install semver tool
         run: pip3 install semver
-      
+
       - name: strip v from tag
         run: |
           if [ ${{ github.event_name }} == 'release' ]
@@ -277,7 +275,6 @@ jobs:
           NEXT=$( pysemver bump patch $VERSION )
           echo "tag=$NEXT" >> $GITHUB_OUTPUT
 
-
       - name: "Calculated unstable tag"
         run: echo "base tag next unstable version... ${{ steps.semver-tag.outputs.tag }}"
 
@@ -301,12 +298,12 @@ jobs:
           fi
 
       - name: Show Tag
-        run: echo ${{ steps.image_tag.outputs.image_tag }}  
+        run: echo ${{ steps.image_tag.outputs.image_tag }}
 
       - name: Docker Manifest
         id: docker_manifest
 
-        run: |    
+        run: |
 
           if [ ${{ github.event_name }} == 'release' ]
 
@@ -315,21 +312,21 @@ jobs:
             #tag:release version
             docker manifest create ${{ steps.image_tag.outputs.image_tag }} \
               ${{needs.Docker_AMD64.outputs.image_tag}} \
-              ${{needs.Docker_ARM64.outputs.image_tag}} 
-            
+              ${{needs.Docker_ARM64.outputs.image_tag}}
+
             docker manifest push ${{ steps.image_tag.outputs.image_tag }}
 
             #tag:latest
             docker manifest create  ${{ env.DOCKERHUB_REPOSITORY }}:latest \
               ${{needs.Docker_AMD64.outputs.image_tag}} \
-              ${{needs.Docker_ARM64.outputs.image_tag}} 
-            
+              ${{needs.Docker_ARM64.outputs.image_tag}}
+
             docker manifest push  ${{ env.DOCKERHUB_REPOSITORY }}:latest
 
           else
              docker manifest create ${{ steps.image_tag.outputs.image_tag }} \
               ${{needs.Docker_AMD64.outputs.image_tag}} \
-              ${{needs.Docker_ARM64.outputs.image_tag}} 
-          docker manifest push ${{ steps.image_tag.outputs.image_tag }}    
+              ${{needs.Docker_ARM64.outputs.image_tag}}
+          docker manifest push ${{ steps.image_tag.outputs.image_tag }}
 
           fi


### PR DESCRIPTION
the arm64 runner needs to be upgraded to be compatible with githubs latest runner framework. until it is upgraded, we skip the arm build