### PR TITLE
fix namespace cleanup gaps and add restore endpoint

### DIFF
--- a/internal/server/namespace_test.go
+++ b/internal/server/namespace_test.go
@@ -172,3 +172,104 @@ func TestNamespacePrefixCounterRecoveredFromStateWithoutCounter(t *testing.T) {
 		t.Errorf("expected ns3, got %s", got)
 	}
 }
+
+func TestAssertSpecificPrefixMapping(t *testing.T) {
+	t.Run("Should restore a deleted mapping under its exact prefix", func(t *testing.T) {
+		s := testStore(t, t.TempDir())
+		defer s.Close()
+
+		prefix := assertPrefix(t, s, "http://data.example.io/people/")
+		if err := s.NamespaceManager.DeleteNamespacePrefix(prefix); err != nil {
+			t.Fatalf("failed to delete prefix: %v", err)
+		}
+
+		err := s.NamespaceManager.AssertSpecificPrefixMapping(prefix, "http://data.example.io/people/")
+		if err != nil {
+			t.Fatalf("failed to restore mapping: %v", err)
+		}
+		expanded, err := s.NamespaceManager.ExpandCurie(prefix + ":bob")
+		if err != nil {
+			t.Fatalf("restored prefix must expand again: %v", err)
+		}
+		if expanded != "http://data.example.io/people/bob" {
+			t.Errorf("unexpected expansion %s", expanded)
+		}
+		roundtrip, err := s.NamespaceManager.GetPrefixMappingForExpansion("http://data.example.io/people/")
+		if err != nil || roundtrip != prefix {
+			t.Errorf("expected expansion to map back to %s, got %s (%v)", prefix, roundtrip, err)
+		}
+	})
+
+	t.Run("Should accept the same mapping twice", func(t *testing.T) {
+		s := testStore(t, t.TempDir())
+		defer s.Close()
+
+		if err := s.NamespaceManager.AssertSpecificPrefixMapping("ns40", "http://data.example.io/a/"); err != nil {
+			t.Fatalf("first restore failed: %v", err)
+		}
+		if err := s.NamespaceManager.AssertSpecificPrefixMapping("ns40", "http://data.example.io/a/"); err != nil {
+			t.Errorf("restore must be idempotent, got: %v", err)
+		}
+	})
+
+	t.Run("Should refuse a prefix that is mapped to a different expansion", func(t *testing.T) {
+		s := testStore(t, t.TempDir())
+		defer s.Close()
+
+		prefix := assertPrefix(t, s, "http://data.example.io/people/")
+		err := s.NamespaceManager.AssertSpecificPrefixMapping(prefix, "http://data.example.io/other/")
+		if err == nil {
+			t.Error("expected an error when the prefix is taken by another expansion")
+		}
+	})
+
+	t.Run("Should keep generated prefixes clear of a restored prefix", func(t *testing.T) {
+		s := testStore(t, t.TempDir())
+		defer s.Close()
+
+		if err := s.NamespaceManager.AssertSpecificPrefixMapping("ns40", "http://data.example.io/a/"); err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+		next := assertPrefix(t, s, "http://data.example.io/b/")
+		if next != "ns41" {
+			t.Errorf("expected the counter to jump past the restored prefix, got %s", next)
+		}
+	})
+
+	t.Run("Should not take over the write path when the expansion has a newer prefix", func(t *testing.T) {
+		s := testStore(t, t.TempDir())
+		defer s.Close()
+
+		newer := assertPrefix(t, s, "http://data.example.io/people/")
+		if err := s.NamespaceManager.AssertSpecificPrefixMapping("ns99", "http://data.example.io/people/"); err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+		writePrefix, err := s.NamespaceManager.GetPrefixMappingForExpansion("http://data.example.io/people/")
+		if err != nil || writePrefix != newer {
+			t.Errorf("the newer prefix %s must keep the write path, got %s (%v)", newer, writePrefix, err)
+		}
+		expanded, err := s.NamespaceManager.ExpandCurie("ns99:bob")
+		if err != nil || expanded != "http://data.example.io/people/bob" {
+			t.Errorf("restored prefix must still resolve, got %s (%v)", expanded, err)
+		}
+	})
+
+	t.Run("Should survive a restart", func(t *testing.T) {
+		location := t.TempDir()
+		s := testStore(t, location)
+
+		if err := s.NamespaceManager.AssertSpecificPrefixMapping("ns673", "http://data.example.io/transfers/"); err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+		if err := s.Close(); err != nil {
+			t.Fatalf("failed to close store: %v", err)
+		}
+
+		restarted := testStore(t, location)
+		defer restarted.Close()
+		expanded, err := restarted.NamespaceManager.ExpandCurie("ns673:1697017997")
+		if err != nil || expanded != "http://data.example.io/transfers/1697017997" {
+			t.Errorf("restored mapping must survive a restart, got %s (%v)", expanded, err)
+		}
+	})
+}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -350,6 +350,35 @@ func (namespaceManager *NamespaceManager) DeleteNamespacePrefix(prefix string) e
 	return namespaceManager.persistState()
 }
 
+// AssertSpecificPrefixMapping restores a mapping under the exact prefix given, for
+// example after a wrong delete. Idempotent; fails when the prefix is taken. An
+// existing prefix for the same expansion keeps the write path.
+func (namespaceManager *NamespaceManager) AssertSpecificPrefixMapping(prefix string, expansion string) error {
+	if prefix == "" || expansion == "" {
+		return errors.New("both prefix and expansion must be given")
+	}
+	namespaceManager.lock.Lock()
+	defer namespaceManager.lock.Unlock()
+
+	if existing, exists := namespaceManager.prefixToExpansionMapping[prefix]; exists {
+		if existing == expansion {
+			return nil
+		}
+		return errors.New("prefix " + prefix + " is already mapped to " + existing)
+	}
+	namespaceManager.prefixToExpansionMapping[prefix] = expansion
+	if _, exists := namespaceManager.expansionToPrefixMapping[expansion]; !exists {
+		namespaceManager.expansionToPrefixMapping[expansion] = prefix
+	}
+	// keep generated prefixes clear of the restored one
+	if rest, found := strings.CutPrefix(prefix, "ns"); found {
+		if n, err := strconv.Atoi(rest); err == nil && n >= namespaceManager.nextPrefixID {
+			namespaceManager.nextPrefixID = n + 1
+		}
+	}
+	return namespaceManager.persistState()
+}
+
 type DsNsInfo struct {
 	DatasetPrefix       string
 	PublicNamespacesKey string

--- a/internal/service/scheduler/namespace_cleanup.go
+++ b/internal/service/scheduler/namespace_cleanup.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/dgraph-io/badger/v4/pb"
 	"github.com/dgraph-io/ristretto/v2/z"
 	"github.com/mimiro-io/datahub/internal/service/store"
+	"github.com/mimiro-io/datahub/internal/service/types"
 	"go.uber.org/zap"
 )
 
@@ -83,8 +85,11 @@ func (nc *NamespaceCleaner) endScan() {
 
 func (nc *NamespaceCleaner) ScanNamespaceUsage(ctx context.Context) error {
 	s := nc.badger.GetDB().NewStream()
+	// prefix for badger's own 5-second progress log lines
+	s.LogPrefix = "namespace_cleanup.scan"
 	foundPrefixes := make(map[string]bool)
 	mapLock := sync.RWMutex{}
+	var scanned, skipped atomic.Int64
 
 	// Set up prefix filter for entity index to reduce iteration scope
 	entityIndexPrefix := make([]byte, 2)
@@ -92,6 +97,16 @@ func (nc *NamespaceCleaner) ScanNamespaceUsage(ctx context.Context) error {
 	s.Prefix = entityIndexPrefix
 
 	s.KeyToList = func(key []byte, itr *badger.Iterator) (*pb.KVList, error) {
+		// key layout: index id (2) + entity rid (8) + dataset id (4) + ...
+		// skip entities of deleted datasets still awaiting GC
+		if len(key) >= 14 {
+			dsID := types.InternalDatasetID(binary.BigEndian.Uint32(key[10:14]))
+			if nc.badger.IsDatasetDeleted(dsID) {
+				skipped.Add(1)
+				return nil, nil
+			}
+		}
+		scanned.Add(1)
 		item := itr.Item()
 		if item.IsDeletedOrExpired() {
 			return nil, nil
@@ -180,6 +195,9 @@ func (nc *NamespaceCleaner) ScanNamespaceUsage(ctx context.Context) error {
 		return ctx.Err()
 	}
 
+	nc.Logger.Infof("Namespace cleanup scanned %d entity versions, skipped %d versions from deleted datasets",
+		scanned.Load(), skipped.Load())
+
 	// Compare found prefixes with stored prefixes
 	nc.compareWithStoredPrefixes(foundPrefixes)
 	return nil
@@ -194,7 +212,20 @@ func (nc *NamespaceCleaner) extractNamespacePrefixesFromJSON(entityData []byte) 
 
 	// Use a map to collect unique prefixes
 	prefixMap := make(map[string]bool)
+	nc.collectEntityPrefixes(entity, prefixMap)
 
+	// Convert map to slice
+	prefixes := make([]string, 0, len(prefixMap))
+	for prefix := range prefixMap {
+		prefixes = append(prefixes, prefix)
+	}
+
+	return prefixes, nil
+}
+
+// collectEntityPrefixes gathers prefixes from an entity's id, property keys, and
+// reference keys and values, recursing into sub-entities in property values.
+func (nc *NamespaceCleaner) collectEntityPrefixes(entity map[string]interface{}, prefixMap map[string]bool) {
 	// Extract prefix from entity ID
 	if id, ok := entity["id"].(string); ok {
 		if prefix := nc.extractPrefix(id); prefix != "" {
@@ -202,12 +233,13 @@ func (nc *NamespaceCleaner) extractNamespacePrefixesFromJSON(entityData []byte) 
 		}
 	}
 
-	// Extract prefixes from property keys
+	// Extract prefixes from property keys, and recurse into sub-entities
 	if props, ok := entity["props"].(map[string]interface{}); ok {
-		for key := range props {
+		for key, value := range props {
 			if prefix := nc.extractPrefix(key); prefix != "" {
 				prefixMap[prefix] = true
 			}
+			nc.collectSubEntityPrefixes(value, prefixMap)
 		}
 	}
 
@@ -236,14 +268,18 @@ func (nc *NamespaceCleaner) extractNamespacePrefixesFromJSON(entityData []byte) 
 			}
 		}
 	}
+}
 
-	// Convert map to slice
-	prefixes := make([]string, 0, len(prefixMap))
-	for prefix := range prefixMap {
-		prefixes = append(prefixes, prefix)
+// collectSubEntityPrefixes recurses into property values that hold sub-entities.
+func (nc *NamespaceCleaner) collectSubEntityPrefixes(value interface{}, prefixMap map[string]bool) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		nc.collectEntityPrefixes(v, prefixMap)
+	case []interface{}:
+		for _, item := range v {
+			nc.collectSubEntityPrefixes(item, prefixMap)
+		}
 	}
-
-	return prefixes, nil
 }
 
 func (nc *NamespaceCleaner) extractPrefix(value string) string {

--- a/internal/service/scheduler/namespace_cleanup_test.go
+++ b/internal/service/scheduler/namespace_cleanup_test.go
@@ -219,10 +219,149 @@ func TestExtractNamespacePrefixesFromJSON(t *testing.T) {
 		}
 	})
 
+	t.Run("Should collect prefixes from sub-entities nested in property values", func(t *testing.T) {
+		// sub-entities in lists under props, nested two levels
+		entity := `{
+			"id": "ns0:cow",
+			"props": {
+				"ns0:transfers": [
+					{
+						"refs": {"ns0:externalId": "ns5:1697017997"},
+						"props": {"ns0:date": "2023-10-11", "ns0:audit": {
+							"refs": {"ns6:verifiedBy": "ns7:vet-1"},
+							"props": {}
+						}}
+					}
+				],
+				"ns0:note": "plain string, no curie"
+			},
+			"refs": {}
+		}`
+
+		got, err := cleaner.extractNamespacePrefixesFromJSON([]byte(entity))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		sort.Strings(got)
+		want := []string{"ns0", "ns5", "ns6", "ns7"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		}
+	})
+
 	t.Run("Should return an error for data that is not an entity", func(t *testing.T) {
 		_, err := cleaner.extractNamespacePrefixesFromJSON([]byte("not json"))
 		if err == nil {
 			t.Error("expected an error for malformed entity data")
 		}
 	})
+}
+
+func TestNamespaceCleanupKeepsNestedPrefixes(t *testing.T) {
+	task, s, dsm := testCleanupTask(t, true)
+
+	basePrefix, err := s.NamespaceManager.AssertPrefixMappingForExpansion("http://data.example.io/cattle/")
+	if err != nil {
+		t.Fatalf("failed to assert base prefix: %v", err)
+	}
+	nestedPrefix, err := s.NamespaceManager.AssertPrefixMappingForExpansion("http://data.example.io/transfers/")
+	if err != nil {
+		t.Fatalf("failed to assert nested prefix: %v", err)
+	}
+
+	ds, err := dsm.CreateDataset("cattle", nil)
+	if err != nil {
+		t.Fatalf("failed to create dataset: %v", err)
+	}
+	// nested prefix used only inside a sub-entity
+	err = ds.StoreEntities([]*server.Entity{
+		server.NewEntityFromMap(map[string]interface{}{
+			"id": basePrefix + ":cow-1",
+			"props": map[string]interface{}{
+				basePrefix + ":transfers": []interface{}{
+					map[string]interface{}{
+						"refs":  map[string]interface{}{basePrefix + ":externalId": nestedPrefix + ":1697017997"},
+						"props": map[string]interface{}{basePrefix + ":date": "2023-10-11"},
+					},
+				},
+			},
+			"refs": map[string]interface{}{},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("failed to store entities: %v", err)
+	}
+
+	task.Run()
+	awaitTask(t, task)
+
+	mapping := s.NamespaceManager.GetPrefixToExpansionMap()
+	if mapping[nestedPrefix] != "http://data.example.io/transfers/" {
+		t.Errorf("prefix %s is used inside a sub-entity and must survive the cleanup, got %q",
+			nestedPrefix, mapping[nestedPrefix])
+	}
+}
+
+func TestNamespaceCleanupIgnoresDeletedDatasets(t *testing.T) {
+	task, s, dsm := testCleanupTask(t, true)
+
+	keepPrefix, err := s.NamespaceManager.AssertPrefixMappingForExpansion("http://data.example.io/people/")
+	if err != nil {
+		t.Fatalf("failed to assert prefix: %v", err)
+	}
+	condemnedPrefix, err := s.NamespaceManager.AssertPrefixMappingForExpansion("http://data.example.io/bad-import/")
+	if err != nil {
+		t.Fatalf("failed to assert prefix: %v", err)
+	}
+
+	people, err := dsm.CreateDataset("people", nil)
+	if err != nil {
+		t.Fatalf("failed to create dataset: %v", err)
+	}
+	err = people.StoreEntities([]*server.Entity{
+		server.NewEntityFromMap(map[string]interface{}{
+			"id":    keepPrefix + ":homer",
+			"props": map[string]interface{}{},
+			"refs":  map[string]interface{}{},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("failed to store entities: %v", err)
+	}
+
+	bad, err := dsm.CreateDataset("bad-import", nil)
+	if err != nil {
+		t.Fatalf("failed to create dataset: %v", err)
+	}
+	err = bad.StoreEntities([]*server.Entity{
+		server.NewEntityFromMap(map[string]interface{}{
+			"id":    condemnedPrefix + ":x-1",
+			"props": map[string]interface{}{},
+			"refs":  map[string]interface{}{},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("failed to store entities: %v", err)
+	}
+
+	// the deleted dataset's data stays in the store until GC purges it
+	if err := dsm.DeleteDataset("bad-import"); err != nil {
+		t.Fatalf("failed to delete dataset: %v", err)
+	}
+
+	task.Run()
+	awaitTask(t, task)
+
+	mapping := s.NamespaceManager.GetPrefixToExpansionMap()
+	if _, found := mapping[condemnedPrefix]; found {
+		t.Errorf("prefix %s is only used by a deleted dataset and should have been cleaned up", condemnedPrefix)
+	}
+	if mapping[keepPrefix] != "http://data.example.io/people/" {
+		t.Errorf("prefix %s is used by a live dataset and must survive, got %q", keepPrefix, mapping[keepPrefix])
+	}
 }

--- a/internal/web/namespacehandler.go
+++ b/internal/web/namespacehandler.go
@@ -15,6 +15,8 @@
 package web
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -35,10 +37,30 @@ func RegisterNamespaceHandler(
 ) {
 	handler := namespaceHandler{store: store}
 	e.GET("/namespaces", handler.getNamespaces, mw.authorizer(logger.Named("web"), datahubRead))
+	e.POST("/namespaces", handler.addNamespaceMappings, mw.authorizer(logger.Named("web"), datahubWrite))
 }
 
 func (handler *namespaceHandler) getNamespaces(c echo.Context) error {
 	v := handler.store.GetGlobalContext(false)
 
 	return c.JSON(http.StatusOK, v.Namespaces)
+}
+
+// addNamespaceMappings restores mappings under their exact prefixes. The body is a
+// JSON object of prefix to expansion, the same shape GET /namespaces returns.
+func (handler *namespaceHandler) addNamespaceMappings(c echo.Context) error {
+	mappings := make(map[string]string)
+	if err := json.NewDecoder(c.Request().Body).Decode(&mappings); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "body must be a JSON object of prefix to expansion")
+	}
+
+	restored := 0
+	for prefix, expansion := range mappings {
+		if err := handler.store.NamespaceManager.AssertSpecificPrefixMapping(prefix, expansion); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest,
+				fmt.Sprintf("failed to restore %s after %d restored mappings: %v", prefix, restored, err))
+		}
+		restored++
+	}
+	return c.JSON(http.StatusOK, map[string]int{"restored": restored})
 }


### PR DESCRIPTION
- extract prefixes from sub-entities nested in property values, so nested-only namespaces are no longer deleted as unused
  - skip entities of deleted datasets awaiting GC in the scan
  - add POST /namespaces and AssertSpecificPrefixMapping to restore deleted mappings under their exact prefixes
  - log scan progress and scanned/skipped counts