### PR TITLE
skip ref counts for dataset stats

### DIFF
--- a/internal/server/statistics.go
+++ b/internal/server/statistics.go
@@ -115,7 +115,9 @@ func (stats Statistics) perPrefixStats(ctx context.Context, pt uint16, datasetNa
 		binary.BigEndian.PutUint32(prefix[2:], dsFilter)
 	}
 	if dsFilter != 0 && pt == ENTITY_ID_TO_JSON_INDEX_ID {
+		prefix = make([]byte, 6)
 		binary.BigEndian.PutUint16(prefix, DATASET_ENTITY_CHANGE_LOG)
+		binary.BigEndian.PutUint32(prefix[2:], dsFilter)
 	}
 	s := stats.Store.database.NewStream()
 	s.Prefix = prefix


### PR DESCRIPTION
when retrieving stats for a single dataset, we dont want to scan all ref indexes to make the request faster. to see ref counts, one can still use the global /statistics endpoint