### PR TITLE
add flatten on start

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1926,6 +1926,11 @@ The Datahub supports reporting metrics trough a StatsD server. This is turned of
 
 Can be used to override Badger's default 7 LSM levels. When more that 1.1TB disk space usage are exceeded or expected to be exceeded, 8 compaction levels are needed.
 
+`FLATTEN_ON_START`
+
+boolean flag to make datahub flatten the database on start. This is useful when you have deleted a lot of data in the database and you want to release some disk space.
+Should only be set temporarily, as it slows startup time down considerably.
+
 #### Securing the Data Hub
 
 There are two main security models for the data hub.

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -82,6 +82,7 @@ func load(basePath string) (*Config, error) {
 		BlockCacheSize:          viper.GetInt64("BLOCK_CACHE_SIZE"),
 		ValueLogFileSize:        viper.GetInt64("VALUE_LOG_FILE_SIZE"),
 		MaxCompactionLevels:     viper.GetInt("MAX_COMPACTION_LEVELS"),
+		FlattenOnStart:          viper.GetBool("FLATTEN_ON_START"),
 		AdminUserName:           viper.GetString("ADMIN_USERNAME"),
 		AdminPassword:           viper.GetString("ADMIN_PASSWORD"),
 		NodeID:                  viper.GetString("NODE_ID"),
@@ -152,7 +153,7 @@ func parse(basePath string, logger *zap.SugaredLogger) error {
 	viper.SetConfigType("env")
 	viper.SetConfigName(configFile)
 	viper.AddConfigPath(path)
-	
+
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// Config file not found; ignore error if desired

--- a/internal/conf/environment.go
+++ b/internal/conf/environment.go
@@ -37,6 +37,7 @@ type Config struct {
 	BlockCacheSize          int64
 	ValueLogFileSize        int64
 	MaxCompactionLevels     int
+	FlattenOnStart          bool
 	AdminUserName           string
 	AdminPassword           string
 	NodeID                  string


### PR DESCRIPTION
large deletions in datahub often are not reflected as reclaimed disk space immediately. Datahub is reliant on badger compactions to clean up the LSM tree where everything is stored.

In normal operation, badger compactions can not be forced and happen in mostly unpredictable patterns.

This change introduces the flag FLATTEN_ON_START, which forces a db.Flatten() call into badger. Since this operation should not run in parallel with other writing processes, startup of jobs and API are blocked until the flattening is done. 