### PR TITLE
move stats and gc to internal jobs

### DIFF
--- a/internal/server/garbagecollector.go
+++ b/internal/server/garbagecollector.go
@@ -41,7 +41,8 @@ func NewGarbageCollector(store *Store, env *conf.Config) *GarbageCollector {
 		env:    env,
 	}
 
-	gc.Start(context.Background())
+	// this is now orchestrated from service/scheduler/scheduler.go
+	//gc.Start(context.Background())
 
 	return gc
 }
@@ -85,7 +86,7 @@ again:
 	if garbageCollector.isCancelled() {
 		return errors.New("gc cancelled")
 	}
-	err := garbageCollector.store.database.RunValueLogGC(0.5)
+	err := garbageCollector.store.database.RunValueLogGC(0.3) // 30% of the value log can be discarded
 	if err == nil {
 		goto again
 	}

--- a/internal/server/statistics.go
+++ b/internal/server/statistics.go
@@ -1,41 +1,9 @@
 package server
 
 import (
-	"bytes"
-	"context"
-	"encoding/binary"
 	"encoding/json"
-	"fmt"
-	"github.com/dgraph-io/badger/v4"
-	"github.com/dgraph-io/badger/v4/pb"
-	"github.com/dgraph-io/ristretto/z"
 	"go.uber.org/zap"
 	"io"
-	"strings"
-	"sync"
-	"time"
-)
-
-const (
-	URI_TO_ID_INDEX_ID         uint16 = 0
-	ENTITY_ID_TO_JSON_INDEX_ID uint16 = 1
-	INCOMING_REF_INDEX         uint16 = 2
-	OUTGOING_REF_INDEX         uint16 = 3
-	DATASET_ENTITY_CHANGE_LOG  uint16 = 4
-	SYS_DATASETS_ID            uint16 = 5
-	SYS_JOBS_ID                uint16 = 6
-	SYS_DATASETS_SEQUENCES     uint16 = 7
-	DATASET_LATEST_ENTITIES    uint16 = 8
-	ID_TO_URI_INDEX_ID         uint16 = 9
-
-	STORE_META_INDEX      uint16 = 10
-	NAMESPACES_INDEX      uint16 = 11
-	JOB_RESULT_INDEX      uint16 = 12
-	JOB_DATA_INDEX        uint16 = 13
-	JOB_CONFIGS_INDEX     uint16 = 14
-	CONTENT_INDEX         uint16 = 15
-	STORE_NEXT_DATASET_ID uint16 = 16
-	LOGIN_PROVIDER_INDEX  uint16 = 17
 )
 
 type Statistics struct {
@@ -43,298 +11,35 @@ type Statistics struct {
 	Logger *zap.SugaredLogger
 }
 
-type keepAliveRoutine struct {
-	ticker *time.Ticker
-}
-
-func (k *keepAliveRoutine) Close() error {
-	k.ticker.Stop()
-	return nil
-}
-
-func keepAlive(writer io.Writer) io.Closer {
-	ticker := time.NewTicker(240 * time.Second)
-	go func() {
-		for range ticker.C {
-			writer.Write([]byte(" "))
-		}
-	}()
-	return &keepAliveRoutine{ticker: ticker}
-}
-
-func (stats Statistics) GetStatistics(writer io.Writer, ctx context.Context) error {
-	defer keepAlive(writer).Close()
-	stats.Logger.Infof("gathering counts for all datasets")
-	datasetName := ""
-	o := stats.perPrefixStats(ctx, INCOMING_REF_INDEX, datasetName)
-	merge(o, stats.perPrefixStats(ctx, OUTGOING_REF_INDEX, datasetName))
-	merge(o, stats.perPrefixStats(ctx, URI_TO_ID_INDEX_ID, datasetName))
-	merge(o, stats.perPrefixStats(ctx, ENTITY_ID_TO_JSON_INDEX_ID, datasetName))
-	merge(o, stats.perPrefixStats(ctx, DATASET_ENTITY_CHANGE_LOG, datasetName))
-	merge(o, stats.perPrefixStats(ctx, SYS_DATASETS_ID, datasetName))
-	merge(o, stats.perPrefixStats(ctx, SYS_JOBS_ID, datasetName))
-	merge(o, stats.perPrefixStats(ctx, SYS_DATASETS_SEQUENCES, datasetName))
-	merge(o, stats.perPrefixStats(ctx, DATASET_LATEST_ENTITIES, datasetName))
-	merge(o, stats.perPrefixStats(ctx, ID_TO_URI_INDEX_ID, datasetName))
-	merge(o, stats.perPrefixStats(ctx, STORE_META_INDEX, datasetName))
-	merge(o, stats.perPrefixStats(ctx, NAMESPACES_INDEX, datasetName))
-	merge(o, stats.perPrefixStats(ctx, JOB_RESULT_INDEX, datasetName))
-	merge(o, stats.perPrefixStats(ctx, JOB_DATA_INDEX, datasetName))
-	merge(o, stats.perPrefixStats(ctx, JOB_CONFIGS_INDEX, datasetName))
-	merge(o, stats.perPrefixStats(ctx, CONTENT_INDEX, datasetName))
-	merge(o, stats.perPrefixStats(ctx, STORE_NEXT_DATASET_ID, datasetName))
-	merge(o, stats.perPrefixStats(ctx, LOGIN_PROVIDER_INDEX, datasetName))
-
-	return json.NewEncoder(writer).Encode(o)
-}
-
-func (stats Statistics) GetStatisticsForDs(datasetName string, writer io.Writer, ctx context.Context) error {
-	defer keepAlive(writer).Close()
-	stats.Logger.Infof("gathering counts for dataset %v", datasetName)
-	//o := map[string]any{}
-	o := stats.perPrefixStats(ctx, INCOMING_REF_INDEX, datasetName)
-	merge(o, stats.perPrefixStats(ctx, OUTGOING_REF_INDEX, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, URI_TO_ID_INDEX_ID, datasetName))
-	merge(o, stats.perPrefixStats(ctx, ENTITY_ID_TO_JSON_INDEX_ID, datasetName))
-	merge(o, stats.perPrefixStats(ctx, DATASET_ENTITY_CHANGE_LOG, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, SYS_DATASETS_ID, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, SYS_JOBS_ID, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, SYS_DATASETS_SEQUENCES, datasetName))
-	merge(o, stats.perPrefixStats(ctx, DATASET_LATEST_ENTITIES, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, ID_TO_URI_INDEX_ID, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, STORE_META_INDEX, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, NAMESPACES_INDEX, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, JOB_RESULT_INDEX, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, JOB_DATA_INDEX, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, JOB_CONFIGS_INDEX, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, CONTENT_INDEX, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, STORE_NEXT_DATASET_ID, datasetName))
-	//merge(o, stats.perPrefixStats(ctx, LOGIN_PROVIDER_INDEX, datasetName))
-
-	return json.NewEncoder(writer).Encode(o)
-}
-
-func merge(o map[string]any, o2 map[string]any) {
-	for k, v := range o2 {
-		if o[k] == nil {
-			o[k] = v
-		} else {
-			merge(o[k].(map[string]any), v.(map[string]any))
-		}
-	}
-}
-func (stats Statistics) perPrefixStats(ctx context.Context, pt uint16, datasetName string) map[string]any {
-	stats.Logger.Infof("gathering counts for %v", idxToStr(pt))
-
-	dsFilter := uint32(0)
-	if datasetName != "" {
-		ds, _ := stats.Store.datasets.Load(datasetName)
-		dsFilter = ds.(*Dataset).InternalID
-	}
-
-	prefix := make([]byte, 2)
-	binary.BigEndian.PutUint16(prefix, pt)
-	if dsFilter != 0 && (pt == DATASET_ENTITY_CHANGE_LOG || pt == DATASET_LATEST_ENTITIES) {
-		prefix = make([]byte, 6)
-		binary.BigEndian.PutUint16(prefix, pt)
-		binary.BigEndian.PutUint32(prefix[2:], dsFilter)
-	}
-
-	jsonViaChanges := false
-	if jsonViaChanges && dsFilter != 0 && pt == ENTITY_ID_TO_JSON_INDEX_ID {
-		prefix = make([]byte, 6)
-		binary.BigEndian.PutUint16(prefix, DATASET_ENTITY_CHANGE_LOG)
-		binary.BigEndian.PutUint32(prefix[2:], dsFilter)
-	}
-	s := stats.Store.database.NewStream()
-	s.Prefix = prefix
-
-	//s.NumGo = 12
-	counts := map[string]int64{}
-	keySizes := map[string]int64{}
-	valueSizes := map[string]int64{}
-	mapLock := sync.RWMutex{}
-	jsonKey := make([]byte, 4)
-	txn := stats.Store.database.NewTransaction(false)
-	defer txn.Discard()
-	s.KeyToList = func(key []byte, itr *badger.Iterator) (*pb.KVList, error) {
-		item := itr.Item()
-		k := item.Key()
-		valSize := item.ValueSize()
-		if jsonViaChanges && dsFilter != 0 && pt == ENTITY_ID_TO_JSON_INDEX_ID {
-			jk, err := item.ValueCopy(jsonKey)
-			if err != nil {
-				return nil, err
-			}
-			jsonItem, err := txn.Get(jk)
-			if err != nil {
-				return nil, err
-			}
-			k = jsonItem.Key()
-			valSize = jsonItem.ValueSize()
-		}
-
-		kv := &pb.KV{
-			//Key: y.Copy(k),
-			Key:   k,
-			Value: binary.BigEndian.AppendUint64(nil, uint64(valSize)),
-		}
-		return &pb.KVList{
-			Kv: []*pb.KV{kv},
-		}, nil
-	}
-	dsFilterBytes := make([]byte, 4)
-	empty := []byte{0, 0, 0, 0}
-	binary.BigEndian.PutUint32(dsFilterBytes, dsFilter)
-	s.Send = func(buf *z.Buffer) error {
-		mapLock.Lock()
-		defer mapLock.Unlock()
-		list, err := badger.BufferToKVList(buf)
-		if err != nil {
-			return err
-		}
-		for _, kv := range list.Kv {
-			cntKey := make([]byte, 8)
-			if kv.StreamDone {
-				return nil
-			}
-			idx := kv.Key[:2]
-			copy(cntKey[0:2], idx)
-
-			if pt == INCOMING_REF_INDEX || pt == OUTGOING_REF_INDEX {
-				dsBytes := kv.Key[36:40]
-
-				if dsFilter != 0 && !bytes.Equal(dsFilterBytes, dsBytes) {
-					continue
-				}
-				copy(cntKey[2:6], dsBytes)
-				copy(cntKey[6:8], kv.Key[34:36]) // deleted
-				//deleted := binary.BigEndian.Uint16(kv.Key[34:36])
-			} else {
-				if pt == DATASET_ENTITY_CHANGE_LOG || pt == DATASET_LATEST_ENTITIES {
-					copy(cntKey[2:6], kv.Key[2:6])
-				}
-				if pt == ENTITY_ID_TO_JSON_INDEX_ID {
-					copy(cntKey[2:6], kv.Key[10:14])
-				}
-
-				if dsFilter != 0 && !bytes.Equal(cntKey[2:6], empty) && !bytes.Equal(dsFilterBytes, cntKey[2:6]) {
-					continue
-				}
-			}
-
-			sKey := string(cntKey)
-			counts[sKey] += 1
-			keySizes[sKey] += int64(len(kv.Key))
-			valueSizes[sKey] += int64(binary.BigEndian.Uint64(kv.Value))
-		}
+func (stats Statistics) GetStatistics(writer io.Writer) error {
+	o := map[string]any{}
+	err := stats.Store.GetObject(StoreMetaIndex, "stats", &o)
+	if err != nil {
 		return err
 	}
+	return json.NewEncoder(writer).Encode(o)
+}
 
-	s.Orchestrate(ctx)
-	mapLock.RLock()
-	defer mapLock.RUnlock()
-	out := map[string]any{}
-	del := []byte{0, 1}
-	for kS, v := range counts {
-		k := []byte(kS)
-		idx := binary.BigEndian.Uint16(k[:2])
-		dsId := binary.BigEndian.Uint32(k[2:6])
-		ds := ""
-		if dsO, dsOK := stats.Store.datasetsByInternalID.Load(dsId); dsOK {
-			ds = dsO.(*Dataset).ID
-		}
-		if bytes.Equal(k[6:8], del) { //deleted
-			ds += " (deleted)"
-		}
-
-		catAndIdx := idxToStr(idx)
-		main, idxName := "_", "_"
-		tokens := strings.Split(catAndIdx, ":")
-		if len(tokens) == 2 {
-			main, idxName = tokens[0], tokens[1]
+func (stats Statistics) GetStatisticsForDs(datasetName string, writer io.Writer) error {
+	o := map[string]any{}
+	err := stats.Store.GetObject(StoreMetaIndex, "stats", &o)
+	if err != nil {
+		return err
+	}
+	for k, v := range o {
+		if k == "entity" || k == "refs" {
+			subMaps := v.(map[string]any)
+			for _, v2 := range subMaps {
+				for k3, _ := range v2.(map[string]any) {
+					if k3 != datasetName {
+						delete(v2.(map[string]any), k3)
+					}
+				}
+			}
 		} else {
-			main = catAndIdx
-		}
-		o, _ := out[main].(map[string]any)
-		if o == nil {
-			o = map[string]any{}
-			out[main] = o
-		}
-		idxMap, _ := o[idxName].(map[string]any)
-		if idxMap == nil {
-			idxMap = map[string]any{}
-			o[idxName] = idxMap
+			delete(o, k)
 		}
 
-		dsMap, _ := idxMap[ds].(map[string]any)
-		if dsMap == nil {
-			dsMap = map[string]any{}
-			idxMap[ds] = dsMap
-		}
-
-		dsMap["keys"] = v
-		dsMap["total-value-size"] = ByteCountIEC(valueSizes[kS])
-		dsMap["total-key-size"] = ByteCountIEC(keySizes[kS])
-		dsMap["avg-value-size"] = ByteCountIEC(valueSizes[kS] / v)
-
 	}
-	return out
-}
-
-func idxToStr(idx uint16) string {
-	switch idx {
-	case URI_TO_ID_INDEX_ID:
-		return "urimap:URI_TO_ID_INDEX_ID"
-	case ENTITY_ID_TO_JSON_INDEX_ID:
-		return "entity:ENTITY_ID_TO_JSON_INDEX_ID"
-	case INCOMING_REF_INDEX:
-		return "refs:INCOMING_REF_INDEX"
-	case OUTGOING_REF_INDEX:
-		return "refs:OUTGOING_REF_INDEX"
-	case DATASET_ENTITY_CHANGE_LOG:
-		return "entity:DATASET_ENTITY_CHANGE_LOG"
-	case SYS_DATASETS_ID:
-		return "sys:SYS_DATASETS_ID"
-	case SYS_JOBS_ID:
-		return "sys:SYS_JOBS_ID"
-	case SYS_DATASETS_SEQUENCES:
-		return "sys:SYS_DATASETS_SEQUENCES"
-	case DATASET_LATEST_ENTITIES:
-		return "entity:DATASET_LATEST_ENTITIES"
-	case ID_TO_URI_INDEX_ID:
-		return "urimap:ID_TO_URI_INDEX_ID"
-	case NAMESPACES_INDEX:
-		return "sys:NAMESPACES_INDEX"
-	case JOB_RESULT_INDEX:
-		return "sys:JOB_RESULT_INDEX"
-	case STORE_META_INDEX:
-		return "sys:STORE_META_INDEX"
-	case JOB_DATA_INDEX:
-		return "sys:JOB_DATA_INDEX"
-	case JOB_CONFIGS_INDEX:
-		return "sys:JOB_CONFIGS_INDEX"
-	case CONTENT_INDEX:
-		return "sys:CONTENT_INDEX"
-	case STORE_NEXT_DATASET_ID:
-		return "sys:STORE_NEXT_DATASET_ID"
-	case LOGIN_PROVIDER_INDEX:
-		return "sys:LOGIN_PROVIDER_INDEX"
-	default:
-		return "sys:other"
-	}
-}
-
-func ByteCountIEC(b int64) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB",
-		float64(b)/float64(div), "KMGTPE"[exp])
+	return json.NewEncoder(writer).Encode(o)
 }

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -1540,7 +1540,7 @@ func (s *Store) GetObject(collection CollectionIndex, id string, obj interface{}
 
 	err := json.Unmarshal(data, obj)
 	if err != nil {
-		s.logger.Errorw("GetObject error: %", err.Error())
+		s.logger.Errorw("GetObject error: ", err.Error())
 		obj = nil
 		return err
 	}

--- a/internal/service/scheduler/gc_update.go
+++ b/internal/service/scheduler/gc_update.go
@@ -1,0 +1,31 @@
+package scheduler
+
+import (
+	"github.com/mimiro-io/datahub/internal/server"
+	"go.uber.org/zap"
+	"time"
+)
+
+func NewGCUpdate(logger *zap.SugaredLogger, gc *server.GarbageCollector) schedulable {
+	return newSchedulableTask("scheduled_gc", true, logger, func() RunResult {
+		ts := time.Now()
+		var err error
+		logger.Info("Starting to clean deleted datasets")
+		err = gc.Cleandeleted()
+		if err != nil {
+			logger.Warnf("cleaning of deleted datasets failed: %v", err.Error())
+			return RunResult{state: RunResultFailed, timestame: time.Now()}
+		} else {
+			logger.Infof("Finished cleaning of deleted datasets after %v", time.Since(ts).Round(time.Millisecond))
+		}
+		ts = time.Now()
+		logger.Info("Starting badger gc")
+		err = gc.GC()
+		if err != nil {
+			logger.Warn("badger gc failed: ", err)
+			return RunResult{state: RunResultFailed, timestame: time.Now()}
+		}
+		logger.Infof("Finished badger gc after %v", time.Since(ts).Round(time.Millisecond))
+		return RunResult{state: RunResultSuccess, timestame: time.Now()}
+	})
+}

--- a/internal/service/scheduler/schedulable.go
+++ b/internal/service/scheduler/schedulable.go
@@ -1,0 +1,93 @@
+package scheduler
+
+import (
+	"context"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+	"sync"
+	"time"
+)
+
+type runnable interface {
+	cron.Job
+	Stop(ctx context.Context)
+	ID() string
+}
+
+const (
+	// RunResultFailed is the state of a failed run
+	RunResultFailed = "failed"
+	// RunResultSuccess is the state of a successful run
+	RunResultSuccess = "success"
+
+	TaskStateRunning   = "running"
+	TaskStateScheduled = "scheduled"
+)
+
+type RunResult struct {
+	state     string
+	timestame time.Time
+}
+
+type schedulable interface {
+	runnable
+	ImmediateRun() bool
+	State() string
+}
+
+type schedulableTask struct {
+	lock         sync.Mutex
+	ticker       *time.Ticker
+	logger       *zap.SugaredLogger
+	run          func() RunResult
+	id           string
+	OnStop       func(ctx context.Context) error
+	state        string
+	sched        cron.Schedule
+	immediateRun bool
+}
+
+func (s *schedulableTask) ImmediateRun() bool {
+	return s.immediateRun
+}
+
+func (s *schedulableTask) State() string {
+	return s.state
+}
+
+func (s *schedulableTask) Stop(ctx context.Context) {
+	if s.OnStop != nil {
+		s.OnStop(ctx)
+	}
+}
+
+func (s *schedulableTask) ID() string {
+	return s.id
+}
+
+func newSchedulableTask(taskId string, immediateRun bool, logger *zap.SugaredLogger, run func() RunResult) *schedulableTask {
+	return &schedulableTask{
+		id:           taskId,
+		immediateRun: immediateRun,
+		logger:       logger,
+		run:          run,
+	}
+}
+
+func (s *schedulableTask) Run() {
+	s.lock.Lock()
+	s.state = TaskStateRunning
+	s.lock.Unlock()
+
+	go func() {
+		ts := time.Now()
+		defer func() {
+			s.lock.Lock()
+			s.state = TaskStateScheduled
+			s.lock.Unlock()
+		}()
+		res := s.run()
+		//TODO: store result in history
+		s.logger.Infof("Task %s completed with state %s in %s. Next run %v", s.ID(), res.state, time.Since(ts), s.sched.Next(time.Now()))
+	}()
+}

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -1,0 +1,59 @@
+package scheduler
+
+import (
+	"context"
+	"github.com/mimiro-io/datahub/internal/server"
+	"github.com/mimiro-io/datahub/internal/service/store"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+	"sync"
+)
+
+type Scheduler struct {
+	store   store.BadgerStore
+	gc      *server.GarbageCollector
+	logger  *zap.SugaredLogger
+	stopped bool
+	cron    *cron.Cron
+}
+
+func (s *Scheduler) Start() error {
+	s.cron.AddJob("0 19 * * *", NewStatisticsUpdater(s.logger, s.store))
+	s.cron.AddJob("0 2 * * *", NewGCUpdate(s.logger, s.gc))
+	s.cron.Start()
+	for _, e := range s.cron.Entries() {
+		task := e.Job.(schedulable)
+		if task.ImmediateRun() {
+			go func() {
+				s.logger.Infof("Running task %s immediately", task.ID())
+				task.Run()
+			}()
+		}
+		task.(*schedulableTask).sched = e.Schedule
+		s.logger.Infof("Scheduled task %s to run at %s", e.Job.(schedulable).ID(), e.Next)
+	}
+	return nil
+}
+
+func (s *Scheduler) Stop(ctx context.Context) {
+	s.stopped = true
+	s.cron.Stop()
+	for _, task := range s.cron.Entries() {
+		wg := sync.WaitGroup{}
+		go func() {
+			wg.Add(1)
+			defer wg.Done()
+			task.Job.(schedulable).Stop(ctx)
+		}()
+		wg.Wait()
+	}
+}
+
+func NewScheduler(logger *zap.SugaredLogger, gc *server.GarbageCollector, store store.BadgerStore) *Scheduler {
+	return &Scheduler{
+		logger: logger,
+		gc:     gc,
+		store:  store,
+		cron:   cron.New(),
+	}
+}

--- a/internal/service/scheduler/statistics_update.go
+++ b/internal/service/scheduler/statistics_update.go
@@ -1,0 +1,292 @@
+package scheduler
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/ristretto/z"
+	"github.com/mimiro-io/datahub/internal/service/store"
+	"github.com/mimiro-io/datahub/internal/service/types"
+	"go.uber.org/zap"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	URI_TO_ID_INDEX_ID         uint16 = 0
+	ENTITY_ID_TO_JSON_INDEX_ID uint16 = 1
+	INCOMING_REF_INDEX         uint16 = 2
+	OUTGOING_REF_INDEX         uint16 = 3
+	DATASET_ENTITY_CHANGE_LOG  uint16 = 4
+	SYS_DATASETS_ID            uint16 = 5
+	SYS_JOBS_ID                uint16 = 6
+	SYS_DATASETS_SEQUENCES     uint16 = 7
+	DATASET_LATEST_ENTITIES    uint16 = 8
+	ID_TO_URI_INDEX_ID         uint16 = 9
+
+	STORE_META_INDEX      uint16 = 10
+	NAMESPACES_INDEX      uint16 = 11
+	JOB_RESULT_INDEX      uint16 = 12
+	JOB_DATA_INDEX        uint16 = 13
+	JOB_CONFIGS_INDEX     uint16 = 14
+	CONTENT_INDEX         uint16 = 15
+	STORE_NEXT_DATASET_ID uint16 = 16
+	LOGIN_PROVIDER_INDEX  uint16 = 17
+)
+
+func NewStatisticsUpdater(logger *zap.SugaredLogger, store store.BadgerStore) schedulable {
+
+	stats := &Statistics{
+		badger: store,
+		Logger: logger,
+	}
+
+	statsKey := make([]byte, 2)
+	binary.BigEndian.PutUint16(statsKey, STORE_META_INDEX)
+	statsKey = append(statsKey, []byte("::stats")...)
+
+	t := newSchedulableTask("scheduled_stats_update", true, logger, func() RunResult {
+		ctx, cancel := context.WithCancel(context.Background())
+		stats.cancel = cancel
+		defer func() {
+			stats.cancel()
+			stats.cancel = nil
+		}()
+		stats.Logger.Infof("gathering counts for all datasets")
+		o := stats.count(ctx)
+		statBytes, err := json.Marshal(o)
+		if err != nil {
+			logger.Errorf("failed to marshal statistics: %v", err)
+			return RunResult{state: RunResultFailed, timestame: time.Now()}
+		}
+
+		err = store.GetDB().Update(func(txn *badger.Txn) error {
+			return txn.Set(statsKey, statBytes)
+		})
+
+		if err != nil {
+			logger.Errorf("failed to store statistics: %v", err)
+			return RunResult{state: RunResultFailed, timestame: time.Now()}
+		}
+		return RunResult{state: RunResultSuccess, timestame: time.Now()}
+	})
+
+	t.OnStop = func(ctx context.Context) error {
+		logger.Info("Stopping statistics updater")
+		return stats.Stop(ctx)
+
+	}
+	return t
+}
+
+type Statistics struct {
+	badger store.BadgerStore
+	Logger *zap.SugaredLogger
+	cancel context.CancelFunc
+}
+
+func (stats *Statistics) count(ctx context.Context) map[string]any {
+	s := stats.badger.GetDB().NewStream()
+	//s.NumGo = 16
+	counts := map[string]int64{}
+	keySizes := map[string]int64{}
+	valueSizes := map[string]int64{}
+	mapLock := sync.RWMutex{}
+	txn := stats.badger.GetDB().NewTransaction(false)
+	defer txn.Discard()
+	s.KeyToList = func(key []byte, itr *badger.Iterator) (*pb.KVList, error) {
+		item := itr.Item()
+		kv := &pb.KV{
+			//Key: y.Copy(item.Key()),
+			Key:   item.Key(),
+			Value: binary.BigEndian.AppendUint64(nil, uint64(item.ValueSize())),
+		}
+		return &pb.KVList{
+			Kv: []*pb.KV{kv},
+		}, nil
+	}
+	INCOMING_REF_BYTES := make([]byte, 2)
+	binary.BigEndian.PutUint16(INCOMING_REF_BYTES, INCOMING_REF_INDEX)
+	OUTGOING_REF_BYTES := make([]byte, 2)
+	binary.BigEndian.PutUint16(OUTGOING_REF_BYTES, OUTGOING_REF_INDEX)
+	DATASET_ENTITY_CHANGE_LOG_BYTES := make([]byte, 2)
+	binary.BigEndian.PutUint16(DATASET_ENTITY_CHANGE_LOG_BYTES, DATASET_ENTITY_CHANGE_LOG)
+	DATASET_LATEST_ENTITIES_BYTES := make([]byte, 2)
+	binary.BigEndian.PutUint16(DATASET_LATEST_ENTITIES_BYTES, DATASET_LATEST_ENTITIES)
+	ENTITY_ID_TO_JSON_INDEX_BYTES := make([]byte, 2)
+	binary.BigEndian.PutUint16(ENTITY_ID_TO_JSON_INDEX_BYTES, ENTITY_ID_TO_JSON_INDEX_ID)
+
+	s.Send = func(buf *z.Buffer) error {
+		mapLock.Lock()
+		defer mapLock.Unlock()
+		list, err := badger.BufferToKVList(buf)
+		if err != nil {
+			return err
+		}
+		for _, kv := range list.Kv {
+			cntKey := make([]byte, 8)
+			if kv.StreamDone {
+				return nil
+			}
+			idx := kv.Key[:2]
+			copy(cntKey[0:2], idx)
+
+			if bytes.Equal(idx, INCOMING_REF_BYTES) || bytes.Equal(idx, OUTGOING_REF_BYTES) {
+				copy(cntKey[2:6], kv.Key[36:40])
+				copy(cntKey[6:8], kv.Key[34:36]) // deleted
+			} else {
+				if bytes.Equal(idx, DATASET_ENTITY_CHANGE_LOG_BYTES) || bytes.Equal(idx, DATASET_LATEST_ENTITIES_BYTES) {
+					copy(cntKey[2:6], kv.Key[2:6])
+				}
+				if bytes.Equal(idx, ENTITY_ID_TO_JSON_INDEX_BYTES) {
+					copy(cntKey[2:6], kv.Key[10:14])
+				}
+			}
+
+			sKey := string(cntKey)
+			counts[sKey] += 1
+			keySizes[sKey] += int64(len(kv.Key))
+			valueSizes[sKey] += int64(binary.BigEndian.Uint64(kv.Value))
+		}
+		return err
+	}
+
+	s.Orchestrate(ctx)
+	mapLock.RLock()
+	defer mapLock.RUnlock()
+	out := map[string]any{}
+	del := []byte{0, 1}
+	for kS, v := range counts {
+		k := []byte(kS)
+		idx := binary.BigEndian.Uint16(k[:2])
+		dsId := binary.BigEndian.Uint32(k[2:6])
+		ds := "other"
+
+		if dsName, ok := stats.badger.LookupDatasetName(types.InternalDatasetID(dsId)); ok {
+			ds = dsName
+		}
+		if bytes.Equal(k[6:8], del) { //deleted
+			ds += " (deleted)"
+		}
+
+		catAndIdx := idxToStr(idx)
+		main, idxName := "_", "_"
+		tokens := strings.Split(catAndIdx, ":")
+		if len(tokens) == 2 {
+			main, idxName = tokens[0], tokens[1]
+		} else {
+			main = catAndIdx
+		}
+
+		o, _ := out[main].(map[string]any)
+		if o == nil {
+			o = map[string]any{}
+			out[main] = o
+		}
+		idxMap, _ := o[idxName].(map[string]any)
+		if idxMap == nil {
+			idxMap = map[string]any{}
+			o[idxName] = idxMap
+		}
+
+		dsMap, _ := idxMap[ds].(map[string]any)
+		if dsMap == nil {
+			dsMap = map[string]any{}
+			idxMap[ds] = dsMap
+		}
+
+		allMap, _ := idxMap["all"].(map[string]any)
+		if main == "entity" || main == "refs" {
+			if allMap == nil {
+				allMap = map[string]any{}
+				idxMap["all"] = allMap
+				allMap["keys"] = int64(0)
+				allMap["size-keys"] = int64(0)
+				allMap["size-values"] = int64(0)
+			}
+		}
+
+		dsMap["keys"] = v
+		dsMap["size-keys"] = keySizes[kS]
+		dsMap["size-values"] = valueSizes[kS]
+		//dsMap["total-value-size"] = map[string]any{"size": ByteCountIEC(valueSizes[kS]), "raw": valueSizes[kS]}
+		//dsMap["total-key-size"] = map[string]any{"size": ByteCountIEC(keySizes[kS]), "raw": keySizes[kS]}
+		//dsMap["avg-value-size"] = map[string]any{"size": ByteCountIEC(valueSizes[kS] / v), "raw": valueSizes[kS] / v}
+		if allMap != nil {
+			allMap["keys"] = allMap["keys"].(int64) + v
+			allMap["size-keys"] = allMap["size-keys"].(int64) + keySizes[kS]
+			allMap["size-values"] = allMap["size-values"].(int64) + valueSizes[kS]
+		}
+	}
+
+	return out
+}
+
+func (stats *Statistics) Stop(ctx context.Context) error {
+	if stats.cancel != nil {
+		stats.cancel()
+	}
+	return nil
+}
+
+func idxToStr(idx uint16) string {
+	switch idx {
+	case URI_TO_ID_INDEX_ID:
+		return "urimap:URI_TO_ID_INDEX_ID"
+	case ENTITY_ID_TO_JSON_INDEX_ID:
+		return "entity:ENTITY_ID_TO_JSON_INDEX_ID"
+	case INCOMING_REF_INDEX:
+		return "refs:INCOMING_REF_INDEX"
+	case OUTGOING_REF_INDEX:
+		return "refs:OUTGOING_REF_INDEX"
+	case DATASET_ENTITY_CHANGE_LOG:
+		return "entity:DATASET_ENTITY_CHANGE_LOG"
+	case SYS_DATASETS_ID:
+		return "sys:SYS_DATASETS_ID"
+	case SYS_JOBS_ID:
+		return "sys:SYS_JOBS_ID"
+	case SYS_DATASETS_SEQUENCES:
+		return "sys:SYS_DATASETS_SEQUENCES"
+	case DATASET_LATEST_ENTITIES:
+		return "entity:DATASET_LATEST_ENTITIES"
+	case ID_TO_URI_INDEX_ID:
+		return "urimap:ID_TO_URI_INDEX_ID"
+	case NAMESPACES_INDEX:
+		return "sys:NAMESPACES_INDEX"
+	case JOB_RESULT_INDEX:
+		return "sys:JOB_RESULT_INDEX"
+	case STORE_META_INDEX:
+		return "sys:STORE_META_INDEX"
+	case JOB_DATA_INDEX:
+		return "sys:JOB_DATA_INDEX"
+	case JOB_CONFIGS_INDEX:
+		return "sys:JOB_CONFIGS_INDEX"
+	case CONTENT_INDEX:
+		return "sys:CONTENT_INDEX"
+	case STORE_NEXT_DATASET_ID:
+		return "sys:STORE_NEXT_DATASET_ID"
+	case LOGIN_PROVIDER_INDEX:
+		return "sys:LOGIN_PROVIDER_INDEX"
+	default:
+		return "unknown:other"
+	}
+}
+
+func ByteCountIEC(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB",
+		float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/web/statisticshandler.go
+++ b/internal/web/statisticshandler.go
@@ -12,11 +12,11 @@ func RegisterStatisticsHandler(e *echo.Echo, logger *zap.SugaredLogger, mw *Midd
 	statistics := &server.Statistics{store, logger.Named("statistics")}
 
 	e.GET("/statistics", func(c echo.Context) error {
-		return statistics.GetStatistics(c.Response(), c.Request().Context())
+		return statistics.GetStatistics(c.Response())
 	}, mw.authorizer(log, datahubRead))
 
 	e.GET("/statistics/:ds", func(c echo.Context) error {
 		datasetName := c.Param("ds")
-		return statistics.GetStatisticsForDs(datasetName, c.Response(), c.Request().Context())
+		return statistics.GetStatisticsForDs(datasetName, c.Response())
 	}, mw.authorizer(log, datahubRead))
 }


### PR DESCRIPTION
since the gathering of badger stats can take a long time with larger data volumes, it is not practical to do the stat aggregation synchronously in an API request.

This change aggregagetes stats in a background job, once a day, and makes cached stats available in the API requests.

the garbage collector is now run regularly as well, and therefore https://github.com/mimiro-io/datahub/issues/1 is fully solved