### PR TITLE
Fix race condition in GetPrefixToExpansionMap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder_src
+FROM golang:1.26.4 AS builder_src
 
 COPY jemalloc-install.sh .
 RUN apt-get update -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder_src
+FROM golang:1.24 AS builder_src
 
 COPY jemalloc-install.sh .
 RUN apt-get update -y

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -281,7 +281,10 @@ func (namespaceManager *NamespaceManager) GetPrefixMappingForExpansion(uriExpans
 
 func (namespaceManager *NamespaceManager) GetPrefixToExpansionMap() (result map[string]string) {
 	namespaceManager.lock.Lock()
-	result = namespaceManager.prefixToExpansionMapping
+	result = make(map[string]string, len(namespaceManager.prefixToExpansionMapping))
+	for k, v := range namespaceManager.prefixToExpansionMapping {
+		result[k] = v
+	}
 	namespaceManager.lock.Unlock()
 	return
 }


### PR DESCRIPTION
## Problem

`GetPrefixToExpansionMap` returned a direct reference to the internal `prefixToExpansionMapping` map:

```go
func (namespaceManager *NamespaceManager) GetPrefixToExpansionMap() (result map[string]string) {
    namespaceManager.lock.Lock()
    result = namespaceManager.prefixToExpansionMapping
    namespaceManager.lock.Unlock()
    return
}
```

The lock is released before the caller uses the map. This means any goroutine that calls `AssertPrefixMappingForExpansion` concurrently can write to the same map while the caller is iterating over it — causing a `fatal error: concurrent map iteration and map write` panic.

The race is triggered when multiple HTTP requests arrive simultaneously. One request iterates the namespace map (e.g. in `GetGlobalContext` → `json.Marshal`) while another writes to it (e.g. in `AssertPrefixMappingForExpansion` → `StoreObject` → `json.Marshal`).

**Stack trace from the panic:**

fatal error: concurrent map iteration and map write

goroutine [running]:

internal/runtime/maps.(*Iter).Next(...)

.../internal/runtime/maps/table.go:683

github.com/mimiro-io/datahub/internal/server.(*Store).GetGlobalContext(...)

.../internal/server/store.go:433

github.com/mimiro-io/datahub/internal/jobs.(*httpDatasetSink).processEntities(...)

.../internal/jobs/sink.go:257

## Fix

Return a copy of the map while the lock is held, so the caller always gets a snapshot that no other goroutine can modify:

```go
func (namespaceManager *NamespaceManager) GetPrefixToExpansionMap() (result map[string]string) {
    namespaceManager.lock.Lock()
    result = make(map[string]string, len(namespaceManager.prefixToExpansionMapping))
    for k, v := range namespaceManager.prefixToExpansionMapping {
        result[k] = v
    }
    namespaceManager.lock.Unlock()
    return
}
```

## Verification

Confirmed by running the datahub system test suite with `-jobs-in-parallel 10`, which submits many concurrent HTTP requests and consistently triggered the panic before this fix. After the fix, the suite runs cleanly with no race conditions.