### PR TITLE
improved entity equality check when storing entities

### DIFF
--- a/internal/jobs/transform.go
+++ b/internal/jobs/transform.go
@@ -591,16 +591,16 @@ func (javascriptTransform *JavascriptTransform) transformEntities(
 		resultEntities = make([]*server.Entity, 0)
 		for _, e := range v {
 			if entity, ok := e.(*server.Entity); ok {
-				typeFix(entity)
+				//typeFix(entity)
 				resultEntities = append(resultEntities, entity)
 			} else {
 				return nil, fmt.Errorf("transform emitted invalid entity: %v", e)
 			}
 		}
 	case []*server.Entity:
-		for _, entity := range v {
-			typeFix(entity)
-		}
+		//for _, entity := range v {
+		//	typeFix(entity)
+		//}
 
 		resultEntities = v
 	default:

--- a/internal/server/entity.go
+++ b/internal/server/entity.go
@@ -15,6 +15,8 @@
 package server
 
 import (
+	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -139,4 +141,166 @@ func (e *Entity) GetProperty(propName string) interface{} {
 	default:
 		return prop
 	}
+}
+
+func IsEntityEqualOld(prevJson []byte, thisJson []byte, prevEntity *Entity, thisEntity *Entity) bool {
+	if !(len(prevJson) == len(thisJson)) {
+		return false
+	}
+	if !reflect.DeepEqual(prevEntity.References, thisEntity.References) {
+		return false
+	}
+	return reflect.DeepEqual(prevEntity.Properties, thisEntity.Properties)
+}
+
+func toMap(in any, tag string) (map[string]any, error) {
+	out := make(map[string]any)
+
+	v := reflect.ValueOf(in)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	// we only accept structs
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("toMap only accepts structs; got %T", v)
+	}
+
+	typ := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		// gets us a StructField
+		fi := typ.Field(i)
+		if tagv := fi.Tag.Get(tag); tagv != "" {
+			val := v.Field(i).Interface()
+			// set key of map to value in struct field
+			t := strings.SplitN(tagv, ",", 2)
+			if len(t) > 1 && t[1] == "omitempty" { //&& reflect.DeepEqual(val, reflect.Zero(v.Field(i).Type()).Interface()) {
+				if t[0] == "deleted" && val == false {
+					continue
+				}
+				if t[0] == "recorded" && val == uint64(0) {
+					continue
+				}
+			}
+			if t[0] == "refs" {
+				refs := val.(map[string]interface{})
+				for k, v := range refs {
+					refs[k], _ = toJsonValue(v)
+				}
+			}
+			if t[0] == "props" {
+				props := val.(map[string]interface{})
+				for k, v := range props {
+					props[k], _ = toJsonValue(v)
+				}
+			}
+			out[t[0]], _ = toJsonValue(val)
+		}
+	}
+	return out, nil
+}
+
+func toJsonValue(value any) (any, reflect.Type) {
+	vt := reflect.ValueOf(value)
+	if vt.Kind() == reflect.Ptr {
+		vt = vt.Elem()
+	}
+
+	if vt.Kind() == reflect.Slice {
+		v2 := make([]any, vt.Len(), vt.Cap())
+		for i := 0; i < vt.Len(); i++ {
+			v2[i], _ = toJsonValue(vt.Index(i).Interface())
+		}
+		value = v2
+	}
+
+	// TODO: https://open.mimiro.io/specifications/uda/latest.html#the-entity-graph-data-model
+	// maps as properties are now allowed according to the spec, so we are not making an effort to
+	// align the map values with json types. This is a potential issue since nothing
+	// in transforms prevents putting maps in properties (but the spec does not allow it).
+
+	//if vt.Kind() == reflect.Map {
+	//v2 := make(map[string]any)
+	//for _, k := range vt.MapKeys() {
+	//	v2[k.String()], _ = toJsonValue(vt.MapIndex(k).Interface())
+	//}
+	//value = v2
+	//}
+	if vt.Kind() == reflect.Struct {
+		v2, _ := toMap(value, "json")
+		vt = reflect.ValueOf(v2)
+		value = v2
+	}
+
+	switch v := value.(type) {
+	case map[string]interface{}:
+		return v, vt.Type()
+	case []interface{}:
+		return v, vt.Type()
+	case string:
+		return v, vt.Type()
+	case int:
+		return float64(v), vt.Type()
+	case int8:
+		return float64(v), vt.Type()
+	case int16:
+		return float64(v), vt.Type()
+	case int32:
+		return float64(v), vt.Type()
+	case int64:
+		return float64(v), vt.Type()
+	case uint:
+		return float64(v), vt.Type()
+	case uint8:
+		return float64(v), vt.Type()
+	case uint16:
+		return float64(v), vt.Type()
+	case uint32:
+		return float64(v), vt.Type()
+	case uint64:
+		return float64(v), vt.Type()
+	case float32:
+		return float64(v), vt.Type()
+	case []map[string]any:
+		return v, vt.Type()
+	default:
+		return v, vt.Type()
+	}
+}
+func IsEntityEqual(prevJson []byte, thisJson []byte, prevEntity *Entity, thisEntity *Entity) bool {
+	if !(len(prevJson) == len(thisJson)) {
+		return false
+	}
+
+	// assuming that the length check is enough to determine that refs and props have the same keys
+	// it is theoretically possible to have the same json length with different keys ... consider matching keys in both objects as well.
+	for i, v := range prevEntity.References {
+		thisVal, ok := thisEntity.References[i]
+		if !ok {
+			return false
+		}
+		v1, t1 := toJsonValue(v)
+		v2, _ := toJsonValue(thisVal)
+		if t1.Kind() == reflect.Slice && !reflect.DeepEqual(v1, v2) {
+			return false
+		} else if v1 != v2 {
+			return false
+		}
+	}
+	for k, v := range prevEntity.Properties {
+		v1, t1 := toJsonValue(v)
+		thisVal, ok := thisEntity.Properties[k]
+		if !ok {
+			return false
+		}
+		v2, _ := toJsonValue(thisVal)
+		if t1.Kind() == reflect.Slice || t1.Kind() == reflect.Map {
+			if !reflect.DeepEqual(v1, v2) {
+				return false
+			}
+		} else if v1 != v2 {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/server/entity.go
+++ b/internal/server/entity.go
@@ -280,9 +280,11 @@ func IsEntityEqual(prevJson []byte, thisJson []byte, prevEntity *Entity, thisEnt
 			return false
 		}
 		v1, t1 := toJsonValue(v)
-		v2, _ := toJsonValue(thisVal)
-		if t1.Kind() == reflect.Slice && !reflect.DeepEqual(v1, v2) {
-			return false
+		v2, t2 := toJsonValue(thisVal)
+		if t1.Kind() == reflect.Slice || t2.Kind() == reflect.Slice {
+			if !reflect.DeepEqual(v1, v2) {
+				return false
+			}
 		} else if v1 != v2 {
 			return false
 		}
@@ -293,8 +295,8 @@ func IsEntityEqual(prevJson []byte, thisJson []byte, prevEntity *Entity, thisEnt
 		if !ok {
 			return false
 		}
-		v2, _ := toJsonValue(thisVal)
-		if t1.Kind() == reflect.Slice || t1.Kind() == reflect.Map {
+		v2, t2 := toJsonValue(thisVal)
+		if t1.Kind() == reflect.Slice || t1.Kind() == reflect.Map || t2.Kind() == reflect.Slice || t2.Kind() == reflect.Map {
 			if !reflect.DeepEqual(v1, v2) {
 				return false
 			}

--- a/internal/server/entity_test.go
+++ b/internal/server/entity_test.go
@@ -1,0 +1,344 @@
+package server
+
+import (
+	"encoding/json"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+var _ = ginkgo.Describe("the IsEntityEqual function",
+	func() {
+		newEntities := func(f func(newEntity *Entity, prevEntity *Entity)) (*Entity, *Entity, []byte, []byte) {
+			newEntity := NewEntity("ns0:entity1", 1)
+			prevEntity := NewEntity("ns0:entity1", 1)
+			newEntity.Properties["ns0:prop1"] = "value1"
+			newEntity.Recorded = 5
+			prevEntity.Properties["ns0:prop1"] = "value1"
+			prevEntity.Recorded = 4
+
+			// apply overrides
+			if f != nil {
+				f(newEntity, prevEntity)
+			}
+
+			newEntityJson, _ := json.Marshal(newEntity)
+			prevEntityJson, _ := json.Marshal(prevEntity)
+			json.Unmarshal(prevEntityJson, &prevEntity) // need to simulate that prevEntity is loaded from store and therefore unmarshaled
+
+			return newEntity, prevEntity, newEntityJson, prevEntityJson
+		}
+
+		// mark as equal
+
+		ginkgo.It("should return true: simple props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(nil)
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+		ginkgo.It("should return true: number props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = 1
+				newEntity.Properties["ns0:prop1"] = 1
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+		ginkgo.It("should return true: float props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = float32(1.5)
+				newEntity.Properties["ns0:prop1"] = float32(1.5)
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+		ginkgo.It("should return true: bool props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = true
+				newEntity.Properties["ns0:prop1"] = true
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+		ginkgo.It("should return true: string array props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = []string{"value1", "value2"}
+				newEntity.Properties["ns0:prop1"] = []string{"value1", "value2"}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+		ginkgo.It("should return true: any array props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = []any{"value1", int64(1.0)}
+				newEntity.Properties["ns0:prop1"] = []any{"value1", int64(1.0)}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+		ginkgo.It("should return true: number array props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = []int64{1, 2}
+				newEntity.Properties["ns0:prop1"] = []int64{1, 2}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+		ginkgo.It("should return true: bool array props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = []bool{true, false}
+				newEntity.Properties["ns0:prop1"] = []bool{true, false}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+		ginkgo.It("should return true: nested entity props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = NewEntity("ns0:entity2", 2)
+				prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop2"] = "value2"
+				prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop3"] = true
+				prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop4"] = 1
+				prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop5"] = []int64{1, 2}
+				prevEntity.Properties["ns0:prop2"] = []*Entity{NewEntity("ns0:entity3", 3), NewEntity("ns0:entity4", 4)}
+
+				newEntity.Properties["ns0:prop1"] = NewEntity("ns0:entity2", 2)
+				newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop2"] = "value2"
+				newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop3"] = true
+				newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop4"] = 1
+				newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop5"] = []int64{1, 2}
+				newEntity.Properties["ns0:prop2"] = []*Entity{NewEntity("ns0:entity3", 3), NewEntity("ns0:entity4", 4)}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeTrue())
+		})
+
+		// mark as different
+
+		ginkgo.It("should return false: deleted", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				newEntity.IsDeleted = true
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false:undeleted", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.IsDeleted = true
+				newEntity.IsDeleted = false
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false: add props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				newEntity.Properties["ns0:prop1"] = "value2"
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+
+		ginkgo.It("should return false: rm props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = "value2"
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false: change props", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = "value2"
+				newEntity.Properties["ns0:prop1"] = "value3"
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+
+			newEntity, prevEntity, newEntityJson, prevEntityJson = newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = 6.3
+				newEntity.Properties["ns0:prop1"] = 6.4
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false: different type", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = "1"
+				newEntity.Properties["ns0:prop1"] = 1
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+
+			newEntity, prevEntity, newEntityJson, prevEntityJson = newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = "hello"
+				newEntity.Properties["ns0:prop1"] = []string{"hello"}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+
+			newEntity, prevEntity, newEntityJson, prevEntityJson = newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = []string{"hello"}
+				newEntity.Properties["ns0:prop1"] = true
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false: changed array", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = []int64{1, 2}
+				newEntity.Properties["ns0:prop1"] = []int64{1, 3}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+
+		ginkgo.It("should return false: change in nested entity ", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.Properties["ns0:prop1"] = NewEntity("ns0:entity2", 2)
+				prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop2"] = "value2"
+				prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop3"] = true
+				prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop4"] = 1
+				prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop5"] = []int64{1, 2}
+
+				newEntity.Properties["ns0:prop1"] = NewEntity("ns0:entity2", 2)
+				newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop2"] = "value2"
+				newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop3"] = true
+				newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop4"] = 1
+				newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop5"] = []int64{1, 3}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false: add ref", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				newEntity.References["ns0:ref1"] = "value1"
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false: rm ref", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.References["ns0:ref1"] = "value1"
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false: change ref", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.References["ns0:ref1"] = "value1"
+				newEntity.References["ns0:ref1"] = "value2"
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+		ginkgo.It("should return false: change ref array", func() {
+			newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.References["ns0:ref1"] = []any{"value1", "value2"}
+				newEntity.References["ns0:ref1"] = []any{"value1", "value3"}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+			newEntity, prevEntity, newEntityJson, prevEntityJson = newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.References["ns0:ref1"] = "value1"
+				newEntity.References["ns0:ref1"] = []any{"value1", "value3"}
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+			newEntity, prevEntity, newEntityJson, prevEntityJson = newEntities(func(newEntity *Entity, prevEntity *Entity) {
+				prevEntity.References["ns0:ref1"] = []any{"value1", "value3"}
+				newEntity.References["ns0:ref1"] = "value1"
+			})
+			Expect(IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)).To(BeFalse())
+		})
+	})
+
+func BenchmarkIsEntityEqual(b *testing.B) {
+	newEntities := func(f func(newEntity *Entity, prevEntity *Entity)) (*Entity, *Entity, []byte, []byte) {
+		newEntity := NewEntity("ns0:entity1", 1)
+		prevEntity := NewEntity("ns0:entity1", 1)
+		newEntity.Properties["ns0:prop1"] = "value1"
+		newEntity.Recorded = 5
+		prevEntity.Properties["ns0:prop1"] = "value1"
+		prevEntity.Recorded = 4
+
+		// apply overrides
+		if f != nil {
+			f(newEntity, prevEntity)
+		}
+
+		newEntityJson, _ := json.Marshal(newEntity)
+		prevEntityJson, _ := json.Marshal(prevEntity)
+		json.Unmarshal(prevEntityJson, &prevEntity) // need to simulate that prevEntity is loaded from store and therefore unmarshaled
+
+		return newEntity, prevEntity, newEntityJson, prevEntityJson
+	}
+	newEntity, prevEntity, newEntityJson, prevEntityJson := newEntities(func(newEntity *Entity, prevEntity *Entity) {
+		prevEntity.Properties["ns0:prop1"] = NewEntity("ns0:entity2", 2)
+		prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop2"] = "value2"
+		prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop3"] = true
+		prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop4"] = 1
+		prevEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop5"] = []int64{1, 2}
+		prevEntity.References["ns0:ref1"] = "value1"
+		newEntity.Properties["ns0:prop1"] = NewEntity("ns0:entity2", 2)
+		newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop2"] = "value2"
+		newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop3"] = true
+		newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop4"] = 1
+		newEntity.Properties["ns0:prop1"].(*Entity).Properties["ns0:prop5"] = []int64{1, 2}
+		newEntity.References["ns0:ref1"] = "value1"
+	})
+
+	b.Run("IsEntityEqual with nested entities", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)
+		}
+	})
+
+	b.Run("IsEntityEqualOld with nested entities", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			IsEntityEqualOld(prevEntityJson, newEntityJson, prevEntity, newEntity)
+		}
+	})
+	newEntity, prevEntity, newEntityJson, prevEntityJson = newEntities(func(newEntity *Entity, prevEntity *Entity) {
+		prevEntity.Properties["ns0:prop1"] = "value1"
+		prevEntity.Properties["ns0:prop2"] = 10
+		prevEntity.Properties["ns0:prop3"] = true
+		prevEntity.Properties["ns0:prop4"] = 1.5
+		prevEntity.References["ns0:ref1"] = "value1"
+		prevEntity.References["ns0:ref2"] = "value2"
+		prevEntity.References["ns0:ref3"] = "value3"
+		prevEntity.References["ns0:ref4"] = "value4"
+
+		newEntity.Properties["ns0:prop1"] = "value1"
+		newEntity.Properties["ns0:prop2"] = 10
+		newEntity.Properties["ns0:prop3"] = true
+		newEntity.Properties["ns0:prop4"] = 1.5
+		newEntity.References["ns0:ref1"] = "value1"
+		newEntity.References["ns0:ref2"] = "value2"
+		newEntity.References["ns0:ref3"] = "value3"
+		newEntity.References["ns0:ref4"] = "value4"
+
+	})
+	b.Run("IsEntityEqual only literals", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)
+		}
+	})
+
+	b.Run("IsEntityEqualOld only literals", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			IsEntityEqualOld(prevEntityJson, newEntityJson, prevEntity, newEntity)
+		}
+	})
+
+	newEntity, prevEntity, newEntityJson, prevEntityJson = newEntities(func(newEntity *Entity, prevEntity *Entity) {
+		prevEntity.Properties["ns0:prop1"] = []int64{1, 2}
+		prevEntity.Properties["ns0:prop2"] = "hello"
+		prevEntity.Properties["ns0:prop3"] = true
+		prevEntity.Properties["ns0:prop4"] = 1.5
+		prevEntity.References["ns0:ref1"] = "value1"
+		prevEntity.References["ns0:ref2"] = []any{"value1", "value2"}
+		newEntity.Properties["ns0:prop1"] = []int64{1, 2}
+		newEntity.Properties["ns0:prop2"] = "hello"
+		newEntity.Properties["ns0:prop3"] = true
+		newEntity.Properties["ns0:prop4"] = 1.5
+		newEntity.References["ns0:ref1"] = "value1"
+		newEntity.References["ns0:ref2"] = []any{"value1", "value2"}
+	})
+	b.Run("IsEntityEqual literals and slices", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			IsEntityEqual(prevEntityJson, newEntityJson, prevEntity, newEntity)
+		}
+	})
+
+	b.Run("IsEntityEqualOld literals and slices", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			IsEntityEqualOld(prevEntityJson, newEntityJson, prevEntity, newEntity)
+		}
+	})
+
+}

--- a/internal/web/statisticshandler.go
+++ b/internal/web/statisticshandler.go
@@ -9,7 +9,7 @@ import (
 func RegisterStatisticsHandler(e *echo.Echo, logger *zap.SugaredLogger, mw *Middleware, store *server.Store) {
 	log := logger.Named("web")
 
-	statistics := &server.Statistics{store, logger.Named("statistics")}
+	statistics := &server.Statistics{Store: store, Logger: logger.Named("statistics")}
 
 	e.GET("/statistics", func(c echo.Context) error {
 		return statistics.GetStatistics(c.Response())


### PR DESCRIPTION
Closes #315 

the new implementation is now correct for nested entities, number
values, array values. see entity_test.go for covered cases.

the new implementation is twice as fast when comparing entities with
only literal values, compared to the old impl. When arrays or nested
entities are encountered, it is comparably slower. but the old impl
would give a wrong result while being fast.

There is a benchmark test included in entity_test.go, which illustrates
the performance difference.

![image](https://github.com/user-attachments/assets/4f0573f1-b686-4943-a222-ea4c64741522)
