### PR TITLE
Fix backup id guard for rsync layouts

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2206,25 +2206,46 @@ When the provider is used the first time, the values are loaded from their store
 
 #### Backup
 
-Backup of the Datahub is important. This makes sure you can recover from disaster.
+The Datahub backs up its store on a schedule. Configuring a backup location enables it.
 
 `BACKUP_LOCATION=`
 
-To enable back, a backup location needs to be configured. The Datahub will attempt to create the directories in this location if they are missing.
+The directory the backup is written to. The Datahub creates it if it is missing.
 
-We do recomment that you put the backup on a separate disk from the STORE_LOCATION for performance reasons. If you are in a Cloud setup, you should probably use something like AWS ELB to make sure your disk survive a shutdown.
+Put the backup on a separate disk from the store for performance. In a cloud setup, use a disk that survives a shutdown, such as an AWS EBS volume.
 
 `BACKUP_SCHEDULE=`
 
-The backup gets scheduled in the internal Job runner in the Datahub, and the schedule supports the same cron schedules as regular Jobs. You can find the documentation [here](https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format).
-
-If you don't provide a schedule, the default schedule is "_/5 _ \* \* \*", aka every 5 minutes.
+A cron expression, the same format as Job schedules ([cron format reference](https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format)). The default is `*/5 * * * *`, every 5 minutes.
 
 `BACKUP_USE_RSYNC=true`
 
-If this is true, then the backup will use rsync for it's backup. rsync must be installed, and on the path for this to work.
-If this is false, the Badger DB native backup will be used instead.
+When true, each backup run mirrors the store to the backup location with rsync. rsync must be installed and on the path.
 
+When false, the Badger DB native backup is used.
+
+`BACKUP_SOURCE_LOCATION=`
+
+The directory rsync backs up. It defaults to the `STORE_LOCATION` setting, which backs up the store alone.
+
+Point it at a common parent to also cover sibling state, such as the `SECURITY_STORAGE_LOCATION` directory. It must always contain the store location. The Datahub refuses to start otherwise.
+
+A trailing slash makes rsync mirror the directory's contents onto the backup location root.
+
+##### The backup id
+
+A `DATAHUB_BACKUPID` file marks which store a backup belongs to. The store creates the file in the store location on first start.
+
+Every backup run compares this id with the one in the backup before writing anything:
+
+- The first backup into an empty backup location places the id file.
+- A mismatch halts the process instead of overwriting another store's backup.
+- A backup location with content but no id file also halts. If the backup belongs to the current store, copy the id file to the path named in the error log.
+
+##### Restoring a backup
+
+- An rsync backup mirrors the backup source. Copy the store's files, id file included, back to the store location.
+- A native backup keeps the id file at the backup location root. After restoring it, copy `DATAHUB_BACKUPID` into the store location before starting the Datahub.
 
 #### Logging profile
 

--- a/internal/server/backup.go
+++ b/internal/server/backup.go
@@ -16,10 +16,12 @@ package server
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/bamzi/jobrunner"
 	"github.com/robfig/cron/v3"
@@ -61,6 +63,10 @@ func NewBackupManager(store *Store, env *conf.Config) (*BackupManager, error) {
 	backup.useRsync = env.BackupRsync
 	backup.store = store
 	backup.logger = env.Logger.Named("backup")
+
+	if _, err := backup.backedUpIDFile(); err != nil {
+		return nil, err
+	}
 
 	// load last id
 	lastID, err := backup.LoadLastID()
@@ -181,39 +187,100 @@ func (backupManager *BackupManager) validLocation() bool {
 	dhIDFile := filepath.Join(backupManager.store.storeLocation, StorageIDFileName)
 	b, err := os.ReadFile(dhIDFile)
 	if err != nil {
-		backupManager.logger.Warnf("could not read DATAHUB_BACKUPID file")
+		backupManager.logger.Warnf("could not read %v file at %v. (%v)", StorageIDFileName, dhIDFile, err)
 		return false
 	}
 	dhID := string(b)
-	backedUpDhIDFile := filepath.Join(backupManager.backupLocation, StorageIDFileName)
-	b, err = os.ReadFile(backedUpDhIDFile)
-	if err != nil {
-		backupManager.logger.Infof("could not read DATAHUB_BACKUPID file at backup location. copying now")
-		source, err := os.Open(dhIDFile)
-		if err != nil {
-			backupManager.logger.Errorf("Could not open backup id file at %v.", dhIDFile)
-			return false
-		}
-		defer source.Close()
 
-		err = os.MkdirAll(backupManager.backupLocation, 0o700)
-		if err != nil {
-			backupManager.logger.Errorf("Could create backup dir at %v. (%w)", backupManager.backupLocation, err)
-			return false
-		}
-		destination, err := os.Create(backedUpDhIDFile)
-		if err != nil {
-			backupManager.logger.Errorf("Could not open backed up id file at %v. (%w)", backedUpDhIDFile, err)
-			return false
-		}
-		defer destination.Close()
-		_, err = io.Copy(destination, source)
-		if err != nil {
-			backupManager.logger.Errorf("Could not copý %v to %v.", dhIDFile, backedUpDhIDFile)
-			return false
-		}
-		return true
+	backedUpIDFile, err := backupManager.backedUpIDFile()
+	if err != nil {
+		backupManager.logger.Errorf("%v", err)
+		return false
 	}
-	buDhID := string(b)
-	return dhID == buDhID
+	b, err = os.ReadFile(backedUpIDFile)
+	if err == nil {
+		return dhID == string(b)
+	}
+	if !os.IsNotExist(err) {
+		backupManager.logger.Errorf("Could not read backup id file at %v. (%v)", backedUpIDFile, err)
+		return false
+	}
+	empty, err := backupManager.backupLocationEmpty()
+	if err != nil {
+		backupManager.logger.Errorf("Could not read backup location %v. (%v)", backupManager.backupLocation, err)
+		return false
+	}
+	if !empty {
+		backupManager.logger.Errorf("no %v file at %v in non-empty backup location. refusing to overwrite a backup "+
+			"of unknown origin. if the backup belongs to this store, copy %v to %v",
+			StorageIDFileName, backedUpIDFile, dhIDFile, filepath.Dir(backedUpIDFile))
+		return false
+	}
+	// the id lands before any data, so a backup torn mid-transfer keeps its identity
+	return backupManager.copyIDFile(dhIDFile, backedUpIDFile)
+}
+
+// backedUpIDFile returns the path of the store's id file inside the backup.
+// Rsync puts a trailing-slash source's contents at the backup root and a slashless source under its basename.
+func (backupManager *BackupManager) backedUpIDFile() (string, error) {
+	if !backupManager.useRsync {
+		return filepath.Join(backupManager.backupLocation, StorageIDFileName), nil
+	}
+	root := backupManager.backupLocation
+	source := backupManager.backupSourceLocation
+	if !strings.HasSuffix(source, "/") {
+		root = filepath.Join(root, filepath.Base(source))
+	}
+	rel, err := filepath.Rel(filepath.Clean(source), filepath.Clean(backupManager.store.storeLocation))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("store location %v is not inside backup source location %v, "+
+			"the rsync backup would not contain the store",
+			backupManager.store.storeLocation, source)
+	}
+	return filepath.Join(root, rel, StorageIDFileName), nil
+}
+
+func (backupManager *BackupManager) backupLocationEmpty() (bool, error) {
+	entries, err := os.ReadDir(backupManager.backupLocation)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	for _, entry := range entries {
+		// a fresh ext4 mount holds only lost+found, which is not backup content
+		if entry.Name() != "lost+found" {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (backupManager *BackupManager) copyIDFile(from string, to string) bool {
+	backupManager.logger.Infof("no %v file at backup location. copying now", StorageIDFileName)
+	source, err := os.Open(from)
+	if err != nil {
+		backupManager.logger.Errorf("Could not open backup id file at %v.", from)
+		return false
+	}
+	defer source.Close()
+
+	err = os.MkdirAll(filepath.Dir(to), 0o700)
+	if err != nil {
+		backupManager.logger.Errorf("Could not create backup dir at %v. (%v)", filepath.Dir(to), err)
+		return false
+	}
+	destination, err := os.Create(to)
+	if err != nil {
+		backupManager.logger.Errorf("Could not create backup id file at %v. (%v)", to, err)
+		return false
+	}
+	defer destination.Close()
+	_, err = io.Copy(destination, source)
+	if err != nil {
+		backupManager.logger.Errorf("Could not copy %v to %v.", from, to)
+		return false
+	}
+	return true
 }

--- a/internal/server/backup_test.go
+++ b/internal/server/backup_test.go
@@ -101,19 +101,28 @@ var _ = ginkgo.Describe("The BackupManager", func() {
 		backup.lastID, err = backup.LoadLastID()
 		Expect(err).To(BeNil())
 		backup.Run()
-		// check backup id file is synced
+		mirroredIDFile := filepath.Join(backupLocation, filepath.Base(storeLocation), StorageIDFileName)
+		if _, err := os.Stat(mirroredIDFile); errors.Is(err, os.ErrNotExist) {
+			ginkgo.Fail("expected store id file to be mirrored into the backup")
+		}
+	}, ginkgo.SpecTimeout(2*time.Minute))
+	ginkgo.It("Should compare ids at the backup root when the source is the store with a trailing slash", func(_ ginkgo.SpecContext) {
+		backup.useRsync = true
+		backup.backupSourceLocation = storeLocation + "/"
+		backup.Run()
 		storageIDFile := filepath.Join(backupLocation, StorageIDFileName)
 		if _, err := os.Stat(storageIDFile); errors.Is(err, os.ErrNotExist) {
-			ginkgo.Fail("expected backup id file to be copied")
+			ginkgo.Fail("expected store id file to be mirrored to the backup root")
 		}
+		// second run takes the id comparison path
+		backup.Run()
 	}, ginkgo.SpecTimeout(2*time.Minute))
 	ginkgo.It("Should stop datahub if backup to invalid location", func(_ ginkgo.SpecContext) {
 		backup.useRsync = true
 		backup.Run()
-		// check backup id file is synced
-		storageIDFile := filepath.Join(backupLocation, StorageIDFileName)
-		if _, err := os.Stat(storageIDFile); errors.Is(err, os.ErrNotExist) {
-			ginkgo.Fail("expected backup id file to be copied")
+		mirroredIDFile := filepath.Join(backupLocation, filepath.Base(storeLocation), StorageIDFileName)
+		if _, err := os.Stat(mirroredIDFile); errors.Is(err, os.ErrNotExist) {
+			ginkgo.Fail("expected store id file to be mirrored into the backup")
 		}
 		// stop store, remove id file and start again - a new id file should be generated
 		s.Close()
@@ -122,6 +131,132 @@ var _ = ginkgo.Describe("The BackupManager", func() {
 
 		// backup should fail now
 		assertPanic(func() { backup.Run() })
+	}, ginkgo.SpecTimeout(2*time.Minute))
+	ginkgo.It("Should stop datahub if the backup location has content but no id file", func(_ ginkgo.SpecContext) {
+		backup.useRsync = true
+		err := os.MkdirAll(backupLocation, 0o700)
+		Expect(err).To(BeNil())
+		err = os.WriteFile(filepath.Join(backupLocation, "orphan.kv"), []byte("data"), 0o644)
+		Expect(err).To(BeNil())
+
+		assertPanic(func() { backup.Run() })
+	}, ginkgo.SpecTimeout(2*time.Minute))
+	ginkgo.It("Should stop datahub when the backup source does not contain the store", func(_ ginkgo.SpecContext) {
+		backup.useRsync = true
+		backup.backupSourceLocation = "./test_store_backup_elsewhere"
+
+		assertPanic(func() { backup.Run() })
+	}, ginkgo.SpecTimeout(2*time.Minute))
+	ginkgo.It("Should fail construction when the backup source does not contain the store", func(_ ginkgo.SpecContext) {
+		e := &conf.Config{
+			Logger:               zap.NewNop().Sugar(),
+			StoreLocation:        storeLocation,
+			BackupLocation:       backupLocation,
+			BackupSchedule:       "*/5 * * * *",
+			BackupSourceLocation: "./test_store_backup_elsewhere",
+			BackupRsync:          true,
+		}
+
+		_, err := NewBackupManager(s, e)
+		Expect(err).To(HaveOccurred())
+	}, ginkgo.SpecTimeout(2*time.Minute))
+	ginkgo.It("Should treat a backup location holding only lost+found as empty", func(_ ginkgo.SpecContext) {
+		backup.useRsync = true
+		err := os.MkdirAll(filepath.Join(backupLocation, "lost+found"), 0o700)
+		Expect(err).To(BeNil())
+
+		backup.Run()
+
+		mirroredIDFile := filepath.Join(backupLocation, filepath.Base(storeLocation), StorageIDFileName)
+		if _, err := os.Stat(mirroredIDFile); errors.Is(err, os.ErrNotExist) {
+			ginkgo.Fail("expected store id file to be mirrored into the backup")
+		}
+	}, ginkgo.SpecTimeout(2*time.Minute))
+})
+
+var _ = ginkgo.Describe("The BackupManager with a backup source above the store location", func() {
+	testCnt := 0
+	var sourceLocation string
+	var storeLocation string
+	var backupLocation string
+	var s *Store
+	var backup *BackupManager
+	ginkgo.BeforeEach(func() {
+		testCnt += 1
+		sourceLocation = fmt.Sprintf("./test_backup_source_%v", testCnt)
+		storeLocation = filepath.Join(sourceLocation, "datahub.store")
+		backupLocation = fmt.Sprintf("./test_backup_source_backup_%v", testCnt)
+		err := os.RemoveAll(sourceLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+sourceLocation)
+		err = os.RemoveAll(backupLocation)
+		Expect(err).To(BeNil(), "should be allowed to clean testfiles in "+backupLocation)
+
+		e := &conf.Config{
+			Logger:        zap.NewNop().Sugar(),
+			StoreLocation: storeLocation,
+		}
+		s = NewStore(e, &statsd.NoOpClient{})
+
+		backup = &BackupManager{}
+		backup.logger = zap.NewNop().Sugar()
+		backup.store = s
+		backup.backupLocation = backupLocation
+		// the trailing slash makes rsync mirror the source's contents onto the backup location root
+		backup.backupSourceLocation = sourceLocation + "/"
+		backup.useRsync = true
+	})
+	ginkgo.AfterEach(func() {
+		_ = os.RemoveAll(sourceLocation)
+		_ = os.RemoveAll(backupLocation)
+	})
+
+	ginkgo.It("Should compare ids inside the mirrored store across runs", func(_ ginkgo.SpecContext) {
+		backup.Run()
+		// the id file travels inside the mirrored store directory, so a restored store carries it
+		mirroredIDFile := filepath.Join(backupLocation, "datahub.store", StorageIDFileName)
+		if _, err := os.Stat(mirroredIDFile); errors.Is(err, os.ErrNotExist) {
+			ginkgo.Fail("expected store id file to be mirrored with the store")
+		}
+		// no id copy at the backup root, so rsync --delete has nothing to remove
+		if _, err := os.Stat(filepath.Join(backupLocation, StorageIDFileName)); err == nil {
+			ginkgo.Fail("expected no id file at the backup root")
+		}
+
+		// second run takes the id comparison path
+		backup.Run()
+		if _, err := os.Stat(mirroredIDFile); errors.Is(err, os.ErrNotExist) {
+			ginkgo.Fail("expected store id file to survive the rsync run")
+		}
+	}, ginkgo.SpecTimeout(2*time.Minute))
+
+	ginkgo.It("Should place the id file before the first backup writes data", func(_ ginkgo.SpecContext) {
+		Expect(backup.validLocation()).To(BeTrue())
+
+		// a first backup torn mid-transfer must already carry its identity
+		mirroredIDFile := filepath.Join(backupLocation, "datahub.store", StorageIDFileName)
+		if _, err := os.Stat(mirroredIDFile); errors.Is(err, os.ErrNotExist) {
+			ginkgo.Fail("expected the id file to be placed before any data")
+		}
+	}, ginkgo.SpecTimeout(2*time.Minute))
+
+	ginkgo.It("Should stop datahub when an empty store points at an existing backup", func(_ ginkgo.SpecContext) {
+		backup.Run()
+		mirroredIDFile := filepath.Join(backupLocation, "datahub.store", StorageIDFileName)
+		backedUpID, err := os.ReadFile(mirroredIDFile)
+		Expect(err).To(BeNil())
+
+		// wipe the store and start over, as after losing the store volume
+		s.Close()
+		err = os.RemoveAll(sourceLocation)
+		Expect(err).To(BeNil())
+		s.Open()
+
+		assertPanic(func() { backup.Run() })
+
+		// the previous store's backup must be untouched
+		current, err := os.ReadFile(mirroredIDFile)
+		Expect(err).To(BeNil())
+		Expect(current).To(Equal(backedUpID))
 	}, ginkgo.SpecTimeout(2*time.Minute))
 })
 

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -528,7 +528,7 @@ func (s *Store) Open() error {
 
 	// if new storage, create unique storage id file. BackupManager can use this id to ensure it does not overwrite
 	// a backup belonging to a different storage
-	storageIDFile := filepath.Join(s.storeLocation, "DATAHUB_BACKUPID")
+	storageIDFile := filepath.Join(s.storeLocation, StorageIDFileName)
 	if _, err = os.Stat(storageIDFile); errors.Is(err, os.ErrNotExist) {
 		err = os.WriteFile(storageIDFile, []byte(fmt.Sprintf("%v", time.Now().UnixNano())), 0o644)
 		if err != nil {


### PR DESCRIPTION
Closes #368

This changes behavior. If the backup folder has files but no DATAHUB_BACKUPID, datahub stops on the next backup run instead of overwriting a backup that may belong to another store.