### PR TITLE
chore: fix FromAsCasing warning when building docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder_src
+FROM golang:1.21 AS builder_src
 
 COPY jemalloc-install.sh .
 RUN apt-get update -y


### PR DESCRIPTION
Since recent Docker versions [run build checks by default](https://docs.docker.com/build/checks/#build-with-checks) when building, we should fix this annoying warning when building the docker container

```
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                          0.0s
```
