### PR TITLE
introduce contextual store to track accessed datasets during transform

### DIFF
--- a/internal/jobs/error_handler.go
+++ b/internal/jobs/error_handler.go
@@ -111,6 +111,10 @@ type wrappedTransform struct {
 	jobId                 string
 }
 
+func (w *wrappedTransform) EndStoreContext(s string) error {
+	return w.EndStoreContext(s)
+}
+
 type wrappedSink struct {
 	s                     Sink
 	failingEntityHandlers []failingEntityHandler

--- a/internal/jobs/pipeline.go
+++ b/internal/jobs/pipeline.go
@@ -154,6 +154,13 @@ func (pipeline *FullSyncPipeline) sync(job *job, ctx context.Context) (int, erro
 		return entCnt, err
 	}
 
+	if pipeline.transform != nil {
+		err = pipeline.transform.EndStoreContext(job.id)
+		if err != nil {
+			return entCnt, err
+		}
+	}
+
 	//Do not store syncState when the target is an http sink.
 	//Since we use entities for httpsinks, the continuation tokens are base64 strings and not compatible with incremental tokens
 	//
@@ -333,5 +340,11 @@ func (pipeline *IncrementalPipeline) sync(job *job, ctx context.Context) (int, e
 		}
 	}
 
+	if pipeline.transform != nil {
+		err = pipeline.transform.EndStoreContext(job.id)
+		if err != nil {
+			return entCnt, err
+		}
+	}
 	return entCnt, nil
 }

--- a/internal/jobs/pipeline_history_test.go
+++ b/internal/jobs/pipeline_history_test.go
@@ -83,6 +83,11 @@ var _ = Describe("Over time, a pipeline", func() {
 		checkEntities("homer_1", "Mimiro_1", "")
 		checkChange(0, "homer_1", "Mimiro_1", "")
 		assertChangeCount(1)
+
+		// transform queries company, check that it is in job meta
+		ctxMeta := &server.MetaContext{}
+		Expect(store.GetObject(server.JobMetaIndex, "sync-datasetsource-to-datasetsink-with-js-and-query", ctxMeta)).To(BeNil())
+		Expect(ctxMeta.QueriedDatasets).To(HaveKey(companies.InternalID))
 	})
 	It("Should produce consistent output for changes in dependency dataset", func() {
 		ns, employees, people, companies := setupDatasets(store, dsm)

--- a/internal/jobs/pipeline_test.go
+++ b/internal/jobs/pipeline_test.go
@@ -217,6 +217,11 @@ var _ = Describe("A pipeline", func() {
 		Expect(err).To(BeNil(), "no result is retrieved")
 
 		Expect(len(result.Entities)).To(Equal(1), "incorrect number of entities retrieved")
+
+		// transform uses txn to write to another dataset, check that dataset is in job meta
+		ctxMeta := &server.MetaContext{}
+		Expect(store.GetObject(server.JobMetaIndex, "sync-datasetsource-to-datasetsink-with-js", ctxMeta)).To(BeNil())
+		Expect(ctxMeta.TransactionSink).To(HaveKey("NewProducts"))
 	})
 
 	It("Should fullsync to an HttpDatasetSink", func() {

--- a/internal/server/constants.go
+++ b/internal/server/constants.go
@@ -38,6 +38,7 @@ const (
 	ContentIndex       CollectionIndex = 15
 	StoreNextDatasetID CollectionIndex = 16
 	LoginProviderIndex CollectionIndex = 17
+	JobMetaIndex       CollectionIndex = 18
 )
 
 var (


### PR DESCRIPTION
In this change, each transform instance uses its own copy of the `Store` struct. These contextual stores can be used to track information during the lifetime of a single transform, without introducing new parameters or other API changes.
The use case in this issue is to track which datasets are accessed from a transform script via queries or transactions.