### PR TITLE
endpoint to reset job meta ( lineage data )

### DIFF
--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -429,6 +429,22 @@ func (s *Scheduler) ResetJob(jobid string, since string) error {
 	return nil
 }
 
+func (s *Scheduler) ResetJobMeta(jobid string) error {
+	jobTitle := s.resolveJobTitle(jobid)
+	s.Logger.Infof("Resetting job meta for job with id '%s' (%s)", jobid, jobTitle)
+	meta := &server.MetaContext{}
+	err := s.Store.GetObject(server.JobMetaIndex, jobid, meta)
+	if err != nil {
+		return fmt.Errorf("error getting meta for job with id '%s' (%s)", jobid, jobTitle)
+	}
+
+	err = s.Store.StoreObject(server.JobMetaIndex, jobid, &server.MetaContext{})
+	if err != nil {
+		return fmt.Errorf("error resetting meta for job with id '%s' (%s)", jobid, jobTitle)
+	}
+	return nil
+}
+
 // RunJob runs an existing job, if not already running. It does so by adding a temp job to the scheduler, without saving it.
 // The temp job is added with the RunOnce flag set to true
 func (s *Scheduler) RunJob(jobid string, jobType string) (string, error) {

--- a/internal/web/joboperationhandler.go
+++ b/internal/web/joboperationhandler.go
@@ -43,6 +43,7 @@ func RegisterJobOperationHandler(
 	e.PUT("/job/:jobid/kill", handler.jobsKill, mw.authorizer(log, datahubWrite))
 	e.PUT("/job/:jobid/run", handler.jobsRun, mw.authorizer(log, datahubWrite))
 	e.PUT("/job/:jobid/reset", handler.jobsReset, mw.authorizer(log, datahubWrite))
+	e.PUT("/job/:jobid/reset_meta", handler.jobsResetMeta, mw.authorizer(log, datahubWrite))
 	e.GET("/job/:jobid/status", handler.jobsGetStatus, mw.authorizer(log, datahubRead)) // is it running
 }
 
@@ -92,6 +93,16 @@ func (handler *jobOperationHandler) jobsReset(c echo.Context) error {
 	since := c.QueryParam("since")
 
 	err := handler.jobScheduler.ResetJob(jobID, since)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, "internal error")
+	}
+	return c.JSON(http.StatusOK, &JobResponse{JobID: jobID})
+}
+
+func (handler *jobOperationHandler) jobsResetMeta(c echo.Context) error {
+	jobID := c.Param("jobid")
+
+	err := handler.jobScheduler.ResetJobMeta(jobID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, "internal error")
 	}


### PR DESCRIPTION
closes #360 

the mim CLI should be updated to provide a job operation for calling this new endpoint